### PR TITLE
chore: enforce vitest coverage thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,5 +17,12 @@ export default defineConfig({
             'src/app/**/*.{test,spec}.{js,ts,jsx,tsx}',
             'packages/**/*.{test,spec}.{js,ts,jsx,tsx}',
         ],
+        coverage: {
+            thresholds: {
+                branches: 80,
+                functions: 80,
+                statements: 80,
+            }
+        }
     },
 });


### PR DESCRIPTION
Enforces strict Vitest coverage thresholds (80% minimum for branches, functions, statements). This will fail the GitHub Action if any PR causes coverage to drop below this limit.