### PR TITLE
chore: Fix OIDC token fetch error in review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:


### PR DESCRIPTION
## Summary
- Upgrades event trigger from `pull_request` to `pull_request_target` for the Claude Code Review workflow.
- This allows the workflow to receive the required `id-token: write` scopes necessary to fetch the Anthropics OIDC token, particularly when evaluating incoming PRs from forks that are otherwise securely stripped of secrets by default.

## Type of Change
- [x] Chore

Closes #13