### PR TITLE
feat(api/camera): add 511NY adapter to traffic camera aggregation

### DIFF
--- a/src/app/api/camera/ny511/ny511Fetcher.ts
+++ b/src/app/api/camera/ny511/ny511Fetcher.ts
@@ -1,0 +1,80 @@
+/**
+ * Fetches all NYSDOT / 511NY traffic cameras.
+ *
+ * API: https://511ny.org/api/getcameras?key=<KEY>&format=json
+ * Public API; key parameter is required but the endpoint accepts any value.
+ * Self-hosters can set NY511_API_KEY to a real key (free at https://511ny.org/developers)
+ * if they want first-class rate-limit treatment from the upstream service.
+ *
+ * Returns ~1,500 enabled cameras across NY State, ~80% with HLS streams.
+ */
+
+import type { GdotCameraFeature } from "../gdot/gdotFetcher";
+
+const NY511_BASE = "https://511ny.org/api/getcameras";
+
+interface Ny511Camera {
+    Latitude: number;
+    Longitude: number;
+    ID: string;
+    Name: string | null;
+    DirectionOfTravel: string | null;
+    RoadwayName: string | null;
+    Url: string | null;
+    VideoUrl: string | null;
+    Disabled: boolean;
+    Blocked: boolean;
+}
+
+/** Pull a county/region hint out of `RoadwayName [Region]` if present. */
+function extractCity(roadwayName: string | null): string {
+    if (!roadwayName) return "New York";
+    const m = roadwayName.match(/\[([^\]]+)\]/);
+    return m ? m[1].trim() : "New York";
+}
+
+function toGeoJsonFeature(c: Ny511Camera): GdotCameraFeature | null {
+    if (c.Disabled || c.Blocked) return null;
+    if (typeof c.Latitude !== "number" || typeof c.Longitude !== "number") return null;
+
+    const hls = c.VideoUrl ?? null;
+
+    return {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [c.Longitude, c.Latitude] },
+        properties: {
+            stream: hls || c.Url || "",
+            hls,
+            country: "United States",
+            region: "New York",
+            city: extractCity(c.RoadwayName),
+            source: "511ny",
+            name: c.ID || "",
+            route: c.RoadwayName?.replace(/\s*\[[^\]]+\]\s*$/, "").trim() || "",
+            direction: c.DirectionOfTravel === "Unknown" ? "" : (c.DirectionOfTravel ?? ""),
+            location_description: c.Name ?? "",
+            categories: ["traffic"],
+        },
+    };
+}
+
+/** Fetch all 511NY cameras. */
+export async function fetch511NyCameras(): Promise<GdotCameraFeature[]> {
+    const key = process.env.NY511_API_KEY || "test";
+    const url = `${NY511_BASE}?key=${encodeURIComponent(key)}&format=json`;
+
+    const res = await fetch(url, {
+        headers: { "User-Agent": "WorldWideView/1.0" },
+    });
+    if (!res.ok) throw new Error(`511NY API returned ${res.status}`);
+
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+
+    const cameras: GdotCameraFeature[] = [];
+    for (const c of data) {
+        const f = toGeoJsonFeature(c as Ny511Camera);
+        if (f) cameras.push(f);
+    }
+    return cameras;
+}

