### PR TITLE
fix(proxy): detect secure cookie when behind TLS-terminating reverse proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -103,10 +103,20 @@ export default async function proxy(req: NextRequest) {
         }
     }
 
-    // Check JWT session from Auth.js cookie
+    // Check JWT session from Auth.js cookie.
+    // Behind a TLS-terminating reverse proxy, the cookie was set with the
+    // `__Secure-` prefix (because the public URL is https), but the request
+    // reaching us is plain http, so getToken's auto-detection looks for the
+    // unprefixed name and misses it. Detect via X-Forwarded-Proto / AUTH_URL.
+    const xfProto = req.headers.get("x-forwarded-proto");
+    const authUrl = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "";
+    const isSecure = xfProto === "https"
+        || authUrl.startsWith("https://")
+        || req.nextUrl.protocol === "https:";
     const token = await getToken({
         req,
         secret: process.env.AUTH_SECRET,
+        secureCookie: isSecure,
     });
 
     if (token) {


### PR DESCRIPTION
## Summary

When self-hosting behind a reverse proxy that terminates TLS (Caddy, Nginx, Traefik, etc.), authenticated users are infinite-looped back to `/login` after a successful credentials sign-in. This blocks the entire app for any non-`localhost:3000` deployment with `AUTH_URL=https://...`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

N/A — discovered while bringing up a fresh self-host behind Caddy with mkcert TLS.

## Changes Made

- `src/proxy.ts`: explicitly compute `secureCookie` for `getToken()` from `X-Forwarded-Proto`, `AUTH_URL` / `NEXTAUTH_URL`, or the request URL's own protocol, instead of relying on the auto-detection.

## Root Cause

Auth.js v5 sets the session cookie with the `__Secure-` prefix when the public URL is `https://` (which is the documented, recommended setup for `AUTH_URL`). The cookie reaching the proxy middleware is therefore `__Secure-authjs.session-token`.

`getToken()` from `next-auth/jwt` infers `secureCookie` from the request URL it sees. Behind a TLS-terminating reverse proxy, the request reaching the Next.js server is plain HTTP (`http://localhost:3000`), so auto-detection falls back to looking for the unprefixed `authjs.session-token`. That cookie never exists, `getToken()` returns null, and `proxy.ts` redirects authenticated users to `/login` — which on success redirects back to `/`, looping forever. The browser-visible symptom is "login hangs."

`/api/auth/session` works correctly because the Auth.js core handler reads its own configured cookie name. Only the middleware's bare `getToken()` call is affected.

## Testing

- [x] I ran `pnpm test` and all tests pass that pass on `main` (the one pre-existing failure in `src/lib/marketplace/cors.test.ts` is unrelated and reproduces on a clean checkout of `main`).
- [x] I manually tested this with a self-hosted Docker build of the app behind Caddy (TLS termination via mkcert), pointed at `https://oracle.internal` with `AUTH_URL=https://oracle.internal` and `AUTH_TRUST_HOST=true`. Before the fix: `GET /` with a valid session cookie returned 307 to `/login`. After the fix: 200 with the globe.
- [ ] I added or updated tests for my changes — happy to add a unit test if you'd like one. The middleware has no existing test file and `getToken`'s cookie-name behavior is library-internal, so I left it out by default; let me know.

## Notes for Reviewer

- The fallback chain `X-Forwarded-Proto → AUTH_URL/NEXTAUTH_URL → req.nextUrl.protocol` is intentionally generous so it works whether the operator sets the env var, the proxy sets the header, or both.
- `setup.sh` ships a localhost-only compose file that publishes `3000:3000` on the host, so the typical user never hits this. Anyone putting the app behind a reverse proxy on a different hostname (the documented self-hosted path) does.
- An accompanying README note for self-hosters — "Behind a reverse proxy? Set `AUTH_URL=https://your.domain` in `.env`" — would also save folks an hour. Happy to send a separate docs PR if you want.