### PR TITLE
test(round 2): PluginManager, PluginRegistry, engineManifest backbone

### DIFF
--- a/src/core/data/engineManifest.test.ts
+++ b/src/core/data/engineManifest.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+    fetchLocalEngineManifest,
+    localEngineHasPlugin,
+    resetManifestCache,
+} from "./engineManifest";
+
+/**
+ * Local-engine detection drives the resolveEngineUrl split-routing
+ * decision: if the local engine has a seeder for plugin X, traffic
+ * goes to localhost; otherwise it falls back to the cloud. Cache the
+ * detection result — the timeout penalty on every plugin toggle is
+ * what `manifestFetched` exists to avoid.
+ *
+ * `resetManifestCache()` is exposed specifically for tests; use it in
+ * `beforeEach` so each test starts from a known unfetched state.
+ */
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+    resetManifestCache();
+    originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+describe("engineManifest", () => {
+    it("returns false from localEngineHasPlugin when nothing has been fetched yet", () => {
+        expect(localEngineHasPlugin("aviation")).toBe(false);
+    });
+
+    it("populates the cache and reports plugin presence after a successful fetch", async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ plugins: ["aviation", "cyber_attacks"] }),
+        } as unknown as Response);
+
+        const result = await fetchLocalEngineManifest();
+
+        expect(result).toEqual(["aviation", "cyber_attacks"]);
+        expect(localEngineHasPlugin("aviation")).toBe(true);
+        expect(localEngineHasPlugin("unknown")).toBe(false);
+    });
+
+    it("returns null on fetch failure and stops re-attempting (caches the negative)", async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+        globalThis.fetch = fetchMock;
+
+        const first = await fetchLocalEngineManifest();
+        const second = await fetchLocalEngineManifest();
+
+        expect(first).toBeNull();
+        expect(second).toBeNull();
+        // Critical: the second call must not re-hit the network. The 500ms
+        // timeout per toggle would compound otherwise.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/core/plugins/PluginManager.test.ts
+++ b/src/core/plugins/PluginManager.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * PluginManager is the orchestrator everything else routes through —
+ * register, enable, disable, fetch coordination, cache and bus updates.
+ * Bugs here have wide blast radius: pins disappear, layers never load,
+ * the agent bus stops driving the UI.
+ *
+ * We let the real `dataBus`, `cacheLayer`, and `pollingManager` through
+ * (they're covered by their own unit tests) so these tests verify the
+ * interaction between PluginManager and the rest of the data layer.
+ * Mock only the things that aren't load-bearing for the assertions:
+ * the Zustand store, analytics, engine-URL resolution, and the local
+ * engine manifest fetcher.
+ */
+
+vi.mock("@/core/state/store", () => ({
+    useStore: {
+        getState: () => ({
+            setLayerLoading: () => {},
+            dataConfig: { pluginSettings: {}, pollingIntervals: {} },
+            isPlaybackMode: false,
+            currentTime: new Date(),
+            showErrorToast: undefined,
+        }),
+        subscribe: () => () => {},
+    },
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: () => {} }));
+vi.mock("@/core/data/resolveEngineUrl", () => ({
+    resolveEngineUrl: () => "wss://test.example/stream",
+}));
+vi.mock("@/core/data/engineManifest", () => ({
+    fetchLocalEngineManifest: async () => null,
+}));
+
+import { pluginManager } from "./PluginManager";
+import { dataBus } from "@/core/data/DataBus";
+import { cacheLayer } from "@/core/data/CacheLayer";
+import type { WorldPlugin } from "@/core/plugins/PluginTypes";
+
+function makePlugin(overrides: Partial<WorldPlugin> = {}): WorldPlugin {
+    return {
+        id: "test-plugin",
+        name: "Test Plugin",
+        description: "for tests",
+        icon: "Box",
+        category: "custom",
+        version: "1.0.0",
+        initialize: async () => {},
+        destroy: () => {},
+        fetch: async () => [],
+        getPollingInterval: () => 0,
+        getLayerConfig: () => ({
+            color: "#fff",
+            clusterEnabled: false,
+            clusterDistance: 50,
+        }),
+        renderEntity: () => ({ type: "point" }),
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    cacheLayer.clear();
+});
+
+afterEach(() => {
+    // PluginManager doesn't expose a registry-clear; destroy() runs the
+    // teardown the AppShell uses at unmount.
+    pluginManager.destroy();
+    dataBus.removeAllListeners();
+});
+
+describe("PluginManager.registerPlugin", () => {
+    it("stores the plugin and emits pluginRegistered with the default interval", async () => {
+        const handler = vi.fn();
+        dataBus.on("pluginRegistered", handler);
+        const plugin = makePlugin({ id: "reg-1", getPollingInterval: () => 30_000 });
+
+        await pluginManager.registerPlugin(plugin);
+
+        expect(pluginManager.getPlugin("reg-1")).toBeDefined();
+        expect(handler).toHaveBeenCalledWith({
+            pluginId: "reg-1",
+            defaultInterval: 30_000,
+        });
+    });
+
+    it("ignores a second registerPlugin with the same id and warns", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        await pluginManager.registerPlugin(makePlugin({ id: "dup", name: "first" }));
+        await pluginManager.registerPlugin(makePlugin({ id: "dup", name: "second" }));
+
+        expect(pluginManager.getPlugin("dup")?.plugin.name).toBe("first");
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+});
+
+describe("PluginManager.enablePlugin", () => {
+    it("flips enabled=true and emits layerToggled(true)", async () => {
+        const layerHandler = vi.fn();
+        dataBus.on("layerToggled", layerHandler);
+        await pluginManager.registerPlugin(makePlugin({ id: "en-1" }));
+
+        await pluginManager.enablePlugin("en-1");
+
+        expect(pluginManager.getPlugin("en-1")?.enabled).toBe(true);
+        expect(layerHandler).toHaveBeenCalledWith({ pluginId: "en-1", enabled: true });
+    });
+
+    it("emits a fresh dataUpdated from cache before kicking off polling", async () => {
+        const dataHandler = vi.fn();
+        const cachedEntities = [
+            {
+                id: "e1",
+                pluginId: "en-2",
+                latitude: 0,
+                longitude: 0,
+                timestamp: new Date(),
+                properties: {},
+            },
+        ];
+        cacheLayer.set("en-2", cachedEntities, 60_000);
+        await pluginManager.registerPlugin(makePlugin({ id: "en-2" }));
+        dataBus.on("dataUpdated", dataHandler);
+
+        await pluginManager.enablePlugin("en-2");
+
+        expect(dataHandler).toHaveBeenCalledWith({
+            pluginId: "en-2",
+            entities: cachedEntities,
+        });
+    });
+});
+
+describe("PluginManager.disablePlugin", () => {
+    it("clears entities and emits layerToggled(false) + dataUpdated([])", async () => {
+        const layerHandler = vi.fn();
+        const dataHandler = vi.fn();
+        await pluginManager.registerPlugin(makePlugin({ id: "dis-1" }));
+        await pluginManager.enablePlugin("dis-1");
+
+        dataBus.on("layerToggled", layerHandler);
+        dataBus.on("dataUpdated", dataHandler);
+        pluginManager.disablePlugin("dis-1");
+
+        expect(pluginManager.getPlugin("dis-1")?.enabled).toBe(false);
+        expect(pluginManager.getEntities("dis-1")).toEqual([]);
+        expect(layerHandler).toHaveBeenCalledWith({ pluginId: "dis-1", enabled: false });
+        expect(dataHandler).toHaveBeenCalledWith({ pluginId: "dis-1", entities: [] });
+    });
+});
+

--- a/src/core/plugins/PluginRegistry.test.ts
+++ b/src/core/plugins/PluginRegistry.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { pluginRegistry } from "./PluginRegistry";
+import type { WorldPlugin } from "@/core/plugins/PluginTypes";
+
+/**
+ * PluginRegistry is the static-side companion to PluginManager: built-in
+ * plugins register here at startup, then PluginManager copies them in.
+ * Same-id duplicates have to be ignored quietly (warned, not thrown) so
+ * the boot path doesn't crash on a re-import during dev hot-reload.
+ */
+
+function makePlugin(overrides: Partial<WorldPlugin> = {}): WorldPlugin {
+    return {
+        id: "test-plugin",
+        name: "Test Plugin",
+        description: "for tests",
+        icon: "Box",
+        category: "custom",
+        version: "1.0.0",
+        initialize: async () => {},
+        destroy: () => {},
+        fetch: async () => [],
+        getPollingInterval: () => 60_000,
+        getLayerConfig: () => ({
+            color: "#fff",
+            clusterEnabled: false,
+            clusterDistance: 50,
+        }),
+        renderEntity: () => ({ type: "point" }),
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    for (const p of pluginRegistry.getAll()) pluginRegistry.unregister(p.id);
+});
+
+describe("PluginRegistry", () => {
+    it("ignores a second register() with the same id and warns rather than throwing", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const first = makePlugin({ id: "dup", name: "first" });
+        const second = makePlugin({ id: "dup", name: "second" });
+
+        pluginRegistry.register(first);
+        pluginRegistry.register(second);
+
+        expect(pluginRegistry.get("dup")).toBe(first);
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    it("filters by category via getByCategory()", () => {
+        pluginRegistry.register(makePlugin({ id: "a", category: "aviation" }));
+        pluginRegistry.register(makePlugin({ id: "b", category: "custom" }));
+        pluginRegistry.register(makePlugin({ id: "c", category: "aviation" }));
+
+        const aviation = pluginRegistry.getByCategory("aviation").map((p) => p.id).sort();
+        expect(aviation).toEqual(["a", "c"]);
+    });
+});


### PR DESCRIPTION
## Why

Follow-up to #110: small, focused tests against the load-bearing backbone that currently has zero unit coverage. Same shape and patterns. Strictly upstream-only.

Each test answers one question: *what specific regression does it catch that I'd otherwise discover from a user bug report?*

## What's covered

| File | Coverage | Tests |
|------|----------|-------|
| \`src/core/plugins/PluginRegistry.test.ts\` | duplicate-id idempotency (warns rather than overwrites), getByCategory filter | 2 |
| \`src/core/data/engineManifest.test.ts\` | initial empty state, populate on successful fetch, fetch failure caches the negative result so the 500ms timeout doesn't compound on every plugin toggle | 3 |
| \`src/core/plugins/PluginManager.test.ts\` | registerPlugin emits pluginRegistered; duplicate is ignored with warn; enablePlugin flips state + emits layerToggled(true); enablePlugin emits dataUpdated from cache when populated; disablePlugin clears entities + emits both events | 5 |

PluginManager is the centerpiece. Bugs we've hit during recent plugin work (the aviation cache-wipe, the layer-toggle store sync) all traced back to behaviour now pinned by these tests.

## Mock strategy

PluginManager has many imports. The tests **let real \`dataBus\`, \`cacheLayer\`, and \`pollingManager\` through** — those are covered by their own tests in #110, and the interaction with them is exactly what these tests verify. Only the Zustand store, analytics, engine-URL resolver, and local-engine manifest fetcher are mocked. None of those are load-bearing for these assertions and they otherwise pull in Cesium or framework setup.

\`engineManifest\` exposes a \`resetManifestCache()\` helper specifically for tests — used in \`beforeEach\` so each test starts from a known unfetched state. \`cacheLayer.clear()\`, \`pluginManager.destroy()\`, and \`dataBus.removeAllListeners()\` handle singleton-state isolation.

## Tests intentionally dropped after review

An earlier revision had 13 tests. Three were dropped after a self-audit because they tested standard-library behaviour rather than load-bearing contracts:

- \`PluginRegistry\`: \"stores plugin under id, exposes via get/has\" — testing \`Map.set\`/\`Map.get\`
- \`PluginRegistry\`: \"removes via unregister()\" — testing \`Map.delete\`
- \`PluginManager\`: \"getEnabledPlugins filters correctly\" — testing \`.filter(p => p.enabled)\`

The remaining \`PluginRegistry\` tests already exercise register/unregister indirectly, so coverage of that surface area didn't actually drop — the audit cut count, not breadth. Calibration note for future test PRs: aim for tests that fail differently for two different broken implementations; skip tests that pass on \"the standard library still works.\"

## Verification

Local run, Node 22 + pnpm 9.15.4, \`--frozen-lockfile\`:

\`\`\`
Test Files  20 passed (20)
Tests       137 passed (137)
\`\`\`

127 before this PR, +10 from it, no regressions.

## What's NOT in this PR

Held back deliberately because they depend on unmerged PRs:

- **Plugin-backend supervisor + proxy tests** — belong in #100.
- **Camera adapter timeout + cache-on-error tests** — belong in #99.
- **Agent bus action dispatch tests** — belong in #79.

Independent next-batch priorities for a future round:

- WsClient connection-pool lifecycle (grace-period close, reconnect on lost socket)
- Marketplace load route (auth gating, DB + local-plugins merge)
- resolveEngineUrl priority chain (local engine → plugin config → env → cloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)