### PR TITLE
test: bedrock tests for the load-bearing data layer + camera registry

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,5 +38,45 @@ Execute the following commands from the root `worldwideview` directory:
   ```
 
 ## Reference
-- **Coverage Scope:** The Vitest configuration primarily targets tests located inside `src/lib/**`, `src/core/**`, and `src/plugins/**`.
+- **Coverage Scope:** The Vitest configuration targets tests located inside `src/lib/**`, `src/core/**`, `src/plugins/**`, `src/app/**`, and `packages/**`.
 - **Environment:** The test environment is configured as `jsdom` via `vite.config.ts` or `vitest.config.ts`, ensuring that DOM-specific API calls function outside of a real browser.
+
+## Patterns
+
+### Plain function — no mocks needed
+Pull in the function, call it with representative inputs, assert the output. See `src/lib/marketplace/cors.test.ts` or `src/app/api/camera/adapters/registry.test.ts` for examples.
+
+### Stateful singleton — reset in `afterEach`
+Most of the data layer (`dataBus`, `cacheLayer`, `pollingManager`) is exported as a singleton instance. Tests pass when run alone but fail when run together if state leaks. `DataBus.test.ts` shows the canonical cleanup:
+
+```typescript
+import { dataBus } from "./DataBus";
+
+afterEach(() => {
+    dataBus.removeAllListeners();
+});
+```
+
+### Module-level dependency — mock with `vi.mock`
+When the module under test pulls in something heavy (the store, the database, Cesium), mock that module before the import. `vi.mock` calls are hoisted, so they take effect even when written below the import in source order. See `src/lib/marketplace/repository.test.ts` (Prisma client) or `src/core/data/PollingManager.test.ts` (Zustand store).
+
+### Timers — fake them per test
+`vi.useFakeTimers()` in `beforeEach`, `vi.useRealTimers()` in `afterEach`. Advance time explicitly with `vi.advanceTimersByTimeAsync(ms)`.
+
+> [!CAUTION]
+> `vi.runOnlyPendingTimersAsync()` ticks `setInterval`s scheduled on the same tick as the call. For tests where a function runs once synchronously and then schedules a recurring interval, this double-counts the first call. To drain microtasks without advancing the clock, use `await Promise.resolve()` a few times — see `PollingManager.test.ts` for the `flushMicrotasks()` helper.
+
+## What NOT to Test (Yet)
+
+- **Cesium-heavy components.** Anything that mounts a `<Viewer>` or renders entities to the globe needs WebGL, which jsdom doesn't provide. These belong in Playwright-style E2E tests rather than unit tests.
+- **Live database round-trips.** Mock the Prisma client at the module boundary — `repository.test.ts` is the reference pattern. Spinning up a real Postgres in CI is expensive and unreliable.
+- **Dynamic-import plugin bundles.** The loader uses `import(/* webpackIgnore: true */ entry)` at runtime against a real URL. Test the loader's pre-import logic with a fake module object, not a real dynamic import.
+
+## Philosophy
+
+A small focused suite is more valuable than a large one that's expensive to maintain. Each test should answer: *what specific regression does this catch that I'd otherwise discover from a user bug report?*
+
+Two practical rules:
+
+1. **Prefer testing pure logic over orchestration.** If a function takes inputs and returns outputs, test it directly. If it coordinates a half-dozen other things (the globe, the store, Cesium primitives), either refactor the pure parts out or use an integration test.
+2. **Add a test when you fix a bug.** A one-line test that fails today and passes after the fix is enough to prevent the bug from coming back. Land the test in the same PR as the fix.

--- a/src/app/api/camera/adapters/registry.test.ts
+++ b/src/app/api/camera/adapters/registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { resolveSources, ALL_ADAPTERS } from "./registry";
+
+/**
+ * `resolveSources` is the input-sanitizer at the top of every
+ * /api/camera/traffic and /api/camera/list call. Wrong behaviour here
+ * either denies legitimate clients or lets the aggregator hit adapters
+ * that aren't registered. Easy to test, high blast radius.
+ */
+
+describe("camera adapter registry — resolveSources", () => {
+    it("returns every registered adapter id when raw is 'all'", () => {
+        const result = resolveSources("all");
+        const expected = ALL_ADAPTERS.map((a) => a.id);
+        expect(result.sort()).toEqual(expected.sort());
+    });
+
+    it("returns every registered adapter id when raw is null (default behaviour)", () => {
+        const result = resolveSources(null);
+        const expected = ALL_ADAPTERS.map((a) => a.id);
+        expect(result.sort()).toEqual(expected.sort());
+    });
+
+    it("returns an empty list when raw is 'none' — clients use this to short-circuit", () => {
+        expect(resolveSources("none")).toEqual([]);
+    });
+
+    it("drops unknown ids from a comma-separated list without erroring", () => {
+        const knownId = ALL_ADAPTERS[0]?.id;
+        if (!knownId) throw new Error("registry has zero adapters — test precondition broken");
+
+        const result = resolveSources(`${knownId},completely-fake-adapter,${knownId}`);
+        expect(result).toContain(knownId);
+        expect(result).not.toContain("completely-fake-adapter");
+    });
+});

--- a/src/core/data/CacheLayer.test.ts
+++ b/src/core/data/CacheLayer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { cacheLayer } from "./CacheLayer";
+import type { GeoEntity } from "@/core/plugins/PluginTypes";
+
+/**
+ * In-memory cache contract. The persistent (IndexedDB) layer needs a
+ * real browser and isn't exercised here — these tests cover only the
+ * Map-backed first tier that every plugin enable/disable cycle hits.
+ *
+ * We `clear()` between tests because cacheLayer is a process-wide
+ * singleton; without it, residual entries from one test would mask
+ * failures in another.
+ */
+
+function entity(id: string): GeoEntity {
+    return {
+        id,
+        pluginId: "test",
+        latitude: 0,
+        longitude: 0,
+        timestamp: new Date(),
+        properties: {},
+    };
+}
+
+beforeEach(() => {
+    cacheLayer.clear();
+    vi.useRealTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("CacheLayer (memory tier)", () => {
+    it("round-trips entities by pluginId within the TTL window", () => {
+        const entities = [entity("a"), entity("b")];
+        cacheLayer.set("aviation", entities, 60_000);
+
+        expect(cacheLayer.get("aviation")).toEqual(entities);
+    });
+
+    it("returns null and evicts the entry once the TTL expires", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+        cacheLayer.set("aviation", [entity("a")], 5_000);
+        expect(cacheLayer.get("aviation")).not.toBeNull();
+
+        vi.advanceTimersByTime(5_001);
+        expect(cacheLayer.get("aviation")).toBeNull();
+
+        // Second get confirms the eviction happened — the entry is gone
+        // from the underlying Map, not just rejected on lookup.
+        expect(cacheLayer.get("aviation")).toBeNull();
+    });
+});

--- a/src/core/data/DataBus.test.ts
+++ b/src/core/data/DataBus.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { dataBus } from "./DataBus";
+
+/**
+ * DataBus is a typed singleton event bus used by every plugin and most
+ * of the UI for cross-component communication. A regression here would
+ * be silent and immediate — events stop arriving, layers go blank, the
+ * agent bus stops responding — so it's worth pinning down the basics.
+ *
+ * Each test removes the listeners it adds in `afterEach` so the
+ * singleton state doesn't leak between tests.
+ */
+
+afterEach(() => {
+    dataBus.removeAllListeners();
+});
+
+describe("DataBus", () => {
+    it("dispatches emit() payloads to subscribers of the matching event", () => {
+        const handler = vi.fn();
+        dataBus.on("dataUpdated", handler);
+
+        dataBus.emit("dataUpdated", { pluginId: "test", entities: [] });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith({ pluginId: "test", entities: [] });
+    });
+
+    it("returns an unsubscribe function from on() that detaches the handler", () => {
+        const handler = vi.fn();
+        const unsubscribe = dataBus.on("dataUpdated", handler);
+
+        unsubscribe();
+        dataBus.emit("dataUpdated", { pluginId: "test", entities: [] });
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("isolates handler failures so one throw doesn't block other subscribers", () => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const throwing = vi.fn(() => {
+            throw new Error("intentional");
+        });
+        const surviving = vi.fn();
+        dataBus.on("layerToggled", throwing);
+        dataBus.on("layerToggled", surviving);
+
+        dataBus.emit("layerToggled", { pluginId: "test", enabled: true });
+
+        expect(throwing).toHaveBeenCalledTimes(1);
+        expect(surviving).toHaveBeenCalledTimes(1);
+        errorSpy.mockRestore();
+    });
+});

--- a/src/core/data/PollingManager.test.ts
+++ b/src/core/data/PollingManager.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// The store import in PollingManager's constructor pulls in Cesium,
+// zustand middleware, and the entire UI state tree. Mock it before the
+// module loads so the polling-manager singleton wakes up against a
+// shape that's safe in jsdom.
+vi.mock("@/core/state/store", () => ({
+    useStore: {
+        getState: () => ({ dataConfig: { pollingIntervals: {} } }),
+        subscribe: () => () => {},
+    },
+}));
+
+import { pollingManager } from "./PollingManager";
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    // Clean up timers and any tasks registered in this test so the next
+    // one starts from a known state. The singleton doesn't expose a
+    // reset method, but `stopAll` + `unregister` covers our cases.
+    pollingManager.stopAll();
+    vi.useRealTimers();
+});
+
+// Helper: drain the microtask queue so the immediate `run()` Promise
+// scheduled inside `start()` resolves before we assert on call counts.
+// We can't use `runAllTimersAsync` here because setInterval is unbounded
+// and `runOnlyPendingTimersAsync` advances the next interval tick too,
+// which would double-count.
+async function flushMicrotasks() {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe("PollingManager", () => {
+    it("runs the callback once immediately when start() is called", async () => {
+        const callback = vi.fn(async () => {});
+        pollingManager.register("test", 60_000, callback);
+
+        pollingManager.start("test");
+        await flushMicrotasks();
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("schedules recurring calls at intervalMs after the initial run", async () => {
+        const callback = vi.fn(async () => {});
+        pollingManager.register("test", 1_000, callback);
+
+        pollingManager.start("test");
+        await flushMicrotasks();
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(callback).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(callback).toHaveBeenCalledTimes(4);
+    });
+
+    it("stops scheduling further calls after stop()", async () => {
+        const callback = vi.fn(async () => {});
+        pollingManager.register("test", 1_000, callback);
+
+        pollingManager.start("test");
+        await flushMicrotasks();
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        pollingManager.stop("test");
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
         alias: {
             '@': path.resolve(__dirname, './src'),
         },
-        include: ['src/lib/**/*.{test,spec}.{js,ts,jsx,tsx}', 'src/core/**/*.{test,spec}.{js,ts,jsx,tsx}', 'src/plugins/**/*.{test,spec}.{js,ts,jsx,tsx}', 'packages/**/*.{test,spec}.{js,ts,jsx,tsx}'],
+        include: [
+            'src/lib/**/*.{test,spec}.{js,ts,jsx,tsx}',
+            'src/core/**/*.{test,spec}.{js,ts,jsx,tsx}',
+            'src/plugins/**/*.{test,spec}.{js,ts,jsx,tsx}',
+            'src/app/**/*.{test,spec}.{js,ts,jsx,tsx}',
+            'packages/**/*.{test,spec}.{js,ts,jsx,tsx}',
+        ],
     },
 });


### PR DESCRIPTION
## Why

Vitest is wired up and CI already runs \`pnpm test\` on every PR, but none of the *load-bearing* systems have coverage. The plugin lifecycle (data bus, cache, polling) and the camera adapter aggregator are touched by every layer toggle — they're exactly where silent breakage hurts most.

This PR is a focused first batch: 12 tests across 4 files plus a doc update on patterns. Intentionally small. The shape matters more than the volume — once these are in, future tests have a template to copy and a CLAUDE.md-readable doc explaining the conventions.

## What's tested

| File | Coverage | Tests |
|------|----------|-------|
| \`src/core/data/DataBus.test.ts\` | emit/subscribe, unsubscribe correctness, handler-failure isolation | 3 |
| \`src/core/data/CacheLayer.test.ts\` | memory-tier set/get, TTL expiry + eviction | 2 |
| \`src/core/data/PollingManager.test.ts\` | immediate-run on start(), interval scheduling, stop() cancels | 3 |
| \`src/app/api/camera/adapters/registry.test.ts\` | resolveSources for \"all\" / null / \"none\" / mixed-with-unknowns | 4 |

Each test answers one question: *what regression does it catch that I'd otherwise discover from a user bug report?*

## Config change

\`vitest.config.ts\` now includes \`src/app/**/*.{test,spec}.*\` so API-route handlers can have tests. Previously only \`src/lib\`, \`src/core\`, \`src/plugins\`, and \`packages\` were scanned.

## Docs

\`docs/testing.md\` gets four new sections appended (existing overview/test-types/run-commands unchanged):

- **Patterns** — plain-function, stateful-singleton-with-cleanup, mock-with-vi.mock, fake-timers. Includes a callout for the \`runOnlyPendingTimersAsync\` double-counting gotcha I hit writing the PollingManager tests.
- **What NOT to Test (Yet)** — Cesium-heavy components, live DB round-trips, dynamic plugin imports.
- **Philosophy** — small focused suite > large expensive one; test pure logic; add a test when you fix a bug.

## Verification

Local run, Node 22 + pnpm 9.15.4:

\`\`\`
Test Files  17 passed (17)
Tests       127 passed (127)
\`\`\`

All 115 existing tests still pass; new 12 land cleanly.

## What's NOT in this PR

The list of load-bearing systems still without coverage, in priority order for follow-up:

- \`PluginManager\` (central plugin lifecycle orchestrator)
- The new plugin-backend supervisor + proxy from #100
- The agent bus from #79
- Plugin marketplace install/uninstall round-trip
- React component tests for LayerPanel and DataBusSubscriber

Worth a follow-up batch once these patterns are familiar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)