### PR TITLE
feat(marketplace): automate default plugin installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/src/app/api/marketplace/load/route.ts
+++ b/src/app/api/marketplace/load/route.ts
@@ -10,6 +10,7 @@ import { getVerifiedPluginIds } from "@/lib/marketplace/registryClient";
 
 import { isDemo, isDemoAdmin } from "@/core/edition";
 import { auth } from "@/lib/auth";
+import { seedDefaultPlugins } from "@/lib/marketplace/seedDefaultPlugins";
 
 export async function OPTIONS(request: Request) {
     return handlePreflight(request);
@@ -24,6 +25,9 @@ export async function OPTIONS(request: Request) {
  * from the verified list are correctly flagged as unverified.
  */
 export async function GET(request: Request) {
+    // Seed default plugins on fresh installs (idempotent — runs once)
+    await seedDefaultPlugins();
+
     // On demo, all installed plugins are visible to everyone (admin vetted them)
     if (!isDemo) {
         const authError = await validateMarketplaceAuth(request);

--- a/src/lib/marketplace/builtinPlugins.ts
+++ b/src/lib/marketplace/builtinPlugins.ts
@@ -3,12 +3,4 @@
  * Used by the status endpoint to always report these as "installed"
  * even when they haven't been installed via the marketplace flow.
  */
-export const BUILT_IN_PLUGIN_IDS = [
-    "aviation",
-    "maritime",
-    "military-aviation",
-    "wildfire",
-    "camera",
-    "borders",
-    "osm-search",
-] as const;
+export const BUILT_IN_PLUGIN_IDS = [] as const;

--- a/src/lib/marketplace/defaultPlugins.ts
+++ b/src/lib/marketplace/defaultPlugins.ts
@@ -1,0 +1,23 @@
+/**
+ * Marketplace plugins automatically installed on fresh instances.
+ *
+ * These provide a rich out-of-the-box experience — the globe looks alive
+ * from the very first load. Users can uninstall any of these afterwards.
+ *
+ * All core plugins are now installed via marketplace defaults.
+ */
+export const DEFAULT_PLUGIN_IDS = [
+    "aviation",
+    "maritime",
+    "military-aviation",
+    "wildfire",
+    "camera",
+    "borders",
+    "osm-search",
+    "earthquakes",
+    "satellite",
+    "daynight",
+    "conflict-zones",
+    "volcanoes",
+    "airports",
+] as const;

--- a/src/lib/marketplace/seedDefaultPlugins.test.ts
+++ b/src/lib/marketplace/seedDefaultPlugins.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockFindUnique = vi.fn();
+const mockCount = vi.fn();
+const mockUpsert = vi.fn();
+
+vi.mock("../db", () => ({
+    prisma: {
+        setting: { findUnique: (...a: any[]) => mockFindUnique(...a), upsert: (...a: any[]) => mockUpsert(...a) },
+        installedPlugin: { count: (...a: any[]) => mockCount(...a) },
+    },
+}));
+
+const mockUpsertPlugin = vi.fn();
+vi.mock("./repository", () => ({ upsertPlugin: (...a: any[]) => mockUpsertPlugin(...a) }));
+
+const mockValidateManifest = vi.fn();
+vi.mock("@/core/plugins/validateManifest", () => ({
+    validateManifest: (...a: any[]) => mockValidateManifest(...a),
+}));
+
+const mockGetVerifiedPluginIds = vi.fn();
+vi.mock("./registryClient", () => ({
+    getVerifiedPluginIds: (...a: any[]) => mockGetVerifiedPluginIds(...a),
+}));
+
+let mockIsDemo = false;
+vi.mock("@/core/edition", () => ({ get isDemo() { return mockIsDemo; } }));
+
+// Mock global fetch for marketplace API calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { seedDefaultPlugins } from "./seedDefaultPlugins";
+import { DEFAULT_PLUGIN_IDS } from "./defaultPlugins";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeManifest(id: string) {
+    return {
+        id,
+        name: id,
+        version: "1.0.0",
+        format: "bundle",
+        entry: `https://unpkg.com/wwv-plugin-${id}@1.0.0/dist/frontend.mjs`,
+        npmPackage: `wwv-plugin-${id}`,
+        rendering: { type: "point", color: "#ff0000", size: 6 },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("seedDefaultPlugins", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockIsDemo = false;
+        delete process.env.WWV_SKIP_DEFAULT_PLUGINS;
+
+        // Defaults: not seeded, no existing plugins, manifests valid
+        mockFindUnique.mockResolvedValue(null);
+        mockCount.mockResolvedValue(0);
+        mockGetVerifiedPluginIds.mockResolvedValue(new Set(DEFAULT_PLUGIN_IDS));
+        mockValidateManifest.mockReturnValue({ valid: true, errors: [] });
+        mockUpsertPlugin.mockResolvedValue({});
+        mockUpsert.mockResolvedValue({});
+
+        mockFetch.mockImplementation(async (url: string) => ({
+            ok: true,
+            json: async () => {
+                const match = url.match(/plugins\/(.+)$/);
+                return match ? fakeManifest(match[1]) : {};
+            },
+        }));
+    });
+
+    it("seeds all default plugins on a fresh install", async () => {
+        await seedDefaultPlugins();
+
+        expect(mockUpsertPlugin).toHaveBeenCalledTimes(DEFAULT_PLUGIN_IDS.length);
+        for (const id of DEFAULT_PLUGIN_IDS) {
+            expect(mockUpsertPlugin).toHaveBeenCalledWith(
+                id,
+                "1.0.0",
+                expect.stringContaining(`"id":"${id}"`),
+            );
+        }
+
+        // Guard row written
+        expect(mockUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { key: "defaults_seeded" },
+                create: { key: "defaults_seeded", value: "true" },
+            }),
+        );
+    });
+
+    it("skips immediately when already seeded", async () => {
+        mockFindUnique.mockResolvedValue({ key: "defaults_seeded", value: "true" });
+
+        await seedDefaultPlugins();
+
+        expect(mockUpsertPlugin).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("marks seeded without installing when plugins already exist", async () => {
+        mockCount.mockResolvedValue(3);
+
+        await seedDefaultPlugins();
+
+        expect(mockUpsertPlugin).not.toHaveBeenCalled();
+        // Guard row still written
+        expect(mockUpsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { key: "defaults_seeded" },
+            }),
+        );
+    });
+
+    it("handles marketplace API failure gracefully", async () => {
+        mockFetch.mockRejectedValue(new Error("Network error"));
+
+        await seedDefaultPlugins();
+
+        // Should NOT throw
+        expect(mockUpsertPlugin).not.toHaveBeenCalled();
+        // Guard row still written (fail-safe)
+        expect(mockUpsert).toHaveBeenCalled();
+    });
+
+    it("skips when WWV_SKIP_DEFAULT_PLUGINS=true", async () => {
+        process.env.WWV_SKIP_DEFAULT_PLUGINS = "true";
+
+        await seedDefaultPlugins();
+
+        expect(mockUpsertPlugin).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
+        // Guard row written so it doesn't re-check
+        expect(mockUpsert).toHaveBeenCalled();
+    });
+
+    it("skips entirely on demo edition", async () => {
+        mockIsDemo = true;
+
+        await seedDefaultPlugins();
+
+        expect(mockUpsertPlugin).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockUpsert).not.toHaveBeenCalled();
+    });
+
+    it("skips individual plugins with invalid manifests", async () => {
+        // Make the first plugin fail validation
+        let callCount = 0;
+        mockValidateManifest.mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return { valid: false, errors: ["missing field"] };
+            return { valid: true, errors: [] };
+        });
+
+        await seedDefaultPlugins();
+
+        // One fewer than total (the first was skipped)
+        expect(mockUpsertPlugin).toHaveBeenCalledTimes(DEFAULT_PLUGIN_IDS.length - 1);
+    });
+
+    it("stamps trust from the verified registry", async () => {
+        const firstId = DEFAULT_PLUGIN_IDS[0];
+        // Only the first plugin is verified
+        mockGetVerifiedPluginIds.mockResolvedValue(new Set([firstId]));
+
+        await seedDefaultPlugins();
+
+        // Check the first call has "verified"
+        const firstCall = mockUpsertPlugin.mock.calls[0];
+        expect(firstCall[0]).toBe(firstId);
+        const firstManifest = JSON.parse(firstCall[2]);
+        expect(firstManifest.trust).toBe("verified");
+
+        // Check a non-verified one
+        const secondCall = mockUpsertPlugin.mock.calls[1];
+        const secondManifest = JSON.parse(secondCall[2]);
+        expect(secondManifest.trust).toBe("unverified");
+    });
+});

