### PR TITLE
Fix(Plugins) Fix the sync-local-plugins script looking in the wrong location for the index.ts file

### DIFF
--- a/scripts/sync-local-plugins.mjs
+++ b/scripts/sync-local-plugins.mjs
@@ -60,7 +60,7 @@ export function discoverLocalPlugins() {
  * into a single ES module, externalizing shared host dependencies.
  */
 export async function buildPlugin({ dir, manifest, pluginDir }) {
-    const devEntry = manifest.dev_entry || "src/index.ts";
+    const devEntry = manifest.dev_entry || "index.ts";
     let entryFile = path.join(pluginDir, devEntry);
 
     // Fallback: check for .tsx


### PR DESCRIPTION
## Summary

<!-- A short description of what this PR does and why. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue
N/A

## Changes Made

- sync-local-plugins.ts 

## Testing

- [x] I ran `npm test` and all tests pass
- [x] I manually tested this in the browser against a live data source
- [ ] I added or updated tests for my changes

## Plugin Checklist (if applicable)

- [ ] Plugin is registered with `PluginRegistry`
- [ ] Plugin does not import or depend on core rendering logic directly
- [ ] Plugin cleans up Cesium primitives on unmount/disable
- [ ] No hardcoded credentials or API keys committed

## Screenshots / Recordings
N/A

## Notes for Reviewer

N/A
