### PR TITLE
fix: silently drop legacy plugin manifest and add sentry logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/src/app/api/marketplace/load/route.ts
+++ b/src/app/api/marketplace/load/route.ts
@@ -82,17 +82,22 @@ export async function GET(request: Request) {
                 if (!m) return false;
                 // Skip built-in plugins — already registered by AppShell
                 if (m.trust === "built-in") return false;
+
+                // Skip stale/malformed records (e.g. old empty-config installs for built-ins)
+                // If it lacks basic required fields, it's a legacy record and we drop it silently
+                // to avoid log spam on every poll.
+                if (!m.entry || !m.name || !m.version) return false;
+
                 // Skip bundle plugins whose entry is a bare module specifier
                 // (e.g. "camera") — cannot be dynamically imported in the browser.
-                // These are stale/malformed DB records from built-in plugins.
                 if (
                     m.format === "bundle" &&
-                    m.entry &&
                     !m.entry.startsWith("/") &&
                     !m.entry.startsWith("./") &&
                     !m.entry.startsWith("http")
                 ) return false;
-                // Skip records with no usable manifest (e.g. old empty-config installs)
+
+                // For anything that looks like a real manifest, validate it and log if it fails
                 const validation = validateManifest(m);
                 if (!validation.valid) {
                     console.error(`[Marketplace API] Manifest validation failed for ${m.id}:`, validation.errors);

--- a/src/app/api/marketplace/load/route.ts
+++ b/src/app/api/marketplace/load/route.ts
@@ -11,6 +11,7 @@ import { getVerifiedPluginIds } from "@/lib/marketplace/registryClient";
 import { isDemo, isDemoAdmin } from "@/core/edition";
 import { auth } from "@/lib/auth";
 import { seedDefaultPlugins } from "@/lib/marketplace/seedDefaultPlugins";
+import * as Sentry from "@sentry/nextjs";
 
 export async function OPTIONS(request: Request) {
     return handlePreflight(request);
@@ -100,7 +101,18 @@ export async function GET(request: Request) {
                 // For anything that looks like a real manifest, validate it and log if it fails
                 const validation = validateManifest(m);
                 if (!validation.valid) {
-                    console.error(`[Marketplace API] Manifest validation failed for ${m.id}:`, validation.errors);
+                    const errorMessage = `Manifest validation failed for ${m.id}`;
+                    console.error(`[Marketplace API] ${errorMessage}:`, validation.errors);
+                    
+                    // Capture in Sentry so we have visibility into malformed third-party plugins
+                    Sentry.captureMessage(errorMessage, {
+                        level: "error",
+                        extra: {
+                            pluginId: m.id,
+                            validationErrors: validation.errors,
+                            manifest: m
+                        }
+                    });
                 }
                 return validation.valid;
             })


### PR DESCRIPTION
## Summary

This PR addresses the log spam issue occurring in the demo instance and improves overall observability by integrating Sentry correctly for plugin manifest validation errors.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

Closes #<!-- issue number -->

## Changes Made

- **`src/app/api/marketplace/load/route.ts`**:
  - Silently skip malformed legacy built-in plugin database records (`!m.entry || !m.name || !m.version`) that lacked standard fields, instead of running them through `validateManifest()` to prevent log spam.
  - Replaced the standalone `console.error` with a dual `console.error` and `Sentry.captureMessage` call. The Sentry log natively binds `extra` contextual data containing the plugin ID, the exact array of validation errors, and the malformed `manifest` object so we can debug external failures via the Sentry dashboard.
- **`package.json`**: Bumped version to `1.19.4`.

## Testing

- [x] I ran `npm test` and all tests pass
- [x] I manually tested this in the browser against a live data source
- [ ] I added or updated tests for my changes

## Plugin Checklist (if applicable)

- [ ] Plugin is registered with `PluginRegistry`
- [ ] Plugin does not import or depend on core rendering logic directly
- [ ] Plugin cleans up Cesium primitives on unmount/disable
- [ ] No hardcoded credentials or API keys committed

## Notes for Reviewer

The original PR for the documentation overhaul (`docs/38-documentation-overhaul`) was already merged into `main` before these commits were added to it in the previous conversation session. This PR isolates these newer two commits cleanly onto a branch off `main` so they can be merged directly.
