### PR TITLE
feat(api/camera): OSM surveillance-points adapter (depends on #62)

### DIFF
--- a/src/app/api/camera/adapters/osm-surveillance.ts
+++ b/src/app/api/camera/adapters/osm-surveillance.ts
@@ -1,0 +1,88 @@
+/**
+ * OpenStreetMap surveillance points (`man_made=surveillance`).
+ *
+ * Location-only — most OSM surveillance nodes don't have public stream URLs,
+ * but the geometry alone is useful as a "where do public/government cameras
+ * exist" overlay alongside the live DOT feeds.
+ *
+ * The query is bounded to a list of major metros (~30km radius each) so a
+ * single Overpass call doesn't return hundreds of thousands of points.
+ * Operators who want fuller coverage can extend `OVERPASS_QUERY` and bump
+ * the per-query cap. Output is capped at 3000 nodes total.
+ *
+ * Cache TTL is 7 days — OSM data changes slowly and Overpass is shared
+ * infrastructure that politely asks consumers not to re-poll aggressively.
+ */
+
+import type { CameraAdapter, CameraFeature } from "./types";
+
+const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
+
+const OVERPASS_QUERY = `[out:json][timeout:25];
+(
+  node["man_made"="surveillance"](around:30000,37.7749,-122.4194);
+  node["man_made"="surveillance"](around:30000,34.0522,-118.2437);
+  node["man_made"="surveillance"](around:30000,40.7128,-74.0060);
+  node["man_made"="surveillance"](around:30000,51.5074,-0.1278);
+  node["man_made"="surveillance"](around:30000,48.8566,2.3522);
+  node["man_made"="surveillance"](around:30000,35.6762,139.6503);
+  node["man_made"="surveillance"](around:30000,35.7796,-78.6382);
+);
+out body 3000;`;
+
+interface OverpassNode {
+    type: "node";
+    id: number;
+    lat: number;
+    lon: number;
+    tags?: Record<string, string>;
+}
+
+export const osmSurveillanceAdapter: CameraAdapter = {
+    id: "osm-surveillance",
+    displayName: "OSM Surveillance Points",
+    region: "Global (sampled major metros)",
+    cacheTtlMs: 7 * 24 * 60 * 60 * 1000,
+    fetch: async () => {
+        const res = await fetch(OVERPASS_URL, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            body: `data=${encodeURIComponent(OVERPASS_QUERY)}`,
+        });
+        if (!res.ok) throw new Error(`overpass ${res.status}`);
+        const data = (await res.json()) as { elements?: OverpassNode[] };
+        const nodes = (data.elements ?? []).filter(
+            (e): e is OverpassNode =>
+                e.type === "node" && typeof e.lat === "number",
+        );
+
+        return nodes.map<CameraFeature>((n) => {
+            const t = n.tags ?? {};
+            return {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [n.lon, n.lat] },
+                properties: {
+                    id: `osm-${n.id}`,
+                    source: "osm-surveillance",
+                    stream: null,
+                    streamType: null,
+                    hls: null,
+                    name: t.name ?? "Surveillance",
+                    country: t["addr:country"],
+                    location_description: t.description ?? "",
+                    categories: ["surveillance"],
+                    extra: {
+                        operator: t.operator,
+                        surveillanceType: t["surveillance:type"],
+                        cameraType: t["camera:type"],
+                        cameraDirection: t.camera_direction,
+                        osmId: n.id,
+                    },
+                },
+            };
+        });
+    },
+};

--- a/src/app/api/camera/adapters/registry.ts
+++ b/src/app/api/camera/adapters/registry.ts
@@ -5,6 +5,7 @@ import { tflAdapter } from "./tfl";
 import { ny511Adapter } from "./ny511";
 import { wsdotAdapter } from "./wsdot";
 import { ncdotAdapter } from "./ncdot";
+import { osmSurveillanceAdapter } from "./osm-surveillance";
 
 /**
  * All registered adapters. To add a new source, add an import + push the
@@ -19,6 +20,7 @@ export const ALL_ADAPTERS: CameraAdapter[] = [
     ny511Adapter,
     wsdotAdapter,
     ncdotAdapter,
+    osmSurveillanceAdapter,
 ];
 
 const ADAPTERS_BY_ID: Map<string, CameraAdapter> = new Map(


### PR DESCRIPTION
## Summary

Adds an adapter that pulls `man_made=surveillance` nodes from the OpenStreetMap Overpass API as location-only camera markers. Useful as a "where do cameras exist" overlay alongside live DOT feeds — most OSM surveillance nodes don't have stream URLs, but their tags (operator, camera:type, surveillance:type) are filterable.

**Stacked on #62.** This branch contains the refactor commit + the OSM commit; once #62 merges, this PR's diff naturally shrinks to just the OSM file + registry edit. Reviewing as-is, focus on the second commit (`feat(api/camera): OSM surveillance-points adapter`).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## What's actually new in this PR

- `src/app/api/camera/adapters/osm-surveillance.ts` (new, ~90 lines)
- `src/app/api/camera/adapters/registry.ts` (+2 lines: import + push)

## Why bound the query

A global `man_made=surveillance` query returns hundreds of thousands of points and would either time out or DoS Overpass's free tier. The adapter queries 7 major metros (SF, LA, NYC, London, Paris, Tokyo, Raleigh) at 30km radius each and caps output at 3,000 nodes. Operators who want fuller coverage can extend `OVERPASS_QUERY` in-source.

Cache TTL is set to **7 days** (overrides the default 24h) because OSM data changes slowly and Overpass is shared infrastructure that politely asks consumers not to poll aggressively.

## Sample feature

```json
{
  "type": "Feature",
  "geometry": { "type": "Point", "coordinates": [-122.4, 37.78] },
  "properties": {
    "id": "osm-1234567",
    "source": "osm-surveillance",
    "stream": null,
    "streamType": null,
    "name": "Traffic enforcement camera",
    "categories": ["surveillance"],
    "extra": { "operator": "SFMTA", "surveillanceType": "public", "cameraType": "fixed" }
  }
}
```

## Testing

- [x] Verified `?sources=osm-surveillance` returns 1,000–2,500 features depending on Overpass load.
- [x] Spot-checked tag preservation in `properties.extra`.
- [x] Cache TTL works: second fetch within 7 days returns cached data instantly.
- [x] `pnpm test` — same passing set as base branch.

## Notes for Reviewer

- The 7-metro list is editorial and could be revisited. A more sophisticated approach would let operators configure regions via env var, but that complicates a fairly simple adapter; happy to follow up if there's appetite.
- Marked `categories: ["surveillance"]` to distinguish from traffic cams — gives client UIs a way to render different icons / behaviors for these (e.g., grey-out / "no stream" hint instead of a play button).