### PR TITLE
feat: enable selection and hover intel for sanctioned countries and conflict zones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/packages/wwv-plugin-conflict-zones/package.json
+++ b/packages/wwv-plugin-conflict-zones/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldwideview/wwv-plugin-conflict-zones",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "WorldWideView plugin — Active conflict zones and geopolitical hotspots worldwide.",
   "main": "src/index.tsx",
   "types": "src/index.tsx",

--- a/packages/wwv-plugin-conflict-zones/src/index.tsx
+++ b/packages/wwv-plugin-conflict-zones/src/index.tsx
@@ -17,6 +17,36 @@ function severityToColor(score: number): string {
     return "#fbbf24"; // Monitoring — yellow
 }
 
+/** Attach _wwvEntity to a Resium Entity ref so InteractionHandler can pick it. */
+function bindWwvEntity(ref: any, geoEntity: GeoEntity): void {
+    const cesiumEntity = ref?.cesiumElement;
+    if (cesiumEntity && !cesiumEntity._wwvEntity) {
+        cesiumEntity._wwvEntity = geoEntity;
+    }
+}
+
+/** Build a synthetic GeoEntity from a static ConflictZone definition. */
+function zoneToGeoEntity(zone: typeof CONFLICT_ZONES[number]): GeoEntity {
+    return {
+        id: zone.id,
+        pluginId: "conflict-zones",
+        latitude: zone.lat,
+        longitude: zone.lon,
+        altitude: 0,
+        timestamp: new Date(),
+        properties: {
+            name: zone.name,
+            description: zone.description,
+            type: zone.subtext || "N/A",
+            status: zone.status,
+            escalationScore: zone.escalationScore,
+            escalationTrend: zone.escalationTrend,
+            whyItMatters: zone.whyItMatters,
+            radiusKm: zone.radiusKm,
+        },
+    };
+}
+
 const ConflictZonesRenderer: React.FC<{ viewer: Cesium.Viewer | null; enabled: boolean }> = ({ enabled }) => {
     if (!enabled) return null;
 
@@ -28,24 +58,14 @@ const ConflictZonesRenderer: React.FC<{ viewer: Cesium.Viewer | null; enabled: b
                 const fillColor = Cesium.Color.fromCssColorString(colorHex).withAlpha(0.25);
                 const outlineColor = Cesium.Color.fromCssColorString(colorHex).withAlpha(0.8);
                 const radiusMeters = zone.radiusKm * 1000;
+                const geoEntity = zoneToGeoEntity(zone);
 
                 return (
                     <Entity
                         key={zone.id}
                         position={position}
                         name={zone.name}
-                        description={`
-                            <table class="cesium-infoBox-defaultTable">
-                                <tbody>
-                                    <tr><th>Overview</th><td>${zone.description}</td></tr>
-                                    <tr><th>Type</th><td>${zone.subtext || "N/A"}</td></tr>
-                                    <tr><th>Status</th><td>${zone.status}</td></tr>
-                                    <tr><th>Escalation Score</th><td>${zone.escalationScore} / 5</td></tr>
-                                    <tr><th>Trend</th><td>${zone.escalationTrend}</td></tr>
-                                    <tr><th>Why It Matters</th><td>${zone.whyItMatters}</td></tr>
-                                </tbody>
-                            </table>
-                        `}
+                        ref={(ref: any) => bindWwvEntity(ref, geoEntity)}
                     >
                         <EllipseGraphics
                             semiMajorAxis={radiusMeters}
@@ -118,3 +138,4 @@ export class ConflictZonesPlugin implements WorldPlugin {
         return ConflictZonesRenderer;
     }
 }
+

--- a/packages/wwv-plugin-international-sanctions/package.json
+++ b/packages/wwv-plugin-international-sanctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldwideview/wwv-plugin-international-sanctions",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.tsx",
   "dependencies": {
     "lucide-react": "^0.364.0"

--- a/packages/wwv-plugin-international-sanctions/src/index.tsx
+++ b/packages/wwv-plugin-international-sanctions/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { Scale } from "lucide-react";
 import { Color, PolygonHierarchy, GeoJsonDataSource, JulianDate } from "cesium";
 import { Entity, PolygonGraphics } from "resium";
@@ -19,6 +19,14 @@ const LEVEL_COLORS: Record<string, string> = {
     "medium": "#f97316", // Orange
     "high": "#ef4444",   // Red
 };
+
+/** Attach _wwvEntity to a Resium Entity ref so InteractionHandler can pick it. */
+function bindWwvEntity(ref: any, geoEntity: GeoEntity): void {
+    const cesiumEntity = ref?.cesiumElement;
+    if (cesiumEntity && !cesiumEntity._wwvEntity) {
+        cesiumEntity._wwvEntity = geoEntity;
+    }
+}
 
 export class InternationalSanctionsPlugin implements WorldPlugin {
     id = "international-sanctions";
@@ -164,10 +172,13 @@ export class InternationalSanctionsPlugin implements WorldPlugin {
 
         const elements = useMemo(() => {
              if (!enabled || Object.keys(countryPolygons).length === 0 || this.data.length === 0) return [];
-             const results = [];
+             const results: Array<{
+                 id: string; name: string; geoEntity: GeoEntity;
+                 color: Color; outlineColor: Color; height: number;
+                 hierarchies: PolygonHierarchy[];
+             }> = [];
              for (const entity of this.data) {
                  const code = entity.properties.countryCode as string;
-                 const count = entity.properties.count as number;
                  const level = (entity.properties.level as string) || "low";
                  const hexStr = LEVEL_COLORS[level] || LEVEL_COLORS["low"];
                  const color = Color.fromCssColorString(hexStr).withAlpha(0.65);
@@ -180,13 +191,7 @@ export class InternationalSanctionsPlugin implements WorldPlugin {
                  results.push({
                      id: entity.id,
                      name: `Sanctioned Country: ${code}`,
-                     description: `
-                        <div class="p-3">
-                            <div class="mb-2"><span class="font-semibold text-gray-300">Target Area:</span> ${code}</div>
-                            <div class="mb-2"><span class="font-semibold text-gray-300">Level:</span> <span style="color: ${hexStr}">${level.toUpperCase()}</span></div>
-                            <div class="mb-2"><span class="font-semibold text-gray-300">Active OFAC Sanctions:</span> ${count}</div>
-                        </div>
-                     `,
+                     geoEntity: entity,
                      color,
                      outlineColor,
                      height,
@@ -205,7 +210,7 @@ export class InternationalSanctionsPlugin implements WorldPlugin {
                         <Entity
                             key={`${rc.id}-${idx}`}
                             name={rc.name}
-                            description={rc.description}
+                            ref={(ref: any) => bindWwvEntity(ref, rc.geoEntity)}
                         >
                             <PolygonGraphics
                                 hierarchy={hier}

--- a/src/components/panels/EntityInfoCard.tsx
+++ b/src/components/panels/EntityInfoCard.tsx
@@ -11,6 +11,14 @@ const OFFSET_X = 16;
 const OFFSET_Y = 16;
 const EDGE_PADDING = 12;
 
+const LEVEL_COLORS: Record<string, string> = {
+    low: "#facc15", medium: "#f97316", high: "#ef4444",
+};
+
+const SEVERITY_LABELS: Record<number, string> = {
+    5: "Critical", 4: "High", 3: "Elevated", 2: "Watchlist",
+};
+
 export function EntityInfoCard() {
     const hoveredEntity = useStore((s) => s.hoveredEntity);
     const screenPos = useStore((s) => s.hoveredScreenPosition);
@@ -66,6 +74,18 @@ export function EntityInfoCard() {
     
     const casualtiesDisplay = 
         hoveredEntity.properties?.casualties !== undefined ? String(hoveredEntity.properties.casualties) : null;
+
+    // Sanctions-specific fields
+    const sanctionLevel = hoveredEntity.properties?.level as string | undefined;
+    const sanctionCount = hoveredEntity.properties?.count as number | undefined;
+    const countryCode = hoveredEntity.properties?.countryCode as string | undefined;
+    const isSanctions = hoveredEntity.pluginId === "international-sanctions";
+
+    // Conflict zone-specific fields
+    const escalationScore = hoveredEntity.properties?.escalationScore as number | undefined;
+    const zoneStatus = hoveredEntity.properties?.status as string | undefined;
+    const escalationTrend = hoveredEntity.properties?.escalationTrend as string | undefined;
+    const isConflictZone = hoveredEntity.pluginId === "conflict-zones";
 
     return (
         <div
@@ -149,6 +169,50 @@ export function EntityInfoCard() {
                         </span>
                     </div>
                 )}
+
+                {/* Sanctions-specific hover intel */}
+                {isSanctions && countryCode && (
+                    <div className="entity-info-card__prop">
+                        <span className="entity-info-card__prop-key">Country</span>
+                        <span className="entity-info-card__prop-value">{countryCode}</span>
+                    </div>
+                )}
+                {isSanctions && sanctionLevel && (
+                    <div className="entity-info-card__prop">
+                        <span className="entity-info-card__prop-key">Severity</span>
+                        <span className="entity-info-card__prop-value" style={{ color: LEVEL_COLORS[sanctionLevel] || "inherit" }}>
+                            {sanctionLevel.toUpperCase()}
+                        </span>
+                    </div>
+                )}
+                {isSanctions && sanctionCount !== undefined && (
+                    <div className="entity-info-card__prop">
+                        <span className="entity-info-card__prop-key">OFAC Sanctions</span>
+                        <span className="entity-info-card__prop-value">{sanctionCount}</span>
+                    </div>
+                )}
+
+                {/* Conflict zone-specific hover intel */}
+                {isConflictZone && escalationScore !== undefined && (
+                    <div className="entity-info-card__prop">
+                        <span className="entity-info-card__prop-key">Escalation</span>
+                        <span className="entity-info-card__prop-value" style={{ color: escalationScore >= 5 ? "#991b1b" : escalationScore >= 4 ? "#ef4444" : escalationScore >= 3 ? "#f97316" : "#fbbf24" }}>
+                            {SEVERITY_LABELS[escalationScore] || escalationScore} / 5
+                        </span>
+                    </div>
+                )}
+                {isConflictZone && zoneStatus && (
+                    <div className="entity-info-card__prop">
+                        <span className="entity-info-card__prop-key">Status</span>
+                        <span className="entity-info-card__prop-value">{zoneStatus}</span>
+                    </div>
+                )}
+                {isConflictZone && escalationTrend && (
+                    <div className="entity-info-card__prop">
+                        <span className="entity-info-card__prop-key">Trend</span>
+                        <span className="entity-info-card__prop-value">{escalationTrend}</span>
+                    </div>
+                )}
             </div>
 
             {/* Footer hint */}
@@ -156,3 +220,4 @@ export function EntityInfoCard() {
         </div>
     );
 }
+


### PR DESCRIPTION
## Summary

Enables full hover intel and click-to-select functionality for sanctioned country polygons and conflict zone ellipses on the globe. Previously, these Resium-rendered entities bypassed the core `InteractionHandler` because they lacked the `_wwvEntity` property. Now users can hover to see contextual intelligence and click to open the full Intel Panel.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

Closes #27

## Changes Made

- **`packages/wwv-plugin-international-sanctions/src/index.tsx`** — Added `bindWwvEntity()` helper that attaches the `_wwvEntity` property to each Resium `<Entity>` via ref callback. Removed legacy HTML `description` strings in favor of the core Intel Panel's `DynamicPropertiesRender`. Typed the elements array properly.
- **`packages/wwv-plugin-conflict-zones/src/index.tsx`** — Added `bindWwvEntity()` and `zoneToGeoEntity()` that constructs synthetic `GeoEntity` payloads from the static `CONFLICT_ZONES` data, enabling the `InteractionHandler` to pick and identify them.
- **`src/components/panels/EntityInfoCard.tsx`** — Extended the hover tooltip card with sanctions-specific fields (Country, Severity with color-coded indicator, OFAC Sanctions count) and conflict-zone-specific fields (Escalation score with severity colors, Status, Trend).
- Bumped versions: root `1.9.1` → `1.10.0`, `wwv-plugin-international-sanctions` `1.0.0` → `1.1.0`, `wwv-plugin-conflict-zones` `1.0.0` → `1.1.0`

## Testing

- [x] I ran `npm test` and all tests pass
- [ ] I manually tested this in the browser against a live data source
- [ ] I added or updated tests for my changes

## Plugin Checklist (if applicable)

- [x] Plugin is registered with `PluginRegistry`
- [x] Plugin does not import or depend on core rendering logic directly
- [x] Plugin cleans up Cesium primitives on unmount/disable
- [x] No hardcoded credentials or API keys committed

## Screenshots / Recordings

N/A — this is a data interaction enhancement, not a visual UI change.

## Notes for Reviewer

The `bindWwvEntity()` pattern is a reusable bridge for any Resium `<Entity>` that needs to participate in the core engine's interaction pipeline. This same technique can be applied to any future plugin that uses `getGlobeComponent()` to render custom Cesium entities.

The `InteractionHandler` uses `picked.id._wwvEntity` to identify entities — when Cesium picks a geometry belonging to an Entity, `picked.id` is the `Cesium.Entity` instance itself, so attaching `_wwvEntity` on it is the correct integration point.
