### PR TITLE
fix: Enlarge panel pull tab trigger areas

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["better-sqlite3", "@prisma/adapter-better-sqlite3", "@prisma/client", "prisma"],
-  transpilePackages: ["@worldwideview/wwv-plugin-sdk","resium",
-    "react-player",
-    "satellite.js"
-  ],
+  transpilePackages: ["@worldwideview/wwv-plugin-sdk", "resium", "react-player", "satellite.js"],
+  allowedDevOrigins: process.env.ALLOWED_DEV_ORIGIN ? [process.env.ALLOWED_DEV_ORIGIN] : undefined,
   experimental: {
     memoryBasedWorkersCount: true,
     cpus: 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.19.6",
+  "version": "1.19.7",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1261,6 +1261,15 @@ html, body {
   z-index: -1;
 }
 
+/* Extend inward trigger area so it's harder to miss when coming from the panel */
+.panel-toggle-btn--left::after {
+  left: -60px;
+}
+
+.panel-toggle-btn--right::after {
+  right: -60px;
+}
+
 .panel-toggle-btn:hover {
   background: var(--bg-glass-active);
   color: var(--text-primary);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1250,6 +1250,17 @@ html, body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
+/* Invisible pseudo-element to expand the effective touch/click trigger area */
+.panel-toggle-btn::after {
+  content: "";
+  position: absolute;
+  top: -20px;
+  bottom: -20px;
+  left: -25px;
+  right: -25px;
+  z-index: -1;
+}
+
 .panel-toggle-btn:hover {
   background: var(--bg-glass-active);
   color: var(--text-primary);

--- a/src/core/globe/hooks/useViewerInitialization.ts
+++ b/src/core/globe/hooks/useViewerInitialization.ts
@@ -35,7 +35,7 @@ export function useViewerInitialization(sceneSettings: any) {
         sscc.zoomEventTypes = [CameraEventType.WHEEL, CameraEventType.PINCH];
 
         if ("ontouchstart" in window || navigator.maxTouchPoints > 0) {
-            (sscc as any)._zoomFactor = 15;
+            (sscc as any)._zoomFactor = 5;
             (sscc as any)._translateFactor = 2;
             (sscc as any)._tiltFactor = 50;
         }


### PR DESCRIPTION
## Summary

Expands the trigger area of the left and right panel pull tabs, both outward and inward into the panel, making them much easier to grab on touch screens and desktop.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

Closes #45

## Changes Made

- Added `::after` pseudo-element to `.panel-toggle-btn` expanding click radius transparently by 20-25px.
- Extended inward area (`left` for left tab, `right` for right tab) to 60px so it reaches into the panel background itself, based on user feedback.

## Testing

- [x] I ran `npm test` and all tests pass
- [x] I manually tested this in the browser against a live data source
- [ ] I added or updated tests for my changes

## Plugin Checklist (if applicable)

- [ ] Plugin is registered with `PluginRegistry`
- [ ] Plugin does not import or depend on core rendering logic directly
- [ ] Plugin cleans up Cesium primitives on unmount/disable
- [ ] No hardcoded credentials or API keys committed

## Screenshots / Recordings

(See related issue)

## Notes for Reviewer

Trigger area expanded purely through CSS pseudo-elements to avoid altering the DOM or visual presentation of the tabs.