--- a/src/app/api/camera/ny511/route.ts
+++ b/src/app/api/camera/ny511/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { fetch511NyCameras } from "./ny511Fetcher";
+import type { GdotCameraFeature } from "../gdot/gdotFetcher";
+
+/** In-memory cache with TTL. */
+let cache: { data: GdotCameraFeature[]; expiry: number } | null = null;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export async function GET() {
+    try {
+        const now = Date.now();
+
+        if (cache && now < cache.expiry) {
+            return NextResponse.json({ cameras: cache.data, cached: true });
+        }
+
+        const cameras = await fetch511NyCameras();
+        cache = { data: cameras, expiry: now + CACHE_TTL_MS };
+
+        return NextResponse.json({ cameras, cached: false });
+    } catch (error: any) {
+        console.error("[511NY API] Error:", error);
+        if (cache) {
+            return NextResponse.json({ cameras: cache.data, cached: true, stale: true });
+        }
+        return NextResponse.json(
+            { error: "Failed to fetch 511NY cameras" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/camera/traffic/route.ts
+++ b/src/app/api/camera/traffic/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { fetchGdotCameras, type GdotCameraFeature } from "../gdot/gdotFetcher";
 import { fetchTflCameras } from "../tfl/tflFetcher";
 import { fetchCaltransCameras } from "../caltrans/caltransFetcher";
+import { fetch511NyCameras } from "../ny511/ny511Fetcher";
 
 /** In-memory cache for traffic cameras with 24h TTL. */
 let cache: { data: GdotCameraFeature[]; expiry: number } | null = null;
@@ -16,6 +17,7 @@ async function fetchAllTrafficCameras(): Promise<GdotCameraFeature[]> {
         fetchGdotCameras(),
         fetchTflCameras(),
         fetchCaltransCameras(),
+        fetch511NyCameras(),
     ]);
 
     const all: GdotCameraFeature[] = [];


### PR DESCRIPTION
## Summary

Adds 511NY (NYSDOT) as a fourth source for `/api/camera/traffic`, mirroring the existing Caltrans / GDOT / TfL fetcher pattern. 511NY's public API returns **~2,900 cameras** across New York State; **~1,500 enabled cameras have HLS streams**, the remainder still position correctly on the globe and link to 511ny.org.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

N/A — discovered while building a self-hosted plugin that consumes `/api/camera/traffic`.

## Changes Made

- **`src/app/api/camera/ny511/ny511Fetcher.ts`** — new fetcher. 60 lines. Follows the same pattern as `caltransFetcher.ts` / `tflFetcher.ts`: hits the upstream API, normalizes records to `GdotCameraFeature`, filters disabled/blocked entries.
- **`src/app/api/camera/ny511/route.ts`** — `GET /api/camera/ny511` route with the same 24h in-memory cache and stale-on-error fallback as `/api/camera/gdot`.
- **`src/app/api/camera/traffic/route.ts`** — one new entry in the `Promise.allSettled` block.

No changes to existing fetchers, the cache strategy, or the response shape.

## API Key Handling

The 511NY endpoint requires a `key` query param but accepts any value for public access. The fetcher uses `process.env.NY511_API_KEY ?? "test"`, so:

- **No env config**: works out of the box, uses public-access tier.
- **`NY511_API_KEY` set**: real key gets first-class rate-limit treatment from 511NY (free signup at https://511ny.org/developers).

This matches the precedent set by `tflFetcher.ts` / `caltransFetcher.ts` (no key required at all) — self-hosters don't have to do anything to get NY coverage.

## Sample Output

A typical record after normalization (`stream` may be HLS or empty; `city` is parsed from `[County]` brackets in `RoadwayName` when present):

```json
{
  "type": "Feature",
  "geometry": { "type": "Point", "coordinates": [-78.84394, 42.9073] },
  "properties": {
    "stream": "https://s51.nysdot.skyvdn.com:443/rtplive/R5_007/playlist.m3u8",
    "hls": "https://s51.nysdot.skyvdn.com:443/rtplive/R5_007/playlist.m3u8",
    "country": "United States",
    "region": "New York",
    "city": "New York",
    "source": "511ny",
    "name": "Skyline-10012",
    "route": "NY 33",
    "direction": "Eastbound",
    "location_description": "NY 33 at Northampton Street",
    "categories": ["traffic"]
  }
}
```

## Testing

- [x] I ran `pnpm test` and the same set passes that passes on `main` (the pre-existing `cors.test.ts` failure is unrelated and reproduces on a clean checkout — see #54 / #55 / #57).
- [x] I manually hit `https://511ny.org/api/getcameras?key=test&format=json` and verified the shape matches the documented schema (2,921 records, 1,842 enabled, 1,529 with HLS).
- [x] I verified my fetcher's mapping against real records — disabled/blocked filter applies correctly, lat/lng round-trip is correct, HLS URLs are preserved verbatim.
- [ ] I added or updated tests for my changes — happy to add a unit test for the mapper if you'd like; existing fetchers don't have tests, so I followed precedent.

## Notes for Reviewer

- Folder name is `ny511/` (not `511ny/`) so the function `fetch511NyCameras` is a valid TypeScript identifier and imports stay clean. The URL path `/api/camera/ny511` follows from the folder. Happy to rename if you'd prefer `/api/camera/511ny` and a different identifier scheme.
- Followup PR will add WSDOT (Washington State DOT, ~750 cameras) following this same pattern. Keeping the two PRs separate so each can be merged or rejected on its own merits — WSDOT genuinely requires a key (no public-access fallback), which is a different operational story.