### PR TITLE
fix(api/camera): per-adapter timeout so one slow source can't stall the rest

### DIFF
--- a/src/app/api/camera/adapters/registry.ts
+++ b/src/app/api/camera/adapters/registry.ts
@@ -83,6 +83,15 @@ export function getAdapterMetadata(): CameraAdapterMeta[] {
  * way, the cache entry's `error` field is set so `/api/camera/list` can
  * report unhealthy adapters.
  */
+/**
+ * Per-adapter cold-fetch timeout. If an upstream API hangs, the aggregator
+ * `Promise.allSettled` waits for the slowest one — so a single dead source
+ * holds up every other adapter's data from reaching the client. With this
+ * cap a stuck source becomes a fast error, and the cache fallback path
+ * keeps serving stale data without blocking the response.
+ */
+const ADAPTER_FETCH_TIMEOUT_MS = 4_000;
+
 export async function fetchAdapter(adapter: CameraAdapter): Promise<CameraFeature[]> {
     if (!isKeyAvailable(adapter)) {
         return [];
@@ -90,11 +99,23 @@ export async function fetchAdapter(adapter: CameraAdapter): Promise<CameraFeatur
     const now = Date.now();
     const ttl = adapter.cacheTtlMs ?? DEFAULT_TTL_MS;
     const c = cache.get(adapter.id);
-    if (c && now < c.expiry && !c.error) {
+    // Serve from cache for the retry window even if the last attempt errored —
+    // otherwise every aggregated request re-fires a doomed upstream call and
+    // pays the timeout penalty each time. The error stays on the cache entry
+    // so /api/camera/list can still report the adapter as unhealthy.
+    if (c && now < c.expiry) {
         return c.data;
     }
     try {
-        const data = await adapter.fetch();
+        const data = await Promise.race([
+            adapter.fetch(),
+            new Promise<CameraFeature[]>((_resolve, reject) =>
+                setTimeout(
+                    () => reject(new Error(`Adapter ${adapter.id} timed out after ${ADAPTER_FETCH_TIMEOUT_MS}ms`)),
+                    ADAPTER_FETCH_TIMEOUT_MS,
+                ),
+            ),
+        ]);
         cache.set(adapter.id, {
             data,
             expiry: now + ttl,


### PR DESCRIPTION
## Why

The traffic-camera aggregator uses `Promise.allSettled`, so the request takes as long as the slowest adapter. Running locally with all 7 adapters enabled, ny511 (without a real API key) returns empty after ~5 s, and that 5 s sits in front of every aggregated response — fast adapters serve their cached data in <50 ms but the whole `/api/camera/traffic?sources=all` call waits for the slow one.

## What

- 4 s per-adapter timeout in `fetchAdapter`. A stuck source rejects fast and the others come back at their normal cadence.
- `fetchAdapter`'s cache lookup now serves errored entries inside the retry window (was: re-attempting on every request, paying the timeout penalty each time; cache `error` still surfaces in `/api/camera/list` so unhealthy adapters are visible).

## Concrete latency

All 7 adapters in parallel, on local docker compose:

| step                       | before  | after  |
| -------------------------- | ------- | ------ |
| cold call                  | ~10.1 s | ~4.1 s |
| warm call (within 60 s)    | ~10.1 s | ~50 ms |

The cold-call ceiling matches the per-adapter timeout window (4 s). Warm calls now hit the cache even for the errored adapters and return instantly.

## Test plan

- [ ] `curl http://localhost:3000/api/camera/traffic?sources=caltrans,gdot,tfl,ny511,wsdot` — total response time should be capped by the timeout, not the slowest adapter.
- [ ] `curl http://localhost:3000/api/camera/list` — errored adapters should still be reported as `healthy: false` with a `lastError`.