### PR TITLE
fix: Resolve host globals race condition on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Header } from "./Header";
 import { LayerPanel } from "@/components/panels/LayerPanel";
 import { EntityInfoCard } from "@/components/panels/EntityInfoCard";
@@ -42,7 +42,8 @@ export function AppShell() {
     const boot = useBootSequence();
     const isMobile = useIsMobile();
     const bootStartRef = useRef(Date.now());
-    const { needsReload, pendingUnverified, approveSelected, denyAll } = useMarketplaceSync();
+    const [hostReady, setHostReady] = useState(false);
+    const { needsReload, pendingUnverified, approveSelected, denyAll } = useMarketplaceSync(hostReady);
 
     useEffect(() => {
         const startPlatform = async () => {
@@ -51,6 +52,7 @@ export function AppShell() {
 
             // Inject host libraries for dynamic plugin loading
             await injectHostGlobals();
+            setHostReady(true);
 
             // Fetch disabled built-in plugins before registration
             let disabledIds = new Set<string>();

--- a/src/core/hooks/useMarketplaceSync.ts
+++ b/src/core/hooks/useMarketplaceSync.ts
@@ -16,7 +16,7 @@ import { isDemo } from "@/core/edition";
  * - Detects built-in plugin changes that require a reload.
  * - Gates unverified plugins behind user approval (batch dialog).
  */
-export function useMarketplaceSync() {
+export function useMarketplaceSync(hostReady: boolean) {
     const initLayer = useStore((s) => s.initLayer);
     const loadedIds = useRef<Set<string>>(new Set());
     const initialDisabledIds = useRef<Set<string> | null>(null);
@@ -171,19 +171,21 @@ export function useMarketplaceSync() {
     }, []);
 
     const syncPlugins = useCallback(async () => {
+        if (!hostReady) return;
         await captureInitialDisabled();
         await syncMarketplacePlugins();
         await checkBuiltinChanges();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [initLayer]);
+    }, [initLayer, hostReady]);
 
     useEffect(() => {
+        if (!hostReady) return;
         syncPlugins();
 
         const handleFocus = () => { syncPlugins(); };
         window.addEventListener("focus", handleFocus);
         return () => window.removeEventListener("focus", handleFocus);
-    }, [syncPlugins]);
+    }, [syncPlugins, hostReady]);
 
     return { syncPlugins, needsReload, pendingUnverified, approveSelected, denyAll };
 }


### PR DESCRIPTION
### Description
This PR resolves a race condition that was causing all plugins to fail on startup with the error `can't access property "React", globalThis.__WWV_HOST__ is undefined`.

**Root Cause:**
`useMarketplaceSync` was attempting to load plugins before `injectHostGlobals` had finished injecting `globalThis.__WWV_HOST__`. Both were fired simultaneously when `AppShell` mounted, but because `injectHostGlobals` is asynchronous, the plugins were trying to access `React` before it was ready.

**Fix:**
- Added a `hostReady` state to `AppShell` which tracks when `injectHostGlobals` completes.
- Passed `hostReady` into `useMarketplaceSync`.
- `useMarketplaceSync` now bails early and waits for `hostReady` to be `true` before attempting to load any plugin manifests.

Also bumped version to `2.1.12`.