### PR TITLE
perf(globe): three Cesium hot-path wins

### DIFF
--- a/src/core/globe/AnimationLoop.ts
+++ b/src/core/globe/AnimationLoop.ts
@@ -11,6 +11,13 @@ import {
     applyHighlight,
 } from "./animationHelpers";
 
+declare global {
+    interface Window {
+        /** Animation-loop frame counter. Exposed for external plugin throttling. */
+        _wwvFrameCount?: number;
+    }
+}
+
 const R_WGS84_MIN = 6356752.0;
 const R2 = R_WGS84_MIN * R_WGS84_MIN;
 
@@ -128,7 +135,7 @@ export function createUpdateLoop(
 
         const Dh = Math.sqrt(camDistSqr - R2);
         const frame = frameCount++;
-        (window as any)._wwvFrameCount = frame; // Expose globally for throttling
+        window._wwvFrameCount = frame;
         const isStaticCullFrame = frame % STATIC_HORIZON_INTERVAL === 0;
         const selectedId = state.selectedEntity?.id ?? null;
         const hoveredId = hoveredEntityIdRef.current;

--- a/src/core/globe/AnimationLoop.ts
+++ b/src/core/globe/AnimationLoop.ts
@@ -1,7 +1,7 @@
 import { Cartesian3, Color, Ellipsoid } from "cesium";
 import type { Viewer as CesiumViewer } from "cesium";
 import { useStore } from "@/core/state/store";
-import { createLabel, removeLabel, type AnimatableItem } from "./EntityRenderer";
+import { createLabel, removeLabel, getCollections, type AnimatableItem } from "./EntityRenderer";
 import { tickStackAnimation } from "./stackAnimation";
 import { updateModelTransform } from "./ModelManager";
 import { isAnyStackExpanded, isEntityInExpandedStack, getEntityTargetPosition, isEntityClustered, getStackStateVersion } from "./StackManager";
@@ -114,14 +114,13 @@ export function createUpdateLoop(
         }
 
         const animatables = animatablesRef.current;
-        const labelsCollection = (viewer as any)._wwvLabels;
+        const { labels: labelsCollection, billboards } = getCollections(viewer);
 
         // Always run stack animation tick so that ghost hubs can be cleaned up
         // even if the user toggles all layers off!
-        const billboards = (viewer as any)._wwvBillboards;
         let isAnimatingStack = false;
         if (billboards) {
-            isAnimatingStack = tickStackAnimation(labelsCollection, billboards);
+            isAnimatingStack = tickStackAnimation(labelsCollection ?? null, billboards);
         }
 
         if (animatables.length === 0) {

--- a/src/core/globe/EntityRenderer.test.ts
+++ b/src/core/globe/EntityRenderer.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// jsdom doesn't provide matchMedia; renderSingleEntity uses it for default point size.
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+});
+
+vi.mock('cesium', () => {
+    class FakeCollection {
+        blendOption = 0;
+        add = vi.fn((x: unknown) => x);
+        remove = vi.fn();
+        constructor(_?: unknown) {}
+    }
+    return {
+        PointPrimitiveCollection: FakeCollection,
+        BillboardCollection: FakeCollection,
+        LabelCollection: FakeCollection,
+        PolylineCollection: FakeCollection,
+        Color: { BLACK: { _kind: 'BLACK' }, WHITE: { _kind: 'WHITE' } },
+        Cartesian3: { fromDegrees: vi.fn() },
+        Cartographic: { fromCartesian: vi.fn(() => ({ height: 1000 })) },
+        Ellipsoid: { WGS84: {} },
+        VerticalOrigin: { BOTTOM: 0 },
+        DistanceDisplayCondition: class { constructor(_n: number, _f: number) {} },
+        NearFarScalar: class { constructor(_a: number, _b: number, _c: number, _d: number) {} },
+        HeightReference: { CLAMP_TO_GROUND: 0 },
+    };
+});
+
+vi.mock('./primitiveOps', () => ({
+    updateExistingItem: vi.fn(),
+    createNewItem: vi.fn(),
+    cleanupRemovedEntities: vi.fn(),
+    getDefaultDotIcon: vi.fn(() => 'data:svg,auto-icon'),
+}));
+
+vi.mock('./renderCaches', () => ({
+    scratchPosition: {},
+    getEntityColor: vi.fn(() => ({ _kind: 'color' })),
+    getCachedColor: vi.fn(() => null),
+    markAnimatablesDirty: vi.fn(),
+    getStableAnimatables: vi.fn(() => []),
+}));
+
+vi.mock('./ChunkedProcessor', () => ({
+    globalChunkedProcessor: {
+        cancel: vi.fn(),
+        processChunked: vi.fn(),
+    },
+}));
+
+vi.mock('./StackManager', () => ({
+    rebuildStacks: vi.fn(),
+    calculateGridSizeDegrees: vi.fn(() => 1),
+}));
+
+import { initPrimitiveCollections, getCollections, renderEntities } from './EntityRenderer';
+import * as primitiveOps from './primitiveOps';
+
+function createViewer() {
+    return {
+        scene: {
+            primitives: { add: vi.fn((x: unknown) => x) },
+            requestRender: vi.fn(),
+        },
+        camera: {
+            positionWC: {},
+            positionCartographic: { height: 1000 },
+        },
+        isDestroyed: () => false,
+    };
+}
+
+describe('EntityRenderer — primitive collections (WeakMap roundtrip)', () => {
+    it('returns empty shape before init', () => {
+        const v = createViewer();
+        expect(getCollections(v as never)).toEqual({});
+    });
+
+    it('populates all four collections after init', () => {
+        const v = createViewer();
+        initPrimitiveCollections(v as never);
+        const c = getCollections(v as never);
+        expect(c.points).toBeDefined();
+        expect(c.billboards).toBeDefined();
+        expect(c.labels).toBeDefined();
+        expect(c.polylines).toBeDefined();
+        expect(v.scene.primitives.add).toHaveBeenCalledTimes(4);
+    });
+
+    it('isolates collections per viewer (WeakMap independence)', () => {
+        const a = createViewer();
+        const b = createViewer();
+        initPrimitiveCollections(a as never);
+        expect(getCollections(a as never).points).toBeDefined();
+        expect(getCollections(b as never)).toEqual({});
+    });
+
+    it('does not throw when viewer has no scene', () => {
+        const broken = { scene: null } as never;
+        expect(() => initPrimitiveCollections(broken)).not.toThrow();
+        expect(getCollections(broken)).toEqual({});
+    });
+});
+
+describe('EntityRenderer — defer-clone in renderSingleEntity (P1)', () => {
+    const createNewItem = vi.mocked(primitiveOps.createNewItem);
+
+    beforeEach(() => {
+        createNewItem.mockClear();
+    });
+
+    it('passes options through by reference when iconUrl is already set', () => {
+        const v = createViewer();
+        initPrimitiveCollections(v as never);
+        const options = { iconUrl: 'icon.png', type: 'billboard' };
+        const entity = { id: 'e1', longitude: 0, latitude: 0, altitude: 0, properties: {} };
+
+        renderEntities(v as never, [{ entity: entity as never, options: options as never }], new Map());
+
+        expect(createNewItem).toHaveBeenCalledTimes(1);
+        const passedOptions = createNewItem.mock.calls[0][1];
+        expect(passedOptions).toBe(options); // no clone
+    });
+
+    it('clones options when the auto-SVG branch fires; original is not mutated', () => {
+        const v = createViewer();
+        initPrimitiveCollections(v as never);
+        const options = { color: '#abc' }; // no iconUrl, type !== "model"
+        const entity = { id: 'e2', longitude: 0, latitude: 0, altitude: 0, properties: {} };
+
+        renderEntities(v as never, [{ entity: entity as never, options: options as never }], new Map());
+
+        const passedOptions = createNewItem.mock.calls[0][1] as unknown as Record<string, unknown>;
+        expect(passedOptions).not.toBe(options);
+        expect(passedOptions.iconUrl).toBe('data:svg,auto-icon');
+        expect(passedOptions.iconScale).toBe(1.0);
+        expect(passedOptions._isAutoSVG).toBe(true);
+        expect((options as unknown as Record<string, unknown>).iconUrl).toBeUndefined();
+    });
+
+    it('does not clone for type === "model" entities', () => {
+        const v = createViewer();
+        initPrimitiveCollections(v as never);
+        const options = { type: 'model', modelUrl: 'plane.glb' };
+        const entity = { id: 'e3', longitude: 0, latitude: 0, altitude: 0, properties: {} };
+
+        renderEntities(v as never, [{ entity: entity as never, options: options as never }], new Map());
+
+        const passedOptions = createNewItem.mock.calls[0][1];
+        expect(passedOptions).toBe(options); // no clone
+    });
+});

