### PR TITLE
feat(api/camera): NCDOT adapter (depends on #62)

### DIFF
--- a/src/app/api/camera/adapters/ncdot.ts
+++ b/src/app/api/camera/adapters/ncdot.ts
@@ -1,0 +1,128 @@
+/**
+ * NCDOT (North Carolina DOT) adapter.
+ *
+ * NCDOT exposes its public traffic-cam API in two parts: a bulk endpoint
+ * that returns ~770 cameras with only `{ id, latitude, longitude }`, and a
+ * detail endpoint that returns one camera's full record (locationName,
+ * roadId, countyId, imageURL, status). To get usable data we fan out an
+ * N+1 fetch from the bulk list with bounded concurrency. First call lands
+ * in ~15s; the registry's per-adapter cache holds it for 24h after that.
+ *
+ * No key required. Image URLs are direct ~45KB JPEGs at 640x360.
+ */
+
+import type { CameraAdapter, CameraFeature } from "./types";
+
+const BULK_URL = "https://eapps.ncdot.gov/services/traffic-prod/v1/cameras";
+const DETAIL_URL = (id: number) =>
+    `https://eapps.ncdot.gov/services/traffic-prod/v1/cameras/${id}`;
+
+const CONCURRENCY = 20;
+
+interface BulkRecord {
+    id: number;
+    latitude: number;
+    longitude: number;
+}
+
+interface DetailRecord {
+    id: number;
+    locationName: string | null;
+    displayName: string | null;
+    mileMarker: number | null;
+    roadId: number;
+    countyId: number;
+    latitude: number;
+    longitude: number;
+    imageURL: string;
+    isDOTCamera: boolean;
+    status: string;
+}
+
+async function fetchDetail(id: number): Promise<DetailRecord | null> {
+    try {
+        const res = await fetch(DETAIL_URL(id), {
+            headers: { "User-Agent": "WorldWideView/1.0" },
+        });
+        if (!res.ok) return null;
+        if (res.status === 204) return null; // camera deleted/unavailable
+        const text = await res.text();
+        if (!text) return null;
+        return JSON.parse(text) as DetailRecord;
+    } catch {
+        return null;
+    }
+}
+
+/** Bounded-concurrency Promise.all. */
+async function mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let next = 0;
+    async function run() {
+        while (next < items.length) {
+            const i = next++;
+            results[i] = await worker(items[i]);
+        }
+    }
+    await Promise.all(Array.from({ length: limit }, run));
+    return results;
+}
+
+function toFeature(d: DetailRecord): CameraFeature | null {
+    if (d.status && d.status !== "OK") return null;
+    if (!d.imageURL) return null;
+    if (typeof d.latitude !== "number" || typeof d.longitude !== "number") return null;
+    return {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [d.longitude, d.latitude] },
+        properties: {
+            id: `ncdot-${d.id}`,
+            source: "ncdot",
+            stream: d.imageURL,
+            streamType: "image",
+            hls: null,
+            name: d.displayName || d.locationName || `NCDOT camera ${d.id}`,
+            country: "United States",
+            region: "North Carolina",
+            city: "North Carolina",
+            location_description: d.locationName ?? "",
+            categories: ["traffic"],
+            extra: {
+                mileMarker: d.mileMarker,
+                roadId: d.roadId,
+                countyId: d.countyId,
+                ncdotStatus: d.status,
+            },
+        },
+    };
+}
+
+export const ncdotAdapter: CameraAdapter = {
+    id: "ncdot",
+    displayName: "NCDOT (North Carolina)",
+    region: "United States — North Carolina",
+    fetch: async () => {
+        const bulkRes = await fetch(BULK_URL, {
+            headers: { "User-Agent": "WorldWideView/1.0" },
+        });
+        if (!bulkRes.ok) throw new Error(`NCDOT bulk ${bulkRes.status}`);
+        const bulk = (await bulkRes.json()) as BulkRecord[];
+        if (!Array.isArray(bulk)) return [];
+
+        const details = await mapWithConcurrency(bulk, CONCURRENCY, (b) =>
+            fetchDetail(b.id),
+        );
+
+        const features: CameraFeature[] = [];
+        for (const d of details) {
+            if (!d) continue;
+            const f = toFeature(d);
+            if (f) features.push(f);
+        }
+        return features;
+    },
+};

--- a/src/app/api/camera/adapters/registry.ts
+++ b/src/app/api/camera/adapters/registry.ts
@@ -4,6 +4,7 @@ import { gdotAdapter } from "./gdot";
 import { tflAdapter } from "./tfl";
 import { ny511Adapter } from "./ny511";
 import { wsdotAdapter } from "./wsdot";
+import { ncdotAdapter } from "./ncdot";
 
 /**
  * All registered adapters. To add a new source, add an import + push the
@@ -17,6 +18,7 @@ export const ALL_ADAPTERS: CameraAdapter[] = [
     tflAdapter,
     ny511Adapter,
     wsdotAdapter,
+    ncdotAdapter,
 ];
 
 const ADAPTERS_BY_ID: Map<string, CameraAdapter> = new Map(


### PR DESCRIPTION
## Summary

Adds North Carolina DOT (~770 cameras statewide) as a sixth source for `/api/camera/traffic`, built on top of the adapter pattern introduced in #62.

**Stacked on #62.** This branch contains the refactor commit + the NCDOT commit; once #62 merges to main, this PR's diff naturally shrinks to just `adapters/ncdot.ts` + 2 lines in `adapters/registry.ts`. Reviewing as-is, focus on the second commit (`feat(api/camera): NCDOT adapter`) — the first is identical to #62.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## What's actually new in this PR

- `src/app/api/camera/adapters/ncdot.ts` (new, ~130 lines)
- `src/app/api/camera/adapters/registry.ts` (+2 lines: import + push)

That's the entire net delta over #62.

## NCDOT API quirk

NCDOT's API is unusual: the bulk endpoint returns only `{ id, latitude, longitude }`, full details require one GET per camera. The adapter fans out detail fetches with a bounded concurrency of 20 — first population takes ~15s, then the registry's per-adapter cache (default 24h) holds it. Cameras with `status !== "OK"` are filtered out.

Image URLs are direct ~45KB JPEGs at 640×360, no auth required.

## Sample feature

```json
{
  "type": "Feature",
  "geometry": { "type": "Point", "coordinates": [-78.998909, 35.950774] },
  "properties": {
    "id": "ncdot-5",
    "source": "ncdot",
    "stream": "https://eapps.ncdot.gov/services/traffic-prod/v1/cameras/images?filename=I40_US15-501.jpg",
    "streamType": "image",
    "name": "I-40 Exit 270 - US 15 - 501",
    "country": "United States",
    "region": "North Carolina",
    "city": "North Carolina",
    "location_description": "I-40 Exit 270 - US 15 - 501",
    "categories": ["traffic"],
    "extra": { "mileMarker": 270, "roadId": 1, "countyId": 32, "ncdotStatus": "OK" }
  }
}
```

## Testing

- [x] Verified `?sources=ncdot` returns 773 features against the live NCDOT API.
- [x] Spot-checked image URLs return `200 image/jpeg` (640×360, ~45KB).
- [x] Concurrency limit prevents flooding NCDOT during initial population.
- [x] `pnpm test` — same passing set as base branch.

## Notes for Reviewer

- Concurrency of 20 was empirically chosen — fast enough that initial fetch is ~15s, polite enough that NCDOT doesn't rate-limit.
- North Carolina also has DriveNC.gov, but it routes through the same `eapps.ncdot.gov` API for camera data; no separate municipal feeds (Charlotte CDOT ArcGIS layer exists but returns 0 features).