### PR TITLE
ci(docker-publish): skip GHCR push on fork PRs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,8 +48,16 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          # Push to GHCR only when the workflow has write access to the
+          # registry: any push event, workflow_dispatch, or PRs whose head
+          # branch lives in this repo (not a fork). Fork PRs still build —
+          # so the Dockerfile is exercised and the image is verified — but
+          # skip the push step that would 403 with
+          # "denied: installation not allowed to Write organization package".
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # GHA cache writes also require write permission, so gate it on
+          # the same condition. (Reads are fine for everyone.)
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=gha,mode=max' || '' }}


### PR DESCRIPTION
## Summary

Every fork PR's `build-and-push` job currently fails with:

```
ERROR: failed to push ghcr.io/silvertakana/worldwideview:pr-NN:
denied: installation not allowed to Write organization package
```

The job's other concerns (verifying the Dockerfile compiles, exercising build-time `NEXT_PUBLIC_*` arg plumbing, surfacing build failures) don't require a push to do their job. Gate just the push step on whether the workflow has write access to the registry.

This affects every external contributor's PR — not just any specific one. PRs #61, #63, #64, #79 are visible examples (more in the queue if other fork contributors have opened any).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Changes Made

`.github/workflows/docker-publish.yml`:

- `push:` becomes conditional. True for: push events (main / `feat/docker-ci`), `workflow_dispatch`, PRs whose head branch lives in this repo. False for fork PRs.
- `cache-to:` gated on the same expression. GHA cache writes have the same permission profile as the registry push, so they 403 from fork PRs the same way; cache reads remain available to fork builds (so they still benefit from your warm cache and stay fast).

The boolean expression:

```yaml
github.event_name != 'pull_request' ||
github.event.pull_request.head.repo.full_name == github.repository
```

Standard pattern from the GitHub Docker Action docs for this exact case.

## Behavior matrix

| Trigger | Before | After |
|---|---|---|
| `push` to `main` / `feat/docker-ci` | build + push | build + push |
| `workflow_dispatch` | build + push | build + push |
| PR from a branch in this repo | build + push | build + push |
| PR from a fork | build + ❌ push (CI red) | build only ✅ |

## Testing

- [x] Confirmed the expression is the same boolean GitHub's own docs recommend for this scenario.
- [x] Verified locally that `cache-to: ''` is a valid no-op for `docker/build-push-action@v5` (it accepts empty string and skips the cache export).
- [ ] Once merged, fork-PR runs should turn green for the build-and-push job. Happy to retrigger #79's CI to confirm if you'd like.

## Notes for Reviewer

- This is a CI policy change only — no source / Dockerfile changes. Zero impact on the resulting image when push happens.
- The `cache-from: type=gha` line is left as-is; cache reads work for everyone, so fork builds still pull warm layers.
- If you'd prefer pushing under a different tag or registry for fork PRs (e.g., a public read-only review-image registry), that's a follow-up. This PR just unblocks the existing flow.