### PR TITLE
feat(analytics): make first-party analytics opt-in (default off)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,11 +40,13 @@ export default function RootLayout({
       <body suppressHydrationWarning>
         {children}
         {process.env.VERCEL && <Analytics />}
-        <Script
-          src="https://analytics.worldwideview.dev/script.js"
-          data-website-id="2c8f6c09-2651-4a2a-af99-b8cee1612b9a"
-          strategy="afterInteractive"
-        />
+        {process.env.NEXT_PUBLIC_WWV_ANALYTICS === "true" && (
+          <Script
+            src="https://analytics.worldwideview.dev/script.js"
+            data-website-id="2c8f6c09-2651-4a2a-af99-b8cee1612b9a"
+            strategy="afterInteractive"
+          />
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

The Umami beacon at `analytics.worldwideview.dev/script.js` is loaded **unconditionally** from `src/app/layout.tsx`. Every self-hosted instance silently sends page-view and event data to the maintainer's analytics server. There is no env var, no docs note, and no opt-out — operators discover the call only by inspecting their browser's network tab.

This PR gates the script tag behind `NEXT_PUBLIC_WWV_ANALYTICS === "true"`, defaulting **off**. Maintainer's own hosted deployment flips it on explicitly via build env (status quo for that environment); self-hosters get no first-party analytics by default and can opt in if they choose to.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [x] Documentation (env var)
- [ ] Performance improvement

## Related Issue

N/A — discovered during a fresh self-host bring-up. Sibling to #54 / #55 from the same audit pass.

## Changes Made

- `src/app/layout.tsx`: wrap the existing `<Script src="…analytics.worldwideview.dev/script.js" …>` in a `process.env.NEXT_PUBLIC_WWV_ANALYTICS === "true"` guard.

## Why default off

Self-hosting *is* the default audience for an open-source project distributed on GitHub. The hosted demo at worldwideview.app is the exception, not the rule. Defaulting telemetry **on** for that audience silently routes their usage data to a third party they didn't choose to send it to. Even with a privacy-friendly stack (Umami, hashed IPs, no cookies), the principle holds: telemetry should be opt-in for the people running the source, not opt-out.

For the maintainer-hosted deployment, the change is one line in build env: `NEXT_PUBLIC_WWV_ANALYTICS=true`. No data is lost — only the source of data narrows from "every self-hoster on the internet" to "your own deployment plus anyone who explicitly opts in."

## What this does NOT change

- The Umami `data-website-id` is preserved.
- The CSP `script-src` allow-list still includes `analytics.worldwideview.dev` (so opting in works without further changes).
- Vercel's `<Analytics />` block (already gated by `process.env.VERCEL`) is untouched.
- No changes to any tracking events the app fires — only to whether the script is loaded.

## Testing

- [x] I ran `pnpm test` and the same set passes that passes on `main` (the pre-existing `cors.test.ts` failure is unrelated and reproduces on a clean checkout — same situation as #54 / #55).
- [x] I verified locally: with `NEXT_PUBLIC_WWV_ANALYTICS` unset, the rendered `/login` HTML contains no `script.js` reference and the browser DevTools network tab shows no calls to `analytics.worldwideview.dev`. Setting it to `"true"` and rebuilding restores the script tag and the beacons.
- [ ] I added or updated tests for my changes — this is a single-line conditional in JSX with no testable behavior beyond "is the env var read." Happy to add one if you'd like.

## Notes for Reviewer

- I considered making this `!== "false"` (default on, explicit opt-out) to preserve current data flows, but defaulted off feels right given who's running this and the lack of any current docs note. Open to flipping the default if you'd prefer to preserve continuity, with a docs note the only addition.
- Could pair with a one-line README mention ("Set `NEXT_PUBLIC_WWV_ANALYTICS=true` to enable usage telemetry"). Happy to send that as a follow-up if accepted.