### PR TITLE
feat(api/camera): add WSDOT adapter to traffic camera aggregation

### DIFF
--- a/src/app/api/camera/traffic/route.ts
+++ b/src/app/api/camera/traffic/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { fetchGdotCameras, type GdotCameraFeature } from "../gdot/gdotFetcher";
 import { fetchTflCameras } from "../tfl/tflFetcher";
 import { fetchCaltransCameras } from "../caltrans/caltransFetcher";
+import { fetchWsdotCameras } from "../wsdot/wsdotFetcher";
 
 /** In-memory cache for traffic cameras with 24h TTL. */
 let cache: { data: GdotCameraFeature[]; expiry: number } | null = null;
@@ -16,6 +17,7 @@ async function fetchAllTrafficCameras(): Promise<GdotCameraFeature[]> {
         fetchGdotCameras(),
         fetchTflCameras(),
         fetchCaltransCameras(),
+        fetchWsdotCameras(),
     ]);
 
     const all: GdotCameraFeature[] = [];

--- a/src/app/api/camera/wsdot/route.ts
+++ b/src/app/api/camera/wsdot/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { fetchWsdotCameras } from "./wsdotFetcher";
+import type { GdotCameraFeature } from "../gdot/gdotFetcher";
+
+/** In-memory cache with TTL. */
+let cache: { data: GdotCameraFeature[]; expiry: number } | null = null;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export async function GET() {
+    try {
+        const now = Date.now();
+
+        if (cache && now < cache.expiry) {
+            return NextResponse.json({ cameras: cache.data, cached: true });
+        }
+
+        const cameras = await fetchWsdotCameras();
+        cache = { data: cameras, expiry: now + CACHE_TTL_MS };
+
+        return NextResponse.json({ cameras, cached: false });
+    } catch (error: any) {
+        console.error("[WSDOT API] Error:", error);
+        if (cache) {
+            return NextResponse.json({ cameras: cache.data, cached: true, stale: true });
+        }
+        return NextResponse.json(
+            { error: "Failed to fetch WSDOT cameras" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/camera/wsdot/wsdotFetcher.ts
+++ b/src/app/api/camera/wsdot/wsdotFetcher.ts
@@ -1,0 +1,102 @@
+/**
+ * Fetches all WSDOT (Washington State DOT) highway cameras.
+ *
+ * API: https://wsdot.wa.gov/Traffic/api/HighwayCameras/HighwayCamerasREST.svc/GetCamerasAsJson?AccessCode=<KEY>
+ * Requires a free WSDOT Traveler Information API key (https://wsdot.wa.gov/traffic/api/).
+ * Returns ~1,600 active cameras (highway + airport + ferry approach).
+ *
+ * Without WSDOT_API_KEY set, the fetcher returns [] (logged once) so the
+ * combined /api/camera/traffic endpoint stays operational.
+ */
+
+import type { GdotCameraFeature } from "../gdot/gdotFetcher";
+
+const WSDOT_BASE =
+    "https://wsdot.wa.gov/Traffic/api/HighwayCameras/HighwayCamerasREST.svc/GetCamerasAsJson";
+
+interface WsdotCamera {
+    CameraID: number;
+    CameraLocation: {
+        Description: string | null;
+        Direction: string | null;
+        Latitude: number;
+        Longitude: number;
+        MilePost: number | null;
+        RoadName: string | null;
+    };
+    CameraOwner: string | null;
+    Description: string | null;
+    DisplayLatitude: number;
+    DisplayLongitude: number;
+    ImageHeight: number;
+    ImageWidth: number;
+    ImageURL: string;
+    IsActive: boolean;
+    OwnerURL: string | null;
+    Region: string | null;
+    SortOrder: number;
+    Title: string | null;
+}
+
+let warnedMissingKey = false;
+
+function toGeoJsonFeature(c: WsdotCamera): GdotCameraFeature | null {
+    if (!c.IsActive) return null;
+    if (!c.ImageURL) return null;
+
+    const lat = c.DisplayLatitude ?? c.CameraLocation?.Latitude;
+    const lon = c.DisplayLongitude ?? c.CameraLocation?.Longitude;
+    if (typeof lat !== "number" || typeof lon !== "number") return null;
+
+    const owner = c.CameraOwner ?? "";
+    const isOdot = /odot|tripcheck/i.test(owner);
+
+    return {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [lon, lat] },
+        properties: {
+            stream: c.ImageURL,
+            hls: null,
+            country: "United States",
+            region: isOdot ? "Oregon" : "Washington",
+            city: isOdot ? "Oregon" : "Washington",
+            source: "wsdot",
+            name: c.Title ?? `Camera ${c.CameraID}`,
+            route: c.CameraLocation?.RoadName ?? "",
+            direction: c.CameraLocation?.Direction ?? "",
+            location_description: c.Title ?? c.Description ?? "",
+            categories: ["traffic"],
+        },
+    };
+}
+
+/** Fetch all WSDOT cameras. Requires WSDOT_API_KEY env var. */
+export async function fetchWsdotCameras(): Promise<GdotCameraFeature[]> {
+    const key = process.env.WSDOT_API_KEY;
+    if (!key) {
+        if (!warnedMissingKey) {
+            console.warn(
+                "[WSDOT] WSDOT_API_KEY not set — skipping. " +
+                "Get a free key at https://wsdot.wa.gov/traffic/api/",
+            );
+            warnedMissingKey = true;
+        }
+        return [];
+    }
+
+    const url = `${WSDOT_BASE}?AccessCode=${encodeURIComponent(key)}`;
+    const res = await fetch(url, {
+        headers: { "User-Agent": "WorldWideView/1.0" },
+    });
+    if (!res.ok) throw new Error(`WSDOT API returned ${res.status}`);
+
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+
+    const cameras: GdotCameraFeature[] = [];
+    for (const c of data) {
+        const f = toGeoJsonFeature(c as WsdotCamera);
+        if (f) cameras.push(f);
+    }
+    return cameras;
+}


### PR DESCRIPTION
## Summary

Adds WSDOT (Washington State DOT) as a fifth source for `/api/camera/traffic`, mirroring the existing Caltrans / GDOT / TfL / 511NY (#58) fetcher pattern. WSDOT's API returns **~1,600 active cameras** across Washington State, plus **~70 cross-border cameras** at I-5/I-205 corridors that WSDOT shares with Oregon DOT (Tripcheck) — all with direct JPG snapshot URLs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

Sibling to #58 (511NY adapter). Same self-host bring-up as #54 / #55 / #57.

## Changes Made

- **`src/app/api/camera/wsdot/wsdotFetcher.ts`** — new fetcher. ~80 lines. Hits the documented WSDOT Traveler Information API, normalizes records to `GdotCameraFeature`, filters inactive / missing-image entries.
- **`src/app/api/camera/wsdot/route.ts`** — `GET /api/camera/wsdot` route with the same 24h in-memory cache and stale-on-error fallback as `/api/camera/gdot`.
- **`src/app/api/camera/traffic/route.ts`** — one new entry in the `Promise.allSettled` block.

No changes to existing fetchers, the cache strategy, or the response shape.

## API Key Handling

WSDOT genuinely requires an API key — unlike 511NY (#58), there's no public-access fallback. **Without `WSDOT_API_KEY` set, the fetcher returns `[]` and logs a single warning** (the warning is gated by a module-level `warnedMissingKey` flag so it doesn't spam the logs every 24h cache miss). The combined `/api/camera/traffic` endpoint stays fully operational; WA coverage just doesn't appear.

This matches the precedent for graceful degrade across the existing fetchers — anyone running a self-host without the env var sees no errors, just no WA cameras.

Self-hosters who want WA coverage register at `https://wsdot.wa.gov/traffic/api/` (~2 min, email confirm) and set `WSDOT_API_KEY` in `.env`.

## Tripcheck / Oregon Coverage

WSDOT's API includes ~70 records owned by `Tripcheck (ODOT)` covering I-5 / I-205 border crossings. The fetcher detects these via `/odot|tripcheck/i.test(CameraOwner)` and tags them `region: "Oregon"` so they show up correctly under Oregon-state filters; everything else is `region: "Washington"`.

## Sample Output

WSDOT-owned (Washington):
```json
{
  "type": "Feature",
  "geometry": { "type": "Point", "coordinates": [-122.6625, 48.498333] },
  "properties": {
    "stream": "https://images.wsdot.wa.gov/airports/anafuel.jpg",
    "hls": null,
    "country": "United States",
    "region": "Washington",
    "city": "Washington",
    "source": "wsdot",
    "name": "Anacortes Airport Fuel Pump",
    "route": "Airports",
    "direction": "W",
    "location_description": "Anacortes Airport Fuel Pump",
    "categories": ["traffic"]
  }
}
```

Tripcheck-owned (Oregon):
```json
{
  "type": "Feature",
  "geometry": { "type": "Point", "coordinates": [-122.705778, 45.370641] },
  "properties": {
    "stream": "https://www.tripcheck.com/RoadCams/cams/i205staf_pid665.jpg",
    "hls": null,
    "country": "United States",
    "region": "Oregon",
    "city": "Oregon",
    "source": "wsdot",
    "name": "I-205 at Stafford Rd.",
    "route": "I-205",
    "direction": "B",
    "location_description": "I-205 at Stafford Rd.",
    "categories": ["traffic"]
  }
}
```

## Testing

- [x] I ran `pnpm test` — same set passes as on `main` (the pre-existing `cors.test.ts` failure is unrelated and reproduces on a clean checkout).
- [x] I tested **end-to-end against the live WSDOT API with a real key** — fetched all 1,676 records, ran them through the mapper, verified 1,610 WA + 66 Oregon split, spot-checked 3 image URLs return `200 image/jpeg`. Sample outputs above are real records from the live API.
- [x] I verified the missing-key path: with `WSDOT_API_KEY` unset, `fetchWsdotCameras()` returns `[]` and logs the warning once.
- [ ] I added or updated tests for my changes — happy to add a unit test for the mapper if you'd like; existing fetchers don't have tests, so I followed precedent.

## Notes for Reviewer

- I considered also tagging the airport-camera records (CameraOwner `WSDOT Aviation`, ~104 records) with a separate category like `["traffic", "aviation"]`. Kept it simple as `["traffic"]` matching the existing fetchers — easy to extend later if there's appetite for finer category gradations.
- WSDOT's API also publishes flow data, alerts, ferry positions, and weather stations under the same key. Not in scope here, but the `/api/camera/wsdot` namespace leaves room for `/api/wsdot/*` if you ever want broader coverage.
- The existing fetchers' shared type alias `GdotCameraFeature` is mildly confusing — every adapter imports a "GDOT" type even when adapting Caltrans/TfL/511NY/WSDOT. Could refactor to a neutral `CameraFeature` type in a follow-up if you want; out of scope for this PR.