--- a/src/lib/marketplace/seedDefaultPlugins.ts
+++ b/src/lib/marketplace/seedDefaultPlugins.ts
@@ -1,0 +1,135 @@
+import { prisma } from "../db";
+import { isDemo } from "@/core/edition";
+import { DEFAULT_PLUGIN_IDS } from "./defaultPlugins";
+import { upsertPlugin } from "./repository";
+import { validateManifest } from "@/core/plugins/validateManifest";
+import { getVerifiedPluginIds } from "./registryClient";
+
+const MARKETPLACE_URL =
+    process.env.NEXT_PUBLIC_MARKETPLACE_URL ||
+    "https://marketplace.worldwideview.dev";
+
+/**
+ * Seed default marketplace plugins on a fresh install.
+ *
+ * Runs once per instance lifecycle — an idempotent guard
+ * (`defaults_seeded` in the Setting table) prevents re-runs.
+ *
+ * Like the "sample data" that ships with a new app: the seeder
+ * writes records to the database on first boot, then never runs again.
+ *
+ * Errors are logged but never thrown — a failed seed must never
+ * block the application from starting.
+ */
+export async function seedDefaultPlugins(): Promise<void> {
+    try {
+        // Demo has its own mechanism (NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS)
+        if (isDemo) return;
+
+        // Opt-out for power users deploying fresh instances
+        if (process.env.WWV_SKIP_DEFAULT_PLUGINS === "true") {
+            await markSeeded();
+            return;
+        }
+
+        // Idempotent guard — already seeded?
+        const guard = await prisma.setting.findUnique({
+            where: { key: "defaults_seeded" },
+        });
+        if (guard) return;
+
+        // Not truly fresh if plugins already exist
+        const existing = await prisma.installedPlugin.count();
+        if (existing > 0) {
+            await markSeeded();
+            return;
+        }
+
+        console.log(
+            `[DefaultPlugins] Fresh install detected — seeding ${DEFAULT_PLUGIN_IDS.length} default plugins…`,
+        );
+
+        const verified = await getVerifiedPluginIds();
+        let installed = 0;
+
+        for (const pluginId of DEFAULT_PLUGIN_IDS) {
+            try {
+                const manifest = await fetchManifest(pluginId);
+                if (!manifest) continue;
+
+                // Server-side trust stamping
+                manifest.trust = verified.has(pluginId)
+                    ? "verified"
+                    : "unverified";
+
+                // Reconstruct CDN entry for npm-distributed plugins
+                if (manifest.npmPackage) {
+                    const ver = manifest.version || "1.0.0";
+                    manifest.format = "bundle";
+                    manifest.entry = `https://unpkg.com/${manifest.npmPackage}@${ver}/dist/frontend.mjs`;
+                }
+
+                const validation = validateManifest(manifest);
+                if (!validation.valid) {
+                    console.warn(
+                        `[DefaultPlugins] Skipping ${pluginId}: ${validation.errors.join(", ")}`,
+                    );
+                    continue;
+                }
+
+                await upsertPlugin(
+                    pluginId,
+                    manifest.version || "1.0.0",
+                    JSON.stringify(manifest),
+                );
+                installed++;
+            } catch (err) {
+                console.warn(
+                    `[DefaultPlugins] Failed to seed ${pluginId}:`,
+                    err,
+                );
+            }
+        }
+
+        await markSeeded();
+        console.log(
+            `[DefaultPlugins] Seeded ${installed}/${DEFAULT_PLUGIN_IDS.length} plugins`,
+        );
+    } catch (err) {
+        console.error("[DefaultPlugins] Seeder failed:", err);
+        // Never throw — seeding failure must not block the app
+    }
+}
+
+/** Fetch a plugin manifest from the marketplace API. */
+async function fetchManifest(
+    pluginId: string,
+): Promise<Record<string, any> | null> {
+    try {
+        const res = await fetch(`${MARKETPLACE_URL}/api/plugins/${pluginId}`);
+        if (!res.ok) {
+            console.warn(
+                `[DefaultPlugins] Marketplace returned ${res.status} for ${pluginId}`,
+            );
+            return null;
+        }
+        const data = await res.json();
+        if (!data.id) data.id = pluginId;
+        return data;
+    } catch (err) {
+        console.warn(
+            `[DefaultPlugins] Network error fetching ${pluginId}:`,
+            err,
+        );
+        return null;
+    }
+}
+
+/** Write the idempotent guard row. */
+async function markSeeded(): Promise<void> {
+    await prisma.setting.upsert({
+        where: { key: "defaults_seeded" },
+        update: { value: "true" },
+        create: { key: "defaults_seeded", value: "true" },
+    });
+}


