### PR TITLE
feat(ui): add layer search and right panel deselection persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "1.19.7",
+  "version": "1.20.0",
   "private": true,
   "scripts": {
     "setup": "node scripts/setup.mjs",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1250,6 +1250,11 @@ html, body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
+body.is-resizing-sidebar .panel-toggle-btn,
+body.is-resizing-sidebar .sidebar {
+  transition: none !important;
+}
+
 /* Invisible pseudo-element to expand the effective touch/click trigger area */
 .panel-toggle-btn::after {
   content: "";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1292,8 +1292,8 @@ html, body {
 }
 
 .panel-toggle-btn--left.panel-toggle-btn--open {
-  /* Attach to the right edge of the left panel (width 280px + left padding 24px) */
-  left: calc(280px + var(--space-lg)); 
+  /* Attach to the right edge of the left panel */
+  left: calc(var(--left-sidebar-width, 280px) + var(--space-lg)); 
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   border-left: none;
   /* Stay slightly hidden under the panel to look attached, poke out 24px */
@@ -1320,8 +1320,8 @@ html, body {
 }
 
 .panel-toggle-btn--right.panel-toggle-btn--open {
-  /* Attach to the left edge of the right panel (width 320px + right padding 24px) */
-  right: calc(320px + var(--space-lg) + var(--ad-strip-inset, 0px));
+  /* Attach to the left edge of the right panel */
+  right: calc(var(--right-sidebar-width, 320px) + var(--space-lg) + var(--ad-strip-inset, 0px));
   border-radius: var(--radius-sm) 0 0 var(--radius-sm);
   border-right: none;
   /* Stay slightly hidden under the panel to look attached, poke out 24px */

--- a/src/components/panels/DataConfig/index.tsx
+++ b/src/components/panels/DataConfig/index.tsx
@@ -2,6 +2,7 @@ import { useStore } from "@/core/state/store";
 import { FilterSection } from "@/components/panels/FilterPanel";
 import { Info, Key, MessageSquare } from "lucide-react";
 import { useIsMobile } from "@/core/hooks/useIsMobile";
+import { useResizablePanel } from "@/core/hooks/useResizablePanel";
 
 import { IntelTab } from "./IntelTab";
 import { CacheTab } from "./CacheTab";
@@ -11,6 +12,7 @@ import { sectionHeaderStyle } from "./sharedStyles";
 
 export function DataConfigPanel() {
     const isMobile = useIsMobile();
+    const { width, startResizing } = useResizablePanel(320, 260, 800, 'right');
     const configPanelOpen = useStore((s) => s.configPanelOpen);
     const openMobilePanel = useStore((s) => s.openMobilePanel);
     const selectedEntity = useStore((s) => s.selectedEntity);
@@ -22,8 +24,24 @@ export function DataConfigPanel() {
     return (
         <aside
             className={`sidebar sidebar--right glass-panel ${isMobile ? "sidebar--mobile" : ""} ${(isMobile ? openMobilePanel === "right" : configPanelOpen) ? "" : "sidebar--closed"}`}
-            style={{ width: isMobile ? undefined : 320, padding: "var(--space-xl)", zIndex: 101, borderLeft: "var(--glass-border)" }}
+            style={{ width: isMobile ? undefined : width, padding: "var(--space-xl)", zIndex: 101, borderLeft: "var(--glass-border)" }}
         >
+            {/* Drag Handle */}
+            {!isMobile && (
+                <div
+                    onMouseDown={startResizing}
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: -4,
+                        width: 8,
+                        height: '100%',
+                        cursor: 'col-resize',
+                        zIndex: 10,
+                        backgroundColor: 'transparent'
+                    }}
+                />
+            )}
             <div className="sidebar__title" style={{ marginBottom: "var(--space-md)", color: "var(--text-primary)", fontSize: "14px", fontWeight: 600 }}>
                 Data Configuration
             </div>

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -5,6 +5,7 @@ import { Search } from "lucide-react";
 
 import { useStore } from "@/core/state/store";
 import { useIsMobile } from "@/core/hooks/useIsMobile";
+import { useResizablePanel } from "@/core/hooks/useResizablePanel";
 import { pluginManager } from "@/core/plugins/PluginManager";
 import { ImageryPicker } from "./ImageryPicker";
 import { LayerItem } from "./LayerItem";
@@ -18,6 +19,7 @@ import { trackEvent } from "@/lib/analytics";
 
 export function LayerPanel() {
     const isMobile = useIsMobile();
+    const { width, startResizing } = useResizablePanel(320, 260, 800, 'left');
     const leftSidebarOpen = useStore((s) => s.leftSidebarOpen);
     const openMobilePanel = useStore((s) => s.openMobilePanel);
     const layers = useStore((s) => s.layers);
@@ -98,7 +100,24 @@ export function LayerPanel() {
     return (
         <aside
             className={`sidebar sidebar--left glass-panel ${isMobile ? "sidebar--mobile" : ""} ${(isMobile ? openMobilePanel === "left" : leftSidebarOpen) ? "" : "sidebar--closed"}`}
+            style={{ width: isMobile ? undefined : width }}
         >
+            {/* Drag Handle */}
+            {!isMobile && (
+                <div
+                    onMouseDown={startResizing}
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        right: -4,
+                        width: 8,
+                        height: '100%',
+                        cursor: 'col-resize',
+                        zIndex: 10,
+                        backgroundColor: 'transparent'
+                    }}
+                />
+            )}
             <div className="sidebar__title">Data Sources</div>
 
             <div

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Search } from "lucide-react";
 
 import { useStore } from "@/core/state/store";
 import { useIsMobile } from "@/core/hooks/useIsMobile";
@@ -28,13 +29,23 @@ export function LayerPanel() {
     const setSelectedEntity = useStore((s) => s.setSelectedEntity);
 
     const allPlugins = pluginManager.getAllPlugins();
+    const [searchQuery, setSearchQuery] = useState("");
 
     // Group by category
     const grouped: Record<string, typeof allPlugins> = {};
+    const query = searchQuery.toLowerCase();
+    
     allPlugins.forEach((managed) => {
-        const cat = managed.plugin.category;
-        if (!grouped[cat]) grouped[cat] = [];
-        grouped[cat].push(managed);
+        if (
+            !query ||
+            managed.plugin.name.toLowerCase().includes(query) ||
+            managed.plugin.description?.toLowerCase().includes(query) ||
+            managed.plugin.id.toLowerCase().includes(query)
+        ) {
+            const cat = managed.plugin.category;
+            if (!grouped[cat]) grouped[cat] = [];
+            grouped[cat].push(managed);
+        }
     });
 
     const categoryLabels: Record<string, string> = {
@@ -130,6 +141,33 @@ export function LayerPanel() {
 
             {activeTab === "layers" && (
                 <div className="layers-tab-content">
+                    <div style={{ padding: "0 var(--space-md) var(--space-md) var(--space-md)" }}>
+                        <div style={{
+                            display: "flex",
+                            alignItems: "center",
+                            background: "var(--bg-layer-2)",
+                            border: "1px solid var(--border-subtle)",
+                            borderRadius: "var(--radius-sm)",
+                            padding: "0 var(--space-sm)",
+                        }}>
+                            <Search size={14} style={{ color: "var(--text-muted)", marginRight: 8 }} />
+                            <input
+                                type="text"
+                                placeholder="Search layers..."
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                style={{
+                                    flex: 1,
+                                    background: "transparent",
+                                    border: "none",
+                                    color: "var(--text-primary)",
+                                    fontSize: "13px",
+                                    padding: "var(--space-sm) 0",
+                                    outline: "none"
+                                }}
+                            />
+                        </div>
+                    </div>
                     <div className="layers-tab-content__list">
                         {Object.entries(grouped).map(([category, plugins]) => (
                             <div key={category} style={{ marginBottom: "var(--space-lg)" }}>

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -19,7 +19,7 @@ import { trackEvent } from "@/lib/analytics";
 
 export function LayerPanel() {
     const isMobile = useIsMobile();
-    const { width, startResizing } = useResizablePanel(320, 260, 800, 'left');
+    const { width, startResizing } = useResizablePanel(280, 260, 800, 'left');
     const leftSidebarOpen = useStore((s) => s.leftSidebarOpen);
     const openMobilePanel = useStore((s) => s.openMobilePanel);
     const layers = useStore((s) => s.layers);

--- a/src/core/hooks/useResizablePanel.ts
+++ b/src/core/hooks/useResizablePanel.ts
@@ -1,0 +1,43 @@
+import { useState, useRef, useEffect } from "react";
+
+export function useResizablePanel(initialWidth: number, minWidth: number, maxWidth: number, direction: 'left' | 'right') {
+    const [width, setWidth] = useState(initialWidth);
+    const isResizing = useRef(false);
+
+    useEffect(() => {
+        const handleMouseMove = (e: MouseEvent) => {
+            if (!isResizing.current) return;
+            
+            let newWidth = direction === 'left' ? e.clientX : window.innerWidth - e.clientX;
+            
+            if (newWidth < minWidth) newWidth = minWidth;
+            if (newWidth > maxWidth) newWidth = maxWidth;
+            
+            setWidth(newWidth);
+        };
+
+        const handleMouseUp = () => {
+            if (isResizing.current) {
+                isResizing.current = false;
+                document.body.style.cursor = 'default';
+                document.body.style.userSelect = 'auto';
+            }
+        };
+
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+        return () => {
+            document.removeEventListener('mousemove', handleMouseMove);
+            document.removeEventListener('mouseup', handleMouseUp);
+        };
+    }, [direction, minWidth, maxWidth]);
+
+    const startResizing = (e: React.MouseEvent) => {
+        e.preventDefault();
+        isResizing.current = true;
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+    };
+
+    return { width, startResizing };
+}

--- a/src/core/hooks/useResizablePanel.ts
+++ b/src/core/hooks/useResizablePanel.ts
@@ -5,6 +5,10 @@ export function useResizablePanel(initialWidth: number, minWidth: number, maxWid
     const isResizing = useRef(false);
 
     useEffect(() => {
+        document.documentElement.style.setProperty(`--${direction}-sidebar-width`, `${initialWidth}px`);
+    }, [initialWidth, direction]);
+
+    useEffect(() => {
         const handleMouseMove = (e: MouseEvent) => {
             if (!isResizing.current) return;
             
@@ -14,6 +18,7 @@ export function useResizablePanel(initialWidth: number, minWidth: number, maxWid
             if (newWidth > maxWidth) newWidth = maxWidth;
             
             setWidth(newWidth);
+            document.documentElement.style.setProperty(`--${direction}-sidebar-width`, `${newWidth}px`);
         };
 
         const handleMouseUp = () => {

--- a/src/core/hooks/useResizablePanel.ts
+++ b/src/core/hooks/useResizablePanel.ts
@@ -26,6 +26,7 @@ export function useResizablePanel(initialWidth: number, minWidth: number, maxWid
                 isResizing.current = false;
                 document.body.style.cursor = 'default';
                 document.body.style.userSelect = 'auto';
+                document.body.classList.remove('is-resizing-sidebar');
             }
         };
 
@@ -42,6 +43,7 @@ export function useResizablePanel(initialWidth: number, minWidth: number, maxWid
         isResizing.current = true;
         document.body.style.cursor = 'col-resize';
         document.body.style.userSelect = 'none';
+        document.body.classList.add('is-resizing-sidebar');
     };
 
     return { width, startResizing };

--- a/src/core/state/uiSlice.ts
+++ b/src/core/state/uiSlice.ts
@@ -82,11 +82,11 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set) => (
         }
         set((state) => ({
             selectedEntity: entity,
-            rightSidebarOpen: entity !== null,
-            configPanelOpen: entity !== null,
+            rightSidebarOpen: entity !== null ? true : state.rightSidebarOpen,
+            configPanelOpen: entity !== null ? true : state.configPanelOpen,
             openMobilePanel: entity !== null ? state.openMobilePanel : null,
             mobileRightPanelGlow: entity !== null,
-            activeConfigTab: entity !== null ? "intel" : "filters"
+            activeConfigTab: entity !== null ? "intel" : state.activeConfigTab
         }));
     },
     setHoveredEntity: (entity, screenPos) =>


### PR DESCRIPTION
This PR introduces two UI improvements:
1. Adds a search bar to the Data Layers panel to filter plugins by name, ID, or description.
2. Ensures the right intelligence panel does not automatically close on desktop when an entity is unselected.