### PR TITLE
ci: trigger on push to main and add dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,29 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
+  # Non-blocking dependency audit. Surfaces high / critical vulnerabilities
+  # in the CI output without failing the build. Flip `continue-on-error` to
+  # `false` once the current transitive vulns (see #97) are resolved.
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --audit-level high
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes the two governance gaps from #97: CI was only running on PRs (direct pushes to `main` bypassed it entirely), and there was no dependency vulnerability scan.

### Trigger change

```yaml
on:
  push:
    branches: [main]   # ← new
  pull_request:
    branches: [main]
```

### New `audit` job

Runs `pnpm audit --audit-level high` and surfaces advisories in the CI run output.

> [!IMPORTANT]
> The audit job is **non-blocking** (`continue-on-error: true`) on first introduction.
>
> Running it locally against the current lockfile yields **2 high + 1 critical** transitive advisories (mostly a `@sentry/webpack-plugin → webpack → schema-utils → ajv → fast-uri` chain — `GHSA-v39h-62p7-jpjc`). Making the job blocking immediately would fail CI on every unrelated PR until those are resolved.
>
> A comment in the workflow points to where to flip the flag (`continue-on-error: false`) once the lockfile is clean — most likely via a `pnpm.overrides` entry pinning the affected transitive, or once `@sentry/webpack-plugin` bumps its dependency tree.

## Type of Change

- [x] CI / governance (no runtime code changes)

## Related Issue

Fixes #97

## Changes Made

- `.github/workflows/ci.yml` — added `push: branches: [main]` trigger; added new `audit` job (runs in parallel with `typecheck` / `test`, non-blocking via `continue-on-error: true`)
- `package.json` — patch version bump (2.8.0 → 2.8.1)

## Testing

- [x] `pnpm audit --audit-level high` runs locally; exits with the expected non-zero code when vulns are present (confirms the gate works once enabled)
- [x] `pnpm test` — all 115 tests still passing
- [ ] Verify against actual CI run on the PR (GitHub Actions UI)

## Notes for Reviewer

- The trigger change has no escape hatch for emergencies — if you sometimes need to bypass CI on a hotfix push to main, we should add a workflow `[skip ci]` convention. I deliberately didn't because the current commit history shows direct pushes to main are common, and silently skipping CI is worse than slow CI.
- The audit job intentionally doesn't include `npx prisma generate` since `pnpm audit` doesn't need it — saves ~10s per run.
- If you'd prefer the audit job to use `--audit-level critical` instead of `high` to soften the eventual hard gate, easy one-line change.