### PR TITLE
feat(build): warn when NEXT_PUBLIC_CESIUM_ION_TOKEN is missing at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:backends": "cd ../wwv-data-engine && pnpm dev",
     "predev": "node scripts/boot-db.mjs && npx dotenv-cli -e .env.local -c -- npx prisma db push --accept-data-loss && npx prisma generate && node scripts/copy-cesium.mjs",
     "copy-cesium": "node scripts/copy-cesium.mjs",
+    "prebuild": "node scripts/check-build-env.mjs",
     "build": "next build --webpack",
     "start": "next start",
     "test": "vitest run",

--- a/scripts/check-build-env.mjs
+++ b/scripts/check-build-env.mjs
@@ -1,0 +1,30 @@
+/**
+ * Pre-build sanity check for build-time public env vars.
+ *
+ * Some NEXT_PUBLIC_* vars are inlined into the client bundle by Next.js at
+ * build time, so they must be set when `next build` runs (not just at runtime).
+ * Missing ones don't fail the build — most have library defaults — but they
+ * surface as opaque runtime 401s / blank panes that are painful to diagnose.
+ *
+ * This script prints actionable warnings instead.
+ */
+
+const checks = [
+    {
+        name: "NEXT_PUBLIC_CESIUM_ION_TOKEN",
+        why: "Cesium ships a built-in default Ion token, but Cesium periodically revokes it. Without your own token, base imagery and world terrain may return 401 Unauthorized at runtime.",
+        how: "Get a free token at https://ion.cesium.com and set NEXT_PUBLIC_CESIUM_ION_TOKEN before building (e.g. in .env).",
+    },
+];
+
+const missing = checks.filter(c => !process.env[c.name]);
+if (missing.length === 0) process.exit(0);
+
+const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+console.warn(yellow("\n⚠  Build-time env vars not set:"));
+for (const c of missing) {
+    console.warn(yellow(`\n  ${c.name}`));
+    console.warn(`    ${c.why}`);
+    console.warn(`    Fix: ${c.how}`);
+}
+console.warn(yellow("\nContinuing build — these are warnings, not errors.\n"));


### PR DESCRIPTION
## Summary

Self-hosters who skip Cesium Ion token setup get a globe that boots fine, then `401 Unauthorized` from `api.cesium.com` on world terrain and base imagery. The cause is hard to find: CesiumJS ships a default Ion token *inside the npm package*, and Cesium periodically revokes it when usage spikes. Without `NEXT_PUBLIC_CESIUM_ION_TOKEN` set at build time, Webpack inlines an empty value, and the runtime falls back to that bundled default — which may be revoked.

This PR adds a `prebuild` script that prints a clear, actionable warning when the var is missing, so the gap is surfaced when it can still be fixed for free.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [x] Documentation
- [ ] Performance improvement

## Related Issue

N/A — discovered while bringing up a self-host: globe loaded but terrain and Bing imagery 401'd against an old revoked Cesium default token.

## Changes Made

- `scripts/check-build-env.mjs`: new pre-build sanity check that warns about missing public build-time env vars (currently just `NEXT_PUBLIC_CESIUM_ION_TOKEN`; the array is structured so adding more is one entry).
- `package.json`: wire it as `prebuild` so `pnpm build` runs it automatically.

## Behavior

Unset:
```
⚠  Build-time env vars not set:

  NEXT_PUBLIC_CESIUM_ION_TOKEN
    Cesium ships a built-in default Ion token, but Cesium periodically
    revokes it. Without your own token, base imagery and world terrain
    may return 401 Unauthorized at runtime.
    Fix: Get a free token at https://ion.cesium.com and set
    NEXT_PUBLIC_CESIUM_ION_TOKEN before building (e.g. in .env).

Continuing build — these are warnings, not errors.
```

Set: silent. Build proceeds.

Either way, exit 0 — never blocks the build, since demo edition and existing setups may rely on the bundled default until it stops working for them.

## Testing

- [x] I ran `pnpm test` and all tests pass that pass on `main` (the one pre-existing failure in `src/lib/marketplace/cors.test.ts` is unrelated and reproduces on a clean checkout of `main`).
- [x] I manually tested the script in both states (var set / unset) on the host and verified exit code is 0 and output is correct.
- [ ] I added or updated tests for my changes — the script is small, side-effect-free, and the assertion is a printed warning. Happy to add a unit test if you'd prefer.

## Notes for Reviewer

- Picked a warning rather than a build failure because failing would break demo edition and any existing self-host that's currently running on Cesium's bundled default. Forcing every operator to obtain a token to build at all felt heavy-handed.
- Kept the check list as a structured array so future build-time public vars (Google Maps, Bing, Supabase, etc.) can be added in one entry each with custom guidance.
- This is a sibling to https://github.com/silvertakana/worldwideview/pull/54 (proxy / cookie fix) — both came from the same fresh self-host bring-up.