### PR TITLE
fix: resolve GlitchTip crashes in core components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/src/core/data/CacheLayer.ts
+++ b/src/core/data/CacheLayer.ts
@@ -67,7 +67,7 @@ class CacheLayer {
     }
 
     async getFromPersistent(pluginId: string): Promise<GeoEntity[] | null> {
-        if (!this.db) return null;
+        if (!this.db || !pluginId) return null;
         return new Promise((resolve) => {
             const tx = this.db!.transaction(this.storeName, "readonly");
             const request = tx.objectStore(this.storeName).get(pluginId);

--- a/src/core/globe/GlobeView.tsx
+++ b/src/core/globe/GlobeView.tsx
@@ -75,7 +75,7 @@ export default function GlobeView() {
         pluginManager.getAllPlugins().forEach((managed) => {
             const pluginId = managed.plugin.id;
             if (!layers[pluginId]?.enabled) return;
-            if (managed.plugin.getLayerConfig().disableDefaultRendering) return;
+            if (managed.plugin.getLayerConfig?.().disableDefaultRendering) return;
             const entities = entitiesByPlugin[pluginId];
             if (!Array.isArray(entities)) return;
 


### PR DESCRIPTION
## Summary

Fixes several crashes reported via GlitchTip telemetry occurring in production.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

Closes #43

## Changes Made

- Bumps version to `1.19.5`.
- **GlobeView.tsx**: Adds optional chaining to `managed.plugin.getLayerConfig?.()` when evaluating `disableDefaultRendering`.
- **CacheLayer.ts**: Adds guard against undefined `pluginId` before calling `IDBObjectStore.get`.

## Testing

- [x] I ran `pnpm test` and all tests pass
- [ ] I manually tested this in the browser against a live data source
- [ ] I added or updated tests for my changes

## Plugin Checklist (if applicable)

- [ ] Plugin is registered with `PluginRegistry`
- [ ] Plugin does not import or depend on core rendering logic directly
- [ ] Plugin cleans up Cesium primitives on unmount/disable
- [ ] No hardcoded credentials or API keys committed