--- a/src/core/globe/EntityRenderer.ts
+++ b/src/core/globe/EntityRenderer.ts
@@ -109,16 +109,21 @@ function renderSingleEntity(
 ) {
     currentIds.add(entity.id);
     Cartesian3.fromDegrees(entity.longitude, entity.latitude, entity.altitude || 0, Ellipsoid.WGS84, scratchPosition);
-    
-    // Auto-upgrade missing icons to SVG Billboards so pixelOffsets (spiderifier) will work
-    const effectiveOptions = { ...options };
-    const baseColor = getEntityColor(effectiveOptions);
-    if (!effectiveOptions.iconUrl && effectiveOptions.type !== "model") {
+
+    const baseColor = getEntityColor(options);
+
+    // Auto-upgrade missing icons to SVG Billboards so pixelOffsets (spiderifier) will work.
+    // Only clone when the auto-SVG branch actually mutates — otherwise pass `options` through.
+    let effectiveOptions: CesiumEntityOptions = options;
+    if (!options.iconUrl && options.type !== "model") {
         const baseOutlineColor = getCachedColor(options.outlineColor) || Color.BLACK;
         const outWidth = options.outlineWidth || 1;
         const pSize = options.size || (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches ? 12 : 8);
-        effectiveOptions.iconUrl = getDefaultDotIcon(baseColor, baseOutlineColor, outWidth, pSize);
-        effectiveOptions.iconScale = 1.0;
+        effectiveOptions = {
+            ...options,
+            iconUrl: getDefaultDotIcon(baseColor, baseOutlineColor, outWidth, pSize),
+            iconScale: 1.0,
+        };
         (effectiveOptions as any)._isAutoSVG = true;
     }
     

--- a/src/core/globe/EntityRenderer.ts
+++ b/src/core/globe/EntityRenderer.ts
@@ -40,6 +40,15 @@ export interface AnimatableItem {
 /** Global render kickstarter for deeply nested async operations. */
 export let globalRequestRender: () => void = () => { };
 
+export interface PrimitiveCollections {
+    points: PointPrimitiveCollection;
+    billboards: BillboardCollection;
+    labels: LabelCollection;
+    polylines: PolylineCollection;
+}
+
+const collectionsByViewer = new WeakMap<CesiumViewer, PrimitiveCollections>();
+
 /** Initialize primitive collections on the viewer. */
 export function initPrimitiveCollections(viewer: CesiumViewer): void {
     if (!viewer?.scene?.primitives) {
@@ -48,12 +57,19 @@ export function initPrimitiveCollections(viewer: CesiumViewer): void {
     }
     const points = new PointPrimitiveCollection();
     points.blendOption = 2; // TRANSLUCENT
-    (viewer as any)._wwvPoints = viewer.scene.primitives.add(points);
+    viewer.scene.primitives.add(points);
+
     const billboards = new BillboardCollection({ scene: viewer.scene });
     billboards.blendOption = 2; // TRANSLUCENT
-    (viewer as any)._wwvBillboards = viewer.scene.primitives.add(billboards);
-    (viewer as any)._wwvLabels = viewer.scene.primitives.add(new LabelCollection({ scene: viewer.scene }));
-    (viewer as any)._wwvPolylines = viewer.scene.primitives.add(new PolylineCollection());
+    viewer.scene.primitives.add(billboards);
+
+    const labels = new LabelCollection({ scene: viewer.scene });
+    viewer.scene.primitives.add(labels);
+
+    const polylines = new PolylineCollection();
+    viewer.scene.primitives.add(polylines);
+
+    collectionsByViewer.set(viewer, { points, billboards, labels, polylines });
 
     globalRequestRender = () => {
         if (viewer && !viewer.isDestroyed()) {
@@ -62,14 +78,9 @@ export function initPrimitiveCollections(viewer: CesiumViewer): void {
     };
 }
 
-/** Get typed references to the primitive collections. */
-export function getCollections(viewer: CesiumViewer) {
-    return {
-        points: (viewer as any)._wwvPoints as PointPrimitiveCollection,
-        billboards: (viewer as any)._wwvBillboards as BillboardCollection,
-        labels: (viewer as any)._wwvLabels as LabelCollection,
-        polylines: (viewer as any)._wwvPolylines as PolylineCollection,
-    };
+/** Get the primitive collections for a viewer. Returns an empty shape if init hasn't run. */
+export function getCollections(viewer: CesiumViewer): Partial<PrimitiveCollections> {
+    return collectionsByViewer.get(viewer) ?? {};
 }
 
 /** Creates a label primitive for an item (lazy evaluation). */

--- a/src/core/globe/hooks/useEntityRendering.ts
+++ b/src/core/globe/hooks/useEntityRendering.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import type { Viewer as CesiumViewer } from "cesium";
 import { Cartographic, Cartesian3 } from "cesium";
 import type { GeoEntity, CesiumEntityOptions } from "@/core/plugins/PluginTypes";
-import { renderEntities, renderEntitiesChunked, AnimatableItem } from "../EntityRenderer";
+import { renderEntities, renderEntitiesChunked, AnimatableItem, getCollections } from "../EntityRenderer";
 import { createUpdateLoop } from "../AnimationLoop";
 import { rebuildStacks, calculateGridSizeDegrees } from "../StackManager";
 
@@ -146,7 +146,7 @@ export function useEntityRendering(
                 viewer.clock.onTick.removeEventListener(updatePositions);
                 viewer.scene.preUpdate.removeEventListener(handlePreUpdateClustering);
                 // Synchronously flush all labels to prevent stale labels persisting
-                const labels = (viewer as any)?._wwvLabels;
+                const { labels } = getCollections(viewer);
                 if (labels) {
                     for (const item of animatablesMapRef.current.values()) {
                         if (item.labelPrimitive && !item.labelPrimitive.isDestroyed?.()) {


### PR DESCRIPTION
## Summary

Three small, targeted wins in the Cesium rendering hot path — one per commit, each independently revertible. Addresses #95.

### `perf(globe): type window._wwvFrameCount via Window interface extension` (a818e31)

Replaces `(window as any)._wwvFrameCount = frame` with a typed
`declare global { interface Window { _wwvFrameCount?: number } }` and a
plain `window._wwvFrameCount = frame` assignment. The external plugin
contract (a window-published frame counter for throttling) is preserved;
only the `as any` cast is removed.

### `perf(globe): defer effectiveOptions clone to auto-SVG branch` (f0bc25b)

`renderSingleEntity` was cloning `options` for every entity via
`const effectiveOptions = { ...options }`, even when the auto-SVG
fallback below didn't need to mutate it. The clone is now deferred
into the branch that actually mutates, so entities that arrive with
`iconUrl` set (or `type === "model"`) pass `options` through by
reference with zero allocation.

### `perf(globe): replace viewer mutation with WeakMap<Viewer, Collections>` (f23a83e)

Primitive collections (points, billboards, labels, polylines) were
attached directly to the Cesium Viewer instance as `_wwvX` properties
behind `(viewer as any)` casts (~11 sites across three files). Replaced
with a module-level `WeakMap<CesiumViewer, PrimitiveCollections>`:

- `initPrimitiveCollections` writes into the WeakMap
- `getCollections` reads from the WeakMap and returns a destructurable
  shape (existing call patterns unchanged)
- `AnimationLoop` and `useEntityRendering` use `getCollections(viewer)`
  instead of direct `(viewer as any)._wwvX` reads
- Zero `(viewer as any)._wwv*` casts remain
- Collections GC cleanly when the viewer is dropped
- Unblocks future multi-viewer setups (mini-map / side-by-side)

## Type of Change

- [x] Performance improvement
- [x] Refactor / code quality

## Related Issue

Fixes #95

## Changes Made

- `src/core/globe/AnimationLoop.ts` — typed `_wwvFrameCount` (P3); destructure collections from `getCollections(viewer)` (P2); `tickStackAnimation(labelsCollection ?? null, ...)` (`labelsCollection` is now correctly typed as possibly `undefined`)
- `src/core/globe/EntityRenderer.ts` — defer-clone for `effectiveOptions` (P1); `WeakMap<Viewer, PrimitiveCollections>` + new `PrimitiveCollections` interface; `getCollections` returns `Partial<PrimitiveCollections>` (P2)
- `src/core/globe/hooks/useEntityRendering.ts` — `getCollections(viewer).labels` replaces `(viewer as any)?._wwvLabels` (P2)
- `src/core/globe/EntityRenderer.test.ts` — **new** test file, 7 vitest tests covering WeakMap roundtrip + defer-clone behavior

## Testing

- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm test` — **122/122 passing** (was 115; +7 new in `EntityRenderer.test.ts`)
- [x] Dev server smoke test — boots cleanly via Turbopack, `/api/health` → 200, `/` → 302 (expected auth-redirect for `edition=local`)
- [ ] **Browser-side WebGL verification not performed.** The unit tests cover the contract of both refactors (WeakMap roundtrip + defer-clone reference identity / non-mutation of the input). A live globe smoke-test on demo edition is recommended before merge.

## Notes for Reviewer

Each commit is a self-contained patch with its own semver bump (`2.8.0 → 2.8.1 → 2.8.2 → 2.8.3`) so a single win can be reverted without unwinding the others. The new test file uses an inline `vi.mock('cesium', …)` factory — the first cesium-aware test in the repo. If you'd prefer a shared test helper, happy to extract it; I kept it local to avoid scope creep.

The `as any` on `_isAutoSVG` (custom property not in `CesiumEntityOptions`) is unchanged — that one is intentional and out of scope here.