### PR TITLE
feat(agent): SSE-based AgentBus for external-tool UI control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,50 @@ ARG NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL
 ARG NEXT_PUBLIC_ADSENSE_CLIENT_ID
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED
+ARG NEXT_PUBLIC_WWV_BUILD_ID
+ARG NEXT_PUBLIC_WWV_BUILD_AT
 
 # Run our pregenerate schema swap script and then generate Prisma client
 RUN NEXT_PUBLIC_WWV_EDITION=$NEXT_PUBLIC_WWV_EDITION pnpm run generate
 
 # Database migrations run at container startup via docker-entrypoint.sh
 # DATABASE_URL must be set to a PostgreSQL connection string
+
+# Stamp the build with a millisecond-precision id + iso timestamp. If the
+# operator hasn't passed NEXT_PUBLIC_WWV_BUILD_ID via build args, generate
+# one here so /api/build and the client console.log both carry a unique
+# value per `docker build`.
+RUN if [ -z "$NEXT_PUBLIC_WWV_BUILD_ID" ]; then \
+        NEXT_PUBLIC_WWV_BUILD_ID="$(date +%s%3N 2>/dev/null || node -e 'process.stdout.write(String(Date.now()))')" ; \
+    fi && \
+    if [ -z "$NEXT_PUBLIC_WWV_BUILD_AT" ]; then \
+        NEXT_PUBLIC_WWV_BUILD_AT="$(node -e 'process.stdout.write(new Date().toISOString())')" ; \
+    fi && \
+    echo "$NEXT_PUBLIC_WWV_BUILD_ID" > /app/.build-id && \
+    echo "$NEXT_PUBLIC_WWV_BUILD_AT" > /app/.build-at
+
+# Write .env.production.local so Next.js sees every NEXT_PUBLIC_* var
+# whose ARG was passed in. Docker doesn't reliably promote ARGs into the
+# build process's environment for `next build` to inline references with
+# Webpack's DefinePlugin — `process.env.NEXT_PUBLIC_X` either gets the
+# inlined literal value (when set) or stays as a runtime polyfill access
+# that resolves to undefined in the browser. Writing the file is the
+# documented Next.js path and behaves the same on every host.
+RUN set +e ; { \
+        echo "NEXT_PUBLIC_WWV_BUILD_ID=$(cat /app/.build-id)" ; \
+        echo "NEXT_PUBLIC_WWV_BUILD_AT=$(cat /app/.build-at)" ; \
+        if [ -n "$NEXT_PUBLIC_WWV_EDITION" ]; then echo "NEXT_PUBLIC_WWV_EDITION=$NEXT_PUBLIC_WWV_EDITION" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED" ]; then echo "NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED=$NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_CESIUM_ION_TOKEN" ]; then echo "NEXT_PUBLIC_CESIUM_ION_TOKEN=$NEXT_PUBLIC_CESIUM_ION_TOKEN" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_GOOGLE_MAPS_API_KEY" ]; then echo "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=$NEXT_PUBLIC_GOOGLE_MAPS_API_KEY" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_BING_MAPS_KEY" ]; then echo "NEXT_PUBLIC_BING_MAPS_KEY=$NEXT_PUBLIC_BING_MAPS_KEY" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_WS_ENGINE_URL" ]; then echo "NEXT_PUBLIC_WS_ENGINE_URL=$NEXT_PUBLIC_WS_ENGINE_URL" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL" ]; then echo "NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL=$NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_ADSENSE_CLIENT_ID" ]; then echo "NEXT_PUBLIC_ADSENSE_CLIENT_ID=$NEXT_PUBLIC_ADSENSE_CLIENT_ID" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_SUPABASE_URL" ]; then echo "NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY" ; fi ; \
+    } > /app/.env.production.local
 
 # Run Next.js build with Webpack cache mounted
 RUN --mount=type=cache,target=/app/.next/cache NODE_OPTIONS="--max_old_space_size=3072" pnpm run build
@@ -79,6 +117,10 @@ COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/scripts/https-proxy.mjs ./scripts/https-proxy.mjs
 COPY --from=builder /app/scripts/migrate-legacy.mjs ./scripts/migrate-legacy.mjs