### PR DESCRIPTION
## Summary

This PR implements an automated seeding mechanism that populates a fresh instance of WorldWideView with a curated list of default marketplace plugins. It migrates core platform features from hard-coded "built-in" status to the dynamic, marketplace-driven plugin architecture, ensuring a feature-rich out-of-the-box experience while centralizing plugin lifecycle management.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

## Changes Made

- Created `seedDefaultPlugins` pipeline for idempotent initial hydration
- Migrated legacy hard-coded plugins from `builtinPlugins.ts` to `defaultPlugins.ts`
- Updated `/api/marketplace/load` to trigger seeding on fresh installs
- Added support for Antigravity worktrees in local test script
- Bumped package version to 1.19.0

## Testing

- [x] I ran `npm test` and all tests pass
- [x] I manually tested this in the browser against a live data source
- [x] I added or updated tests for my changes

## Plugin Checklist (if applicable)

- [ ] Plugin is registered with `PluginRegistry`
- [ ] Plugin does not import or depend on core rendering logic directly
- [ ] Plugin cleans up Cesium primitives on unmount/disable
- [ ] No hardcoded credentials or API keys committed

## Screenshots / Recordings

## Notes for Reviewer

This update is critical for transitioning all default functionalities to the new BYOB (Bring Your Own Backend) containerized architecture by routing default plugins through the marketplace verification flow.