+
+# Build stamp — read by /api/build at runtime.
+COPY --from=builder /app/.build-id ./.build-id
+COPY --from=builder /app/.build-at ./.build-at
 
 # Entrypoint: migrate DB on first run, then start server
 COPY docker-entrypoint.sh ./docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ WorldWideView is a real-time geospatial engine visualizing live global data on a
 - **Real-Time Data Pipeline**: High-frequency WebSocket updates managed by a custom `DataBus`.
 - **Advanced Entity Management**: Automatic horizon culling, chunked primitive rendering, and 3D stacking/spiderification.
 - **Marketplace Integration**: Download and sync new plugins directly from the UI.
+- **Agent Bus (opt-in)**: HTTP+SSE control surface that lets an external tool — typically an MCP server fronting an LLM — fly the globe, toggle layers, and select entities in the running browser session. Default off; see [Agent Bus docs](docs/agent-bus.md).
 
 ## Core Technologies
 
@@ -145,6 +146,7 @@ WorldWideView is distributed across several specialized repositories:
 3. **`worldwideview-plugins`**: First-party maintained plugins.
 4. **`worldwideview-marketplace`**: The web application driving the plugin directory.
 5. **`worldwideview-web`**: Marketing and landing site.
+6. **[`szski/wwv-mcp`](https://github.com/szski/wwv-mcp)**: Reference MCP server for driving the globe from an LLM agent (Claude Code, Claude Desktop, Cursor, Cline, …) via the [Agent Bus](docs/agent-bus.md). Contributor-hosted today; may move under the project org.
 
 ## Development & Workflow
 
@@ -172,6 +174,7 @@ Explore our comprehensive documentation suite for detailed engineering insights:
 - **[Development](docs/development.md)**: Coding conventions and common implementation patterns.
 - **[Testing](docs/testing.md)**: Vitest setup and coverage targets.
 - **[Deployment](docs/deployment.md)**: Coolify integration and persistent volumes.
+- **[Agent Bus](docs/agent-bus.md)**: Wiring an MCP server (or any external tool) to drive the running globe.
 - **[Files Catalog](docs/files.md)**: Comprehensive mapping of core source files.
 
 > [!IMPORTANT]

--- a/docs/agent-bus.md
+++ b/docs/agent-bus.md
@@ -1,0 +1,166 @@
+# Agent Bus — driving WWV from external tools
+
+## Overview
+
+The Agent Bus is an opt-in HTTP+SSE surface that lets a trusted external process — most commonly a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server fronting an LLM agent — drive the running WWV browser session. The agent can fly the globe, toggle layers, focus entities, and select things by posting JSON actions to a server endpoint, which fans them out over SSE to every browser tab belonging to the same logged-in user.
+
+Read-only camera and engine queries already work via the existing REST API. The Agent Bus is the missing **write path**.
+
+```
+LLM client  ──MCP──▶  szski/wwv-mcp  ──HTTP──▶  /api/agent/publish  ──SSE──▶  browser
+(Claude, Cursor, …)   (separate repo)            (this PR adds these)         (Cesium flies)
+```
+
+## Enabling the bus
+
+The bus is **off by default**. The subscriber early-returns and no SSE connection is opened. You explicitly opt in via a build-time environment variable.
+
+### In Docker
+
+Pass the ARG at build time:
+
+```sh
+docker build \
+  --build-arg NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED=true \
+  -t worldwideview .
+```
+
+### In a Coolify / hosted build
+
+Set `NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED=true` in the build environment. Because it's a `NEXT_PUBLIC_*` variable, it is inlined into the JavaScript bundle at `next build` time — runtime-only env changes will not enable it.
+
+### Verifying it's on
+
+On a fresh page load, open the browser DevTools console. You should see a one-line build banner:
+
+```
+[wwv build] id=1714572934123 built_at=2026-05-13T18:35:34Z agent_bus=on
+```
+
+If `agent_bus=off` after enabling the env var, the build did not pick up the variable — re-check that it was passed as `--build-arg` (Docker) or set before `next build` ran (other hosts).
+
+You can also hit `/api/build` to confirm the served bundle's build id and flag state.
+
+## Using it — quick smoke test with curl
+
+To verify the bus end-to-end without an MCP server, log into WWV in your browser, grab your `__Secure-authjs.session-token` cookie value from DevTools, and POST an action:
+
+```sh
+curl -X POST https://your-wwv-host/api/agent/publish \
+  -H "Content-Type: application/json" \
+  -H "Cookie: __Secure-authjs.session-token=PASTE_TOKEN_HERE" \
+  -d '{"action":"fly_to","lat":35.7796,"lon":-78.6382,"distance":50000}'
+```
+
+If the bus is enabled and the cookie is valid, the open tab will fly to Raleigh and the response will be:
+
+```json
+{ "ok": true, "delivered": 1, "subscribers": 1 }
+```
+
+`subscribers: 0` means the bus is off in the build, the cookie's user has no open tabs, or the env var wasn't applied — see *Verifying* above.
+
+## Using it — wiring an MCP server
+
+The reference MCP server for WWV is published at **[szski/wwv-mcp](https://github.com/szski/wwv-mcp)**. It exposes 15 tools (`globe_fly_to`, `layer_toggle`, `engine_query`, `geocode`, `system_status`, etc.) and works with any MCP-aware client (Claude Code, Claude Desktop, Cursor, Continue, Cline).
+
+> [!NOTE]
+> `szski/wwv-mcp` lives in a contributor's namespace today and may move under the project's own organization later. Update the install URL accordingly when that happens.
+
+### Install (Node)
+
+```sh
+git clone https://github.com/szski/wwv-mcp
+cd wwv-mcp
+npm install
+npm run build
+```
+
+Then store credentials so the MCP server can auto-login at startup:
+
+```sh
+mkdir -p ~/.config/wwv-mcp
+cat > ~/.config/wwv-mcp/credentials <<'EOF'
+WWV_USERNAME=you@example.com
+WWV_PASSWORD=your-password
+EOF
+chmod 600 ~/.config/wwv-mcp/credentials
+```
+
+### Install (Docker)
+
+If a published image exists at `szski/wwv-mcp` (or wherever the maintainer mirrors it), no install step is needed — the MCP client config below uses `docker run` to launch the server on demand.
+
+### Client config — Claude Code
+
+Edit `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "wwv": {
+      "command": "node",
+      "args": ["/absolute/path/to/wwv-mcp/dist/index.js"],
+      "env": {
+        "WWV_BASE_URL": "https://your-wwv-host.example",
+        "WWV_ENGINE_URL": "http://localhost:5001"
+      }
+    }
+  }
+}
+```
+
+Or, with Docker:
+
+```json
+{
+  "mcpServers": {
+    "wwv": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "WWV_BASE_URL=http://host.docker.internal:3000",
+        "-e", "WWV_ENGINE_URL=http://host.docker.internal:5001",
+        "szski/wwv-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+Then `/mcp` in Claude Code should list `wwv` with all 15 tools.
+
+### Client config — Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows). The `mcpServers.wwv` block is identical to Claude Code above.
+
+### Client config — Cursor, Continue, Cline
+
+Each of these reads an MCP server list in its own settings UI but the shape of the entry — `command` + `args` + `env` — is the same as Claude Code's. See your client's MCP docs for the exact location of its config file.
+
+### Verifying the wiring
+
+Once configured, ask the agent something like *"What's the status of the WWV system?"* — it should call `system_status` and report back. If you see `agent_bus_enabled: false`, the bus is off in the WWV build; fix that before trying write tools like `globe_fly_to`.
+
+## Security and multi-tenancy
+
+- **Default off.** Without the env var, the subscriber doesn't open a connection, the publish endpoint exists but has no subscribers, and the bundle's dead-code elimination removes the `EventSource` constructor entirely.
+- **Auth gated.** Both `/api/agent/publish` and `/api/agent/stream` use the same `auth()` helper as the rest of the marketplace API. No tokens — just the existing Auth.js session cookie.
+- **Per-user scoping.** Subscriptions live in `Map<userId, …>`, so a publish from user A's session never reaches user B's stream, even though both sit on the same Node process. Multi-tenant deployments are safe.
+- **Same trust model as a browser tab.** An MCP server "acts as the user" by holding the user's session cookie. If you wouldn't trust a browser tab on the same machine, don't give an MCP server the cookie.
+- **Single-process only.** The `AgentBus` is in-memory and process-local. Multi-instance deployments behind a load balancer would need a Redis pub/sub adapter — about 30 lines of additional code, not included here.
+
+## Endpoint reference
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/agent/stream` | SSE channel. Auth-gated. Streams `AgentAction` JSON events for the connected user. Heartbeat every 25s. |
+| `POST` | `/api/agent/publish` | Accept an `AgentAction` JSON body, broadcast to the publishing user's subscribers, return `{ok, delivered, subscribers}`. |
+| `GET` | `/api/build` | Build id + ISO timestamp + `NEXT_PUBLIC_*` flag state. Used by `AgentBusSubscriber` to print the build banner. |
+
+`AgentAction` is currently a six-verb union: `fly_to`, `face_towards`, `layer_toggle`, `highlight_layer`, `select_entity`, `ping`. The shape is `{action: string, …payload}` JSON, so additive changes are backwards-compatible.
+
+## Companion repos
+
+- **[szski/wwv-mcp](https://github.com/szski/wwv-mcp)** — reference MCP server. 15 tools. Required for any LLM-driven use of the bus.
+- **[silvertakana/wwv-data-engine](https://github.com/silvertakana/wwv-data-engine)** — separate repo, supplies the read-only `engine_query` data that the MCP server's read tools wrap.

--- a/src/app/api/agent/publish/route.ts
+++ b/src/app/api/agent/publish/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { agentBus, type AgentAction } from "@/lib/agent/bus";
+
+/**
+ * POST /api/agent/publish
+ *
+ * Accept an AgentAction from a trusted caller (an external tool acting as
+ * the logged-in user) and broadcast it to every subscriber currently
+ * listening on /api/agent/stream *for the same user*. The browser subscriber
+ * routes the action onto the client-side dataBus, which the React + Cesium
+ * app already drives off of.
+ *
+ * Returns the number of clients the action reached.
+ *
+ * Auth: same session-cookie gate as /stream — only the same user's
+ * sessions can publish or subscribe, and per-user routing is enforced
+ * inside the bus.
+ */
+export async function POST(req: NextRequest) {
+    const session = await auth();
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = session.user.id;
+
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (!isAgentAction(body)) {
+        return NextResponse.json(
+            { error: "Body must be an AgentAction with a recognized `action` field" },
+            { status: 400 },
+        );
+    }
+
+    const result = agentBus.publish(userId, body);
+    return NextResponse.json({
+        ok: true,
+        delivered: result.delivered,
+        subscribers: agentBus.subscribersFor(userId),
+    });
+}
+
+function isAgentAction(v: unknown): v is AgentAction {
+    if (!v || typeof v !== "object") return false;
+    const a = (v as { action?: unknown }).action;
+    return (
+        a === "fly_to" ||
+        a === "face_towards" ||
+        a === "layer_toggle" ||
+        a === "highlight_layer" ||
+        a === "select_entity" ||
+        a === "ping"
+    );
+}

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -1,0 +1,69 @@
+import { auth } from "@/lib/auth";
+import { agentBus } from "@/lib/agent/bus";
+
+/**
+ * GET /api/agent/stream
+ *
+ * Server-Sent Events channel that the browser subscribes to. Each connected
+ * client receives every action `/api/agent/publish` broadcasts *for the
+ * same authenticated user*. Multi-tenant safe: user A's stream never sees
+ * user B's publishes.
+ *
+ * Auth-gated via Auth.js session.
+ */
+export async function GET() {
+    const session = await auth();
+    if (!session?.user?.id) {
+        return new Response("Unauthorized", { status: 401 });
+    }
+    const userId = session.user.id;
+
+    let unsubscribe = () => {};
+    const id = `${userId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            const encoder = new TextEncoder();
+
+            // Initial comment + retry hint so EventSource has something to ack
+            // immediately and reconnects fast if the connection drops.
+            controller.enqueue(encoder.encode(":connected\nretry: 3000\n\n"));
+
+            unsubscribe = agentBus.subscribe(userId, {
+                id,
+                write: (chunk) => controller.enqueue(encoder.encode(chunk)),
+                close: () => {
+                    try { controller.close(); } catch { /* already closed */ }
+                },
+            });
+
+            // Heartbeat every 25s so intermediaries (Caddy, nginx, CDNs) don't
+            // tear down a "stalled" connection. SSE-aware proxies typically
+            // need a comment line every <30s to keep the channel alive.
+            const heartbeat = setInterval(() => {
+                try {
+                    controller.enqueue(encoder.encode(`:hb ${Date.now()}\n\n`));
+                } catch {
+                    clearInterval(heartbeat);
+                }
+            }, 25_000);
+
+            (controller as any)._cleanup = () => {
+                clearInterval(heartbeat);
+                unsubscribe();
+            };
+        },
+        cancel() {
+            unsubscribe();
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    });
+}

--- a/src/app/api/build/route.ts
+++ b/src/app/api/build/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * GET /api/build
+ *
+ * Lightweight build identification — lets you confirm exactly which build
+ * the running browser tab is talking to. Pair with the `[wwv build] ...`
+ * client-side console log so a refresh mismatch (browser holding stale
+ * chunks) becomes obvious instead of looking like a feature regression.
+ *
+ * Public — no secrets here, just a build stamp + a few public flags useful
+ * for diagnostics.
+ */
+
+function readMaybe(p: string): string | null {
+    try {
+        return fs.readFileSync(p, "utf-8").trim();
+    } catch {
+        return null;
+    }
+}
+
+const BUILD_ID =
+    process.env.NEXT_PUBLIC_WWV_BUILD_ID ??
+    readMaybe(path.join(process.cwd(), ".build-id")) ??
+    "dev";
+const BUILD_AT =
+    process.env.NEXT_PUBLIC_WWV_BUILD_AT ??
+    readMaybe(path.join(process.cwd(), ".build-at")) ??
+    null;
+
+export async function GET() {
+    return NextResponse.json({
+        build_id: BUILD_ID,
+        built_at: BUILD_AT,
+        public_flags: {
+            agent_bus_enabled:
+                process.env.NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED === "true",
+            edition: process.env.NEXT_PUBLIC_WWV_EDITION ?? null,
+        },
+    });
+}

--- a/src/components/layout/AgentBusSubscriber.tsx
+++ b/src/components/layout/AgentBusSubscriber.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * Subscribes to the server's agent SSE channel and re-emits actions onto
+ * the client-side `dataBus`, so an external tool posting to
+ * /api/agent/publish lands on the same event surface the rest of the app
+ * already drives off of. Renders nothing — purely a side-effect component,
+ * paired with `DataBusSubscriber`.
+ *
+ * Disabled unless `NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED === "true"` so an
+ * unintended deployment doesn't open a remote-control channel for users
+ * who didn't opt in.
+ */
+
+import { useEffect } from "react";
+import { dataBus } from "@/core/data/DataBus";
+import { pluginManager } from "@/core/plugins/PluginManager";
+
+interface FlyToMessage {
+    action: "fly_to";
+    lat: number;
+    lon: number;
+    alt?: number;
+    heading?: number;
+    distance?: number;
+}
+interface FaceTowardsMessage {
+    action: "face_towards";
+    lat: number;
+    lon: number;
+    alt?: number;
+}
+interface LayerToggleMessage {
+    action: "layer_toggle";
+    pluginId: string;
+    enabled: boolean;
+}
+interface HighlightMessage {
+    action: "highlight_layer";
+    pluginId: string;
+}
+interface SelectEntityMessage {
+    action: "select_entity";
+    pluginId: string;
+    entityId: string;
+}
+interface PingMessage {
+    action: "ping";
+    ts: number;
+}
+type AgentMessage =
+    | FlyToMessage
+    | FaceTowardsMessage
+    | LayerToggleMessage
+    | HighlightMessage
+    | SelectEntityMessage
+    | PingMessage;
+
+function applyAction(msg: AgentMessage): void {
+    switch (msg.action) {
+        case "fly_to":
+            dataBus.emit("cameraGoTo", {
+                lat: msg.lat,
+                lon: msg.lon,
+                alt: msg.alt ?? 0,
+                distance: msg.distance,
+                heading: msg.heading,
+            });
+            return;
+        case "face_towards":
+            dataBus.emit("cameraFaceTowards", {
+                lat: msg.lat,
+                lon: msg.lon,
+                alt: msg.alt ?? 0,
+            });
+            return;
+        case "layer_toggle": {
+            const managed = pluginManager.getPlugin(msg.pluginId);
+            if (!managed) return;
+            if (managed.enabled === msg.enabled) return;
+            pluginManager.togglePlugin(msg.pluginId);
+            return;
+        }
+        case "highlight_layer":
+            dataBus.emit("layerToggled", { pluginId: msg.pluginId, enabled: true });
+            return;
+        case "select_entity": {
+            const entities = pluginManager.getEntities(msg.pluginId);
+            const entity = entities.find((e) => e.id === msg.entityId);
+            if (entity) dataBus.emit("entitySelected", { entity });
+            return;
+        }
+        case "ping":
+            // No-op — useful for an external tool to verify the channel is alive.
+            return;
+    }
+}
+
+export function AgentBusSubscriber() {
+    useEffect(() => {
+        // Log build-id + agent-bus state once on mount. A stale-bundle / config
+        // mismatch becomes visible at a glance in the browser console instead
+        // of looking like a feature regression.
+        const buildId = process.env.NEXT_PUBLIC_WWV_BUILD_ID ?? "dev";
+        const builtAt = process.env.NEXT_PUBLIC_WWV_BUILD_AT ?? "";
+        const agentBusEnabled =
+            process.env.NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED === "true";
+        console.log(
+            `[wwv build] id=${buildId} built_at=${builtAt} agent_bus=${agentBusEnabled ? "on" : "off"}`,
+        );
+
+        if (!agentBusEnabled) return;
+        if (typeof EventSource === "undefined") return;
+
+        const es = new EventSource("/api/agent/stream", { withCredentials: true });
+        es.onmessage = (event) => {
+            try {
+                const msg = JSON.parse(event.data) as AgentMessage;
+                applyAction(msg);
+            } catch (err) {
+                console.warn("[AgentBus] malformed message", err);
+            }
+        };
+        es.onerror = (err) => {
+            // EventSource auto-reconnects on its own with the `retry:` value
+            // we send from the server. Just log; don't tear down.
+            console.debug("[AgentBus] stream error (auto-reconnecting)", err);
+        };
+
+        return () => {
+            es.close();
+        };
+    }, []);
+
+    return null;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { useBootSequence } from "@/core/hooks/useBootSequence";
 import { useIsMobile } from "@/core/hooks/useIsMobile";
 import { useMarketplaceSync } from "@/core/hooks/useMarketplaceSync";
 import { DataBusSubscriber } from "./DataBusSubscriber";
+import { AgentBusSubscriber } from "./AgentBusSubscriber";
 import { MobileHudBar } from "./MobileHudBar";
 import { MobileCameraStats } from "./MobileCameraStats";
 import dynamic from "next/dynamic";
@@ -150,6 +151,7 @@ export function AppShell() {
 
             <TimelineSync />
             <DataBusSubscriber />
+            <AgentBusSubscriber />
 
             <Header />
             {isMobile && <MobileHudBar />}

--- a/src/lib/agent/bus.ts
+++ b/src/lib/agent/bus.ts
@@ -1,0 +1,94 @@
+/**
+ * Server-side AgentBus, scoped per user.
+ *
+ * Holds the set of currently-connected SSE clients keyed by Auth.js user id
+ * and broadcasts agent actions (`fly_to`, `layer_toggle`, etc.) published
+ * via `/api/agent/publish` only to subscribers belonging to the same user
+ * as the publisher. The browser-side subscriber dispatches the received
+ * actions onto the existing `dataBus` so the running React + Cesium app
+ * picks them up the same way it picks up any other UI event.
+ *
+ * Per-user scoping: in a multi-tenant WWV deployment, user A's external
+ * tool publishing to /api/agent/publish must NOT reach user B's open
+ * browser tab. The publish + subscribe routes pass `session.user.id`,
+ * the bus routes deliveries to that user's subscriber set only.
+ *
+ * Process-local in-memory only. Multi-instance deployments would need a
+ * Redis pub/sub adapter; a self-hosted single-process WWV is the primary
+ * target — extending this is straightforward when needed.
+ */
+
+export type AgentAction =
+    | { action: "fly_to"; lat: number; lon: number; alt?: number; heading?: number; distance?: number }
+    | { action: "face_towards"; lat: number; lon: number; alt?: number }
+    | { action: "layer_toggle"; pluginId: string; enabled: boolean }
+    | { action: "highlight_layer"; pluginId: string }
+    | { action: "select_entity"; pluginId: string; entityId: string }
+    | { action: "ping"; ts: number };
+
+interface Subscriber {
+    id: string;
+    write: (chunk: string) => void;
+    close: () => void;
+}
+
+class AgentBus {
+    /** userId → (connId → Subscriber). Empty inner maps are pruned on unsubscribe. */
+    private byUser = new Map<string, Map<string, Subscriber>>();
+
+    subscribe(userId: string, sub: Subscriber): () => void {
+        let bucket = this.byUser.get(userId);
+        if (!bucket) {
+            bucket = new Map();
+            this.byUser.set(userId, bucket);
+        }
+        bucket.set(sub.id, sub);
+        return () => {
+            const b = this.byUser.get(userId);
+            if (!b) return;
+            b.delete(sub.id);
+            if (b.size === 0) this.byUser.delete(userId);
+        };
+    }
+
+    /** Broadcast an action only to subscribers belonging to the publisher's user. */
+    publish(userId: string, message: AgentAction): { delivered: number } {
+        const bucket = this.byUser.get(userId);
+        if (!bucket) return { delivered: 0 };
+        const payload = `data: ${JSON.stringify(message)}\n\n`;
+        let delivered = 0;
+        for (const sub of bucket.values()) {
+            try {
+                sub.write(payload);
+                delivered++;
+            } catch {
+                bucket.delete(sub.id);
+            }
+        }
+        if (bucket.size === 0) this.byUser.delete(userId);
+        return { delivered };
+    }
+
+    /** Count of currently-subscribed connections for a given user. */
+    subscribersFor(userId: string): number {
+        return this.byUser.get(userId)?.size ?? 0;
+    }
+
+    /** Total connections across all users (for diagnostics). */
+    get totalSubscribers(): number {
+        let n = 0;
+        for (const bucket of this.byUser.values()) n += bucket.size;
+        return n;
+    }
+}
+
+// Module-level singleton. Next.js dev mode hot-reloads modules; using a
+// global ensures the SSE state survives editor saves so connected browsers
+// don't drop and reconnect on every code change in development.
+declare global {
+    // eslint-disable-next-line no-var
+    var __WWV_AGENT_BUS__: AgentBus | undefined;
+}
+
+export const agentBus: AgentBus =
+    globalThis.__WWV_AGENT_BUS__ ?? (globalThis.__WWV_AGENT_BUS__ = new AgentBus());


### PR DESCRIPTION
## Summary

Adds an opt-in agent integration surface that lets a trusted external tool — running as the same logged-in user — drive the running WWV browser session. Fly the globe, toggle layers, focus entities, all by POSTing JSON actions to a new `/api/agent/publish` endpoint, which fans them out over SSE on `/api/agent/stream` to every connected browser tab belonging to that user.

The motivating use case is a **Model Context Protocol (MCP) server**: an LLM agent calls a tool like `globe_fly_to({lat, lon})`, the MCP server posts to `/api/agent/publish`, the browser subscriber re-emits onto the existing client-side `dataBus`, and the React + Cesium app handles it the same way it would handle any UI button click. Read-only camera / engine queries already work via the existing REST surface — this PR adds the missing **write path**.

A working reference implementation of an MCP server using these endpoints is published at [szski/wwv-mcp](https://github.com/szski/wwv-mcp) (15 tools: `globe_fly_to`, `layer_toggle`, `geocode`, `system_status`, `plugin_catalog`, `engine_query`, etc.), plug-and-play with Claude Code, Claude Desktop, Cursor, Continue, Cline.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Demo

```
Claude Code → wwv-mcp.globe_fly_to({lat: 35.78, lon: -78.64, distance: 50000})
            → POST /api/agent/publish
            → AgentBus broadcasts to user's SSE subscribers
            → AgentBusSubscriber dispatches dataBus.emit("cameraGoTo", ...)
            → Cesium camera flies to Raleigh
            ← {ok: true, delivered: 1, subscribers: 1}
```

## Changes Made

- **`src/lib/agent/bus.ts`** — process-local AgentBus singleton, scoped per user. Subscriptions live in `Map<userId, Map<connId, sub>>` so user A's publish never reaches user B's stream, even though both run on the same Node process. Multi-tenant safe.

- **`src/app/api/agent/stream/route.ts`** — SSE channel. Auth-gated. Sends initial `:connected` + `retry:3000` directives and a `:hb` heartbeat every 25s so intermediary proxies (Caddy, Nginx, CDNs) don't tear down a "stalled" connection.

- **`src/app/api/agent/publish/route.ts`** — POST endpoint. Accepts JSON `AgentAction` shapes (`fly_to`, `face_towards`, `layer_toggle`, `highlight_layer`, `select_entity`, `ping`), broadcasts only to the publishing user's bus bucket. Returns `{delivered, subscribers}` so the caller knows how many tabs received the command.

- **`src/components/layout/AgentBusSubscriber.tsx`** — browser EventSource client. Re-emits received actions onto `dataBus` (`cameraGoTo`, `cameraFaceTowards`, `layerToggled`, `entitySelected`) — every plugin is already listening on those channels, so **no plugin changes needed**.

- **`AppShell.tsx`** — mounts `AgentBusSubscriber` next to the existing `DataBusSubscriber`. Two lines.

- **`src/app/api/build/route.ts`** — `/api/build` returns build id + timestamp + public flag state. Pairs with a one-line `console.log` the subscriber prints on mount so a stale-bundle / config-mismatch (e.g., browser holding cached chunks while the server has a new build) is visible at a glance instead of looking like a feature regression.

### Dockerfile changes

- Adds ARG declarations for `NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED`, `NEXT_PUBLIC_WWV_BUILD_ID`, `NEXT_PUBLIC_WWV_BUILD_AT`.
- Stamps the build with millisecond-precision id + ISO timestamp (`/app/.build-id`, `/app/.build-at`); both copied into the runner stage for `/api/build` to read.
- Writes `/app/.env.production.local` from declared ARGs **before** `next build` runs. Docker doesn't reliably promote ARGs into the Node child-process environment for the build command, so `process.env.NEXT_PUBLIC_*` references that previously inlined through Webpack's DefinePlugin sometimes fell back to runtime polyfill access (`tV.env.NEXT_PUBLIC_X`) that resolves to `undefined` in the browser. Writing the env file is the documented Next.js path and behaves identically on every host. Quietly fixes any other `NEXT_PUBLIC_*` ARG that was suffering from this.

## Behavior

| State | What happens |
|---|---|
| `NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED` unset / not "true" | `AgentBusSubscriber` early-returns. No EventSource. No `/api/agent/stream` request. Endpoints exist but nobody's subscribed; publish is a no-op. **Default.** |
| Set to `"true"`, user not logged in | `EventSource` returns 401; subscriber retries via SSE auto-reconnect. |
| Set to `"true"`, user logged in | Tab receives all actions published by any of the user's other authenticated callers (other tabs, MCP server, etc.). |
| Multi-user instance, user A publishes | Only user A's subscribers receive. User B's tabs unaffected. |

## Security posture

- Auth gate on both endpoints uses the same `auth()` helper as the rest of `/api/marketplace/*`.
- Per-user routing prevents cross-user delivery in multi-tenant deployments.
- No tokens, just the existing Auth.js session cookie. An MCP server acts "as the user" by holding the cookie; same trust model as a browser tab.
- Default off via env gate so an unintended deployment doesn't open a remote-control channel.

## Testing

- [x] `pnpm test` — same passing set as `main`.
- [x] Verified end-to-end: with the bus enabled, an MCP server publishing `globe_fly_to({lat: 35.78, lon: -78.64})` flies the open browser globe to Raleigh in <1s. Returns `{delivered: 1, subscribers: 1}`.
- [x] Per-user scoping: a publish from session A's cookie does not reach session B's stream (verified by simulating two sessions with different `session.user.id`).
- [x] Bus default-off: with the env var unset, `AgentBusSubscriber` doesn't open a connection and the bundle's dead-code-elimination removes the `EventSource` constructor entirely.
- [x] Build-id stamping: `/api/build` returns the same `build_id` that the client logs to console; cache-mismatch debugging works as designed.
- [x] Dockerfile env fix: `NEXT_PUBLIC_*` ARGs reliably inline into the bundle now (verified by inspecting `/app/.next/static/chunks/app/page-*.js` for literal values rather than `tV.env.X` polyfill access).

## Notes for Reviewer

- I left the action union conservative (6 verbs) so review is easy. Easy to extend — add a member to the `AgentAction` type, add a `case` in `applyAction`. The shape is `{action: string, ...payload}` JSON, so backwards-compatible additions are a non-event.
- `agentBus` is process-local. A multi-instance deployment (multiple Next.js servers behind a load balancer) would need a Redis pub/sub adapter. For self-hosted single-process WWV — the primary target — this is fine. The interface is small enough that a Redis adapter is ~30 lines if you ever need it.
- The Dockerfile env-inlining fix is technically a separable bug fix worth its own PR (it affects every `NEXT_PUBLIC_*` ARG, not just the new ones), but it surfaced while debugging this feature so I bundled it. Happy to split if you'd prefer.