### PR TITLE
test: round 3 — consolidated test bedrock + stryker setup (supersedes #113, #114, #117, #118)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,53 @@
+name: Mutation Testing
+
+# Mutation testing is expensive (10–30 min per full run, even with
+# `coverageAnalysis: "perTest"`), so we don't gate every PR on it.
+# Instead it runs weekly so we catch drift in test quality, and on
+# demand via workflow_dispatch when someone wants to validate a
+# specific change.
+on:
+  schedule:
+    # 03:00 UTC Monday = 10 PM US Eastern Sunday night.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for Stryker's incremental mode.
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm exec prisma generate
+
+      - name: Run Stryker
+        run: pnpm exec stryker run
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stryker-report
+          path: reports/mutation/
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "test": "vitest run",
+    "test:mutate": "stryker run",
     "lint": "eslint .",
     "db:reset": "npx prisma migrate reset --force",
     "generate": "prisma generate"
@@ -55,6 +56,8 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/vitest-runner": "^9.6.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^3.0.0",
@@ -69,6 +72,7 @@
     "copy-webpack-plugin": "^14.0.0",
     "eslint": "^9",
     "eslint-config-next": "^16.2.6",
+    "fast-check": "^4.8.0",
     "jsdom": "^28.1.0",
     "rollup-plugin-external-globals": "^0.13.0",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,12 @@ importers:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@stryker-mutator/core':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/node@25.7.0)
+      '@stryker-mutator/vitest-runner':
+        specifier: ^9.6.1
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.7.0))(vitest@4.1.6)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -144,6 +150,9 @@ importers:
       eslint-config-next:
         specifier: ^16.2.6
         version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
@@ -162,248 +171,6 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-
-  local-plugins/wwv-plugin-air-defense:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.19
-      '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.14
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  local-plugins/wwv-plugin-airports:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-
-  local-plugins/wwv-plugin-aviation:
-    dependencies:
-      '@worldwideview/wwv-lib-aviation':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-aviation
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.14.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-borders:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-
-  local-plugins/wwv-plugin-camera:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.14.0(react@19.2.6)
-      react:
-        specifier: '>=18'
-        version: 19.2.6
-
-  local-plugins/wwv-plugin-civil-unrest:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      cesium:
-        specifier: ^1.139.0
-        version: 1.141.0
-      lucide-react:
-        specifier: ^0.477.0
-        version: 0.477.0(react@19.2.6)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.6
-      resium:
-        specifier: 1.19.4
-        version: 1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)
-
-  local-plugins/wwv-plugin-conflict-events:
-    dependencies:
-      '@worldwideview/wwv-lib-incidents':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-incidents
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      cesium:
-        specifier: ^1.139.0
-        version: 1.141.0
-      lucide-react:
-        specifier: ^0.477.0
-        version: 0.477.0(react@19.2.6)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.6
-      resium:
-        specifier: 1.19.4
-        version: 1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)
-
-  local-plugins/wwv-plugin-cyber-attacks:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.14.0(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)
-
-  local-plugins/wwv-plugin-earthquakes:
-    dependencies:
-      '@worldwideview/wwv-lib-incidents':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-incidents
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.14.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-fortiguard:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  local-plugins/wwv-plugin-gps-jamming:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      cesium:
-        specifier: ^1.139.0
-        version: 1.141.0
-      h3-js:
-        specifier: ^4.4.0
-        version: 4.4.0
-      lucide-react:
-        specifier: ^0.477.0
-        version: 0.477.0(react@19.2.6)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.6
-      resium:
-        specifier: 1.19.4
-        version: 1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)
-
-  local-plugins/wwv-plugin-international-sanctions:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.14.0(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)
-
-  local-plugins/wwv-plugin-iranwarlive:
-    dependencies:
-      '@worldwideview/wwv-lib-incidents':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-incidents
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-maritime:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.14.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-military-aviation:
-    dependencies:
-      '@worldwideview/wwv-lib-aviation':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-aviation
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.14.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-nz-traffic-cameras:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@types/node':
-        specifier: ^20.0.0
-        version: 20.19.41
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-      vitest:
-        specifier: ^1.0.0
-        version: 1.6.1(@types/node@20.19.41)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.47.1)
-
-  local-plugins/wwv-plugin-wildfire:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.14.0(react@19.2.6)
 
   packages/wwv-cli:
     dependencies:
@@ -518,12 +285,26 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.29.3':
+    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -536,8 +317,22 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-plugin-utils@7.28.6':
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -566,6 +361,48 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-proposal-decorators@7.29.0':
+    resolution: {integrity: sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.28.6':
+    resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-destructuring@7.28.5':
+    resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-explicit-resource-management@7.28.6':
+    resolution: {integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -574,6 +411,18 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -672,34 +521,16 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.4':
@@ -708,34 +539,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.4':
@@ -744,22 +557,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -768,22 +569,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.4':
@@ -792,22 +581,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.4':
@@ -816,22 +593,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -840,34 +605,16 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.4':
@@ -882,12 +629,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.27.4':
     resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
@@ -898,12 +639,6 @@ packages:
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -918,23 +653,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.27.4':
     resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
@@ -942,22 +665,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.4':
@@ -1181,9 +892,139 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@jest/schemas@29.6.3':
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.5':
+    resolution: {integrity: sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.13':
+    resolution: {integrity: sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.10':
+    resolution: {integrity: sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.1.2':
+    resolution: {integrity: sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.14':
+    resolution: {integrity: sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.0':
+    resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.13':
+    resolution: {integrity: sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.13':
+    resolution: {integrity: sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.13':
+    resolution: {integrity: sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.4.3':
+    resolution: {integrity: sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.9':
+    resolution: {integrity: sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.9':
+    resolution: {integrity: sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.5':
+    resolution: {integrity: sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1730,9 +1571,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rolldown/pluginutils@1.0.0-rc.7':
-    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
-
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -1879,6 +1717,9 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sentry-internal/browser-utils@10.52.0':
     resolution: {integrity: sha512-x/yEPZdpH6NGQeoeQnV9tj8reAH8twNttiltGZl2o8Rk7sQeUfe7E8yuYP2XbJ2RqyZK5qRS3COrNyMPzf6KFA==}
     engines: {node: '>=18'}
@@ -2022,8 +1863,9 @@ packages:
     peerDependencies:
       webpack: '>=5.0.0'
 
-  '@sinclair/typebox@0.27.10':
-    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@spz-loader/core@0.3.0':
     resolution: {integrity: sha512-sbStwMHb/MIE29st7rRuMYWqhX1UmLSFzdpyGtUZUXLkFNIuYKblzjQdtiet8bau8sUf21uL1DQ451zuySGmcA==}
@@ -2031,6 +1873,29 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stryker-mutator/api@9.6.1':
+    resolution: {integrity: sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==}
+    engines: {node: '>=20.0.0'}
+
+  '@stryker-mutator/core@9.6.1':
+    resolution: {integrity: sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@stryker-mutator/instrumenter@9.6.1':
+    resolution: {integrity: sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@stryker-mutator/util@9.6.1':
+    resolution: {integrity: sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==}
+
+  '@stryker-mutator/vitest-runner@9.6.1':
+    resolution: {integrity: sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==}
+    engines: {node: '>=14.18.0'}
+    peerDependencies:
+      '@stryker-mutator/core': 9.6.1
+      vitest: '>=2.0.0'
 
   '@supabase/auth-js@2.105.4':
     resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
@@ -2204,9 +2069,6 @@ packages:
 
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
-
-  '@types/node@22.19.19':
-    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/node@25.7.0':
     resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
@@ -2429,19 +2291,6 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitejs/plugin-react@6.0.1':
-    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
-      babel-plugin-react-compiler: ^1.0.0
-      vite: ^8.0.0
-    peerDependenciesMeta:
-      '@rolldown/plugin-babel':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
-
   '@vitest/coverage-v8@4.1.6':
     resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
     peerDependencies:
@@ -2450,9 +2299,6 @@ packages:
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
-
-  '@vitest/expect@1.6.1':
-    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
@@ -2471,26 +2317,14 @@ packages:
   '@vitest/pretty-format@4.1.6':
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@1.6.1':
-    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
-
   '@vitest/runner@4.1.6':
     resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
-
-  '@vitest/snapshot@1.6.1':
-    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@4.1.6':
     resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@1.6.1':
-    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
-
   '@vitest/spy@4.1.6':
     resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
-
-  '@vitest/utils@1.6.1':
-    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
@@ -2571,10 +2405,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2604,8 +2434,15 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  angular-html-parser@10.4.0:
+    resolution: {integrity: sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==}
+    engines: {node: '>= 14'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2667,9 +2504,6 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
-
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2802,10 +2636,6 @@ packages:
       magicast:
         optional: true
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2840,10 +2670,6 @@ packages:
     resolution: {integrity: sha512-bRwgABDjsXRqNLjeJAxSlCrWCTvAt/yWJD30fY5CbqtoEKR6g/YCOcJW37vk4w/Gq3uMW7sF1uP74ajRrktjEw==}
     engines: {node: '>=22.0.0'}
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2852,12 +2678,16 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -2879,6 +2709,10 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -2908,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2921,9 +2759,6 @@ packages:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
     engines: {node: '>=18'}
     hasBin: true
-
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
@@ -3018,10 +2853,6 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3056,6 +2887,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -3063,9 +2897,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3119,6 +2952,9 @@ packages:
 
   electron-to-chromium@1.5.353:
     resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3190,11 +3026,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -3347,9 +3178,9 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -3373,6 +3204,10 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3386,8 +3221,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3400,6 +3244,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3474,9 +3322,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3488,9 +3333,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -3551,10 +3396,6 @@ packages:
 
   graphmatch@1.1.1:
     resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
-
-  h3-js@4.4.0:
-    resolution: {integrity: sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==}
-    engines: {node: '>=4', npm: '>=3', yarn: '>=1.3.0'}
 
   har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -3640,9 +3481,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
@@ -3781,6 +3622,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -3805,9 +3650,9 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -3823,6 +3668,10 @@ packages:
 
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -3872,14 +3721,14 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3911,6 +3760,9 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -4048,16 +3900,15 @@ packages:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
-  local-pkg@0.5.1:
-    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
-    engines: {node: '>=14'}
-
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -4068,9 +3919,6 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
-
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
@@ -4086,11 +3934,6 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
-
-  lucide-react@0.477.0:
-    resolution: {integrity: sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lucide-react@1.14.0:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
@@ -4155,13 +3998,12 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4180,14 +4022,28 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-  mlly@1.8.2:
-    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
-
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mutation-server-protocol@0.4.1:
+    resolution: {integrity: sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==}
+    engines: {node: '>=18'}
+
+  mutation-testing-elements@3.7.3:
+    resolution: {integrity: sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==}
+
+  mutation-testing-metrics@3.7.3:
+    resolution: {integrity: sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==}
+
+  mutation-testing-report-schema@3.7.3:
+    resolution: {integrity: sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mux-embed@5.17.10:
     resolution: {integrity: sha512-i+eaoezVxIEliYGWPsjQztrWbA8A3Rzwqhwv1WGuRrl2npx85jFYJV5y+cjh7FASPOjT+7zJTYCJfxmcbgM7Hg==}
@@ -4289,9 +4145,9 @@ packages:
   nosleep.js@0.12.0:
     resolution: {integrity: sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -4346,10 +4202,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4362,10 +4214,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
-
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -4376,6 +4224,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -4411,14 +4263,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -4470,9 +4316,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
@@ -4538,9 +4381,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   prisma@7.8.0:
     resolution: {integrity: sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==}
@@ -4589,6 +4432,13 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   qs@6.5.5:
     resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
     engines: {node: '>=0.6'}
@@ -4619,9 +4469,6 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-player@3.4.0:
     resolution: {integrity: sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ==}
@@ -4677,14 +4524,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  resium@1.19.4:
-    resolution: {integrity: sha512-RW0ffHlQUbgqbc0jDaF2Dnor/GKbiz5s5AKdamEKxMJfxiwQNgtgfaKK7UvafFpX25Y2J4DZP1MclTlEQ/5YUw==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      cesium: 1.x
-      react: '>=18.2.0'
-      react-dom: '>=18.2.0'
 
   resium@1.21.0:
     resolution: {integrity: sha512-fxP43kQKXQeDkZ2gwHN08vFvsaKefJ21NeeJMuAeYl/3OmspRpZx4BcfwbfvhsQhLMMmXQreHInfwO8RUoh81A==}
@@ -4774,6 +4613,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
@@ -4860,6 +4704,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -4934,9 +4782,9 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -4945,9 +4793,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@2.1.1:
-    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   stripe@22.1.1:
     resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
@@ -5066,16 +4911,8 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.27:
@@ -5132,6 +4969,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
@@ -5141,10 +4982,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
 
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
@@ -5166,6 +5003,14 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typed-inject@5.0.0:
+    resolution: {integrity: sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==}
+    engines: {node: '>=18'}
+
+  typed-rest-client@2.3.1:
+    resolution: {integrity: sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==}
+    engines: {node: '>= 16.0.0'}
+
   typescript-eslint@8.59.3:
     resolution: {integrity: sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5182,12 +5027,12 @@ packages:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
-  ufo@1.6.4:
-    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5198,6 +5043,10 @@ packages:
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -5242,42 +5091,6 @@ packages:
   vimeo-video-element@1.7.0:
     resolution: {integrity: sha512-UydSgi8svX7Iwd7yInAJVzcGKPv3E705sjCjnevQSNlJBmLcitx4aq0IBczopK6zw0OFJPWd8Qqby0Yflkz42w==}
 
-  vite-node@1.6.1:
-    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@8.0.12:
     resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5319,31 +5132,6 @@ packages:
       tsx:
         optional: true
       yaml:
-        optional: true
-
-  vitest@1.6.1:
-    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.1
-      '@vitest/ui': 1.6.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@4.1.6:
@@ -5398,6 +5186,9 @@ packages:
   weakmap-polyfill@2.0.4:
     resolution: {integrity: sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==}
     engines: {node: '>=8.10.0'}
+
+  weapon-regex@1.3.6:
+    resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5522,9 +5313,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   youtube-video-element@1.9.0:
     resolution: {integrity: sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg==}
@@ -5645,11 +5436,15 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -5659,7 +5454,27 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -5677,7 +5492,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -5698,6 +5533,54 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -5708,12 +5591,34 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -5721,7 +5626,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -5820,103 +5725,52 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
   '@esbuild/android-arm@0.27.4':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
   '@esbuild/linux-s390x@0.27.4':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
@@ -5925,16 +5779,10 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -5943,25 +5791,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -6142,9 +5978,124 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@jest/schemas@29.6.3':
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/checkbox@5.1.5(@types/node@25.7.0)':
     dependencies:
-      '@sinclair/typebox': 0.27.10
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/confirm@6.0.13(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/core@11.1.10(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/editor@5.1.2(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/external-editor': 3.0.0(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/expand@5.0.14(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/external-editor@3.0.0(@types/node@25.7.0)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@5.0.13(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/number@4.0.13(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/password@5.0.13(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/prompts@8.4.3(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.5(@types/node@25.7.0)
+      '@inquirer/confirm': 6.0.13(@types/node@25.7.0)
+      '@inquirer/editor': 5.1.2(@types/node@25.7.0)
+      '@inquirer/expand': 5.0.14(@types/node@25.7.0)
+      '@inquirer/input': 5.0.13(@types/node@25.7.0)
+      '@inquirer/number': 4.0.13(@types/node@25.7.0)
+      '@inquirer/password': 5.0.13(@types/node@25.7.0)
+      '@inquirer/rawlist': 5.2.9(@types/node@25.7.0)
+      '@inquirer/search': 4.1.9(@types/node@25.7.0)
+      '@inquirer/select': 5.1.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/rawlist@5.2.9(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/search@4.1.9(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/select@5.1.5(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.10(@types/node@25.7.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.7.0)
+    optionalDependencies:
+      '@types/node': 25.7.0
+
+  '@inquirer/type@4.0.5(@types/node@25.7.0)':
+    optionalDependencies:
+      '@types/node': 25.7.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6712,8 +6663,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.7': {}
-
   '@rollup/plugin-commonjs@28.0.1(rollup@4.60.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
@@ -6810,6 +6759,8 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@sec-ant/readable-stream@0.4.1': {}
 
   '@sentry-internal/browser-utils@10.52.0':
     dependencies:
@@ -6998,11 +6949,78 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sinclair/typebox@0.27.10': {}
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@spz-loader/core@0.3.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stryker-mutator/api@9.6.1':
+    dependencies:
+      mutation-testing-metrics: 3.7.3
+      mutation-testing-report-schema: 3.7.3
+      tslib: 2.8.1
+      typed-inject: 5.0.0
+
+  '@stryker-mutator/core@9.6.1(@types/node@25.7.0)':
+    dependencies:
+      '@inquirer/prompts': 8.4.3(@types/node@25.7.0)
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/instrumenter': 9.6.1
+      '@stryker-mutator/util': 9.6.1
+      ajv: 8.18.0
+      chalk: 5.6.2
+      commander: 14.0.3
+      diff-match-patch: 1.0.5
+      emoji-regex: 10.6.0
+      execa: 9.6.1
+      json-rpc-2.0: 1.7.1
+      lodash.groupby: 4.6.0
+      minimatch: 10.2.5
+      mutation-server-protocol: 0.4.1
+      mutation-testing-elements: 3.7.3
+      mutation-testing-metrics: 3.7.3
+      mutation-testing-report-schema: 3.7.3
+      npm-run-path: 6.0.0
+      progress: 2.0.3
+      rxjs: 7.8.2
+      semver: 7.8.0
+      source-map: 0.7.6
+      tree-kill: 1.2.2
+      tslib: 2.8.1
+      typed-inject: 5.0.0
+      typed-rest-client: 2.3.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+
+  '@stryker-mutator/instrumenter@9.6.1':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/util': 9.6.1
+      angular-html-parser: 10.4.0
+      semver: 7.7.4
+      tslib: 2.8.1
+      weapon-regex: 1.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@stryker-mutator/util@9.6.1': {}
+
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.7.0))(vitest@4.1.6)':
+    dependencies:
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/core': 9.6.1(@types/node@25.7.0)
+      '@stryker-mutator/util': 9.6.1
+      semver: 7.8.0
+      tslib: 2.8.1
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
 
   '@supabase/auth-js@2.105.4':
     dependencies:
@@ -7175,10 +7193,6 @@ snapshots:
       '@types/node': 25.7.0
 
   '@types/node@20.19.41':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 
@@ -7398,11 +7412,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)
-
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -7416,12 +7425,6 @@ snapshots:
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0))
-
-  '@vitest/expect@1.6.1':
-    dependencies:
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      chai: 4.5.0
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -7444,22 +7447,10 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@1.6.1':
-    dependencies:
-      '@vitest/utils': 1.6.1
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
   '@vitest/runner@4.1.6':
     dependencies:
       '@vitest/utils': 4.1.6
       pathe: 2.0.3
-
-  '@vitest/snapshot@1.6.1':
-    dependencies:
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      pretty-format: 29.7.0
 
   '@vitest/snapshot@4.1.6':
     dependencies:
@@ -7468,18 +7459,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@1.6.1':
-    dependencies:
-      tinyspy: 2.2.1
-
   '@vitest/spy@4.1.6': {}
-
-  '@vitest/utils@1.6.1':
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -7585,10 +7565,6 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-
   acorn@8.16.0: {}
 
   agent-base@6.0.2:
@@ -7615,12 +7591,21 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  angular-html-parser@10.4.0: {}
 
   ansi-regex@5.0.1: {}
 
@@ -7710,8 +7695,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   assert-plus@1.0.0: {}
-
-  assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -7855,8 +7838,6 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.2
 
-  cac@6.7.14: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -7893,16 +7874,6 @@ snapshots:
       '@cesium/engine': 25.0.0
       '@cesium/widgets': 15.0.0
 
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -7910,13 +7881,13 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
+  chardet@2.1.1: {}
+
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
 
   cheerio-select@2.1.0:
     dependencies:
@@ -7952,6 +7923,8 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
 
   cliui@8.0.1:
@@ -7976,6 +7949,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commondir@1.0.1: {}
@@ -7990,8 +7965,6 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
-
-  confbox@0.1.8: {}
 
   confbox@0.2.4: {}
 
@@ -8119,10 +8092,6 @@ snapshots:
       mimic-response: 3.1.0
     optional: true
 
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
-
   deep-extend@0.6.0:
     optional: true
 
@@ -8150,11 +8119,16 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
 
-  diff-sequences@29.6.3: {}
+  diff-match-patch@1.0.5: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -8211,6 +8185,8 @@ snapshots:
   electron-to-chromium@1.5.328: {}
 
   electron-to-chromium@1.5.353: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -8343,32 +8319,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -8623,17 +8573,20 @@ snapshots:
 
   events@3.3.0: {}
 
-  execa@8.0.1:
+  execa@9.6.1:
     dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
       cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
       signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
 
   expand-template@2.0.3:
     optional: true
@@ -8650,6 +8603,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -8664,7 +8621,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -8673,6 +8640,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8745,8 +8716,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-func-name@2.0.2: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -8767,7 +8736,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@8.0.1: {}
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -8822,8 +8794,6 @@ snapshots:
   grapheme-splitter@1.0.4: {}
 
   graphmatch@1.1.1: {}
-
-  h3-js@4.4.0: {}
 
   har-schema@2.0.0: {}
 
@@ -8916,7 +8886,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  human-signals@5.0.0: {}
+  human-signals@8.0.1: {}
 
   iceberg-js@0.8.1: {}
 
@@ -8962,8 +8932,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
@@ -9063,6 +9032,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-property@1.0.2: {}
@@ -9088,7 +9059,7 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-stream@3.0.0: {}
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -9106,6 +9077,8 @@ snapshots:
       which-typed-array: 1.1.20
 
   is-typedarray@1.0.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -9156,11 +9129,11 @@ snapshots:
 
   jose@6.2.3: {}
 
+  js-md4@0.3.2: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -9202,6 +9175,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -9311,11 +9286,6 @@ snapshots:
 
   loader-runner@4.3.2: {}
 
-  local-pkg@0.5.1:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 1.3.1
-
   localforage@1.10.0:
     dependencies:
       lie: 3.1.1
@@ -9324,6 +9294,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.groupby@4.6.0: {}
+
   lodash.merge@4.6.2: {}
 
   long@5.3.2: {}
@@ -9331,10 +9303,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
 
   lru-cache@11.2.7: {}
 
@@ -9345,10 +9313,6 @@ snapshots:
       yallist: 3.1.1
 
   lru.min@1.1.4: {}
-
-  lucide-react@0.477.0(react@19.2.6):
-    dependencies:
-      react: 19.2.6
 
   lucide-react@1.14.0(react@19.2.6):
     dependencies:
@@ -9409,10 +9373,10 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mimic-fn@4.0.0: {}
-
   mimic-response@3.1.0:
     optional: true
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -9429,16 +9393,23 @@ snapshots:
   mkdirp-classic@0.5.3:
     optional: true
 
-  mlly@1.8.2:
-    dependencies:
-      acorn: 8.16.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.4
-
   module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
+
+  mutation-server-protocol@0.4.1:
+    dependencies:
+      zod: 4.4.3
+
+  mutation-testing-elements@3.7.3: {}
+
+  mutation-testing-metrics@3.7.3:
+    dependencies:
+      mutation-testing-report-schema: 3.7.3
+
+  mutation-testing-report-schema@3.7.3: {}
+
+  mute-stream@3.0.0: {}
 
   mux-embed@5.17.10: {}
 
@@ -9526,9 +9497,10 @@ snapshots:
 
   nosleep.js@0.12.0: {}
 
-  npm-run-path@5.3.0:
+  npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   nth-check@2.1.1:
     dependencies:
@@ -9591,10 +9563,6 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -9614,10 +9582,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -9627,6 +9591,8 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-ms@4.0.0: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -9660,11 +9626,7 @@ snapshots:
       lru-cache: 11.3.6
       minipass: 7.1.3
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
-
-  pathval@1.1.1: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -9710,12 +9672,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.8.2
-      pathe: 2.0.3
 
   pkg-types@2.3.1:
     dependencies:
@@ -9787,11 +9743,9 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  pretty-format@29.7.0:
+  pretty-ms@9.3.0:
     dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
+      parse-ms: 4.0.0
 
   prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
@@ -9851,6 +9805,12 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  pure-rand@8.4.0: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.5.5: {}
 
   queue-microtask@1.2.3: {}
@@ -9882,8 +9842,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
-
-  react-is@18.3.1: {}
 
   react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -9976,12 +9934,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  resium@1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      cesium: 1.141.0
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   resium@1.21.0(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -10116,6 +10068,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
   semver@7.8.0: {}
 
   seq-queue@0.0.5: {}
@@ -10239,6 +10193,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   split2@4.2.0: {}
 
   spotify-audio-element@1.0.4: {}
@@ -10341,16 +10297,12 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-final-newline@3.0.0: {}
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1:
     optional: true
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@2.1.1:
-    dependencies:
-      js-tokens: 9.0.1
 
   stripe@22.1.1(@types/node@25.7.0):
     optionalDependencies:
@@ -10429,11 +10381,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@0.8.4: {}
-
   tinyrainbow@3.1.0: {}
-
-  tinyspy@2.2.1: {}
 
   tldts-core@7.0.27: {}
 
@@ -10490,6 +10438,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  tunnel@0.0.6: {}
+
   tweetnacl@0.14.5: {}
 
   twitch-video-element@0.1.6: {}
@@ -10497,8 +10447,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@4.1.0: {}
 
   type-fest@0.7.1: {}
 
@@ -10535,6 +10483,16 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-inject@5.0.0: {}
+
+  typed-rest-client@2.3.1:
+    dependencies:
+      des.js: 1.1.0
+      js-md4: 0.3.2
+      qs: 6.15.1
+      tunnel: 0.0.6
+      underscore: 1.13.8
+
   typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -10550,8 +10508,6 @@ snapshots:
 
   ua-parser-js@1.0.41: {}
 
-  ufo@1.6.4: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -10559,11 +10515,15 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  underscore@1.13.8: {}
+
   undici-types@6.21.0: {}
 
   undici-types@7.21.0: {}
 
   undici@7.24.6: {}
+
+  unicorn-magic@0.3.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -10632,35 +10592,6 @@ snapshots:
       '@vimeo/player': 2.29.0
       media-played-ranges-mixin: 0.1.0
 
-  vite-node@1.6.1(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.14
-      rollup: 4.60.3
-    optionalDependencies:
-      '@types/node': 20.19.41
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-      terser: 5.47.1
-
   vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -10675,41 +10606,6 @@ snapshots:
       jiti: 2.7.0
       terser: 5.47.1
       tsx: 4.21.0
-
-  vitest@1.6.1(@types/node@20.19.41)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.47.1):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.5
-      chai: 4.5.0
-      debug: 4.4.3
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1)
-      vite-node: 1.6.1(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.41
-      jsdom: 28.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)):
     dependencies:
@@ -10751,6 +10647,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   weakmap-polyfill@2.0.4: {}
+
+  weapon-regex@1.3.6: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -10911,7 +10809,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.2.2: {}
+  yoctocolors@2.1.2: {}
 
   youtube-video-element@1.9.0:
     dependencies:

--- a/src/core/data/DataUtils.test.ts
+++ b/src/core/data/DataUtils.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchLocalEngineManifest, localEngineHasPlugin, resetManifestCache } from "./engineManifest";
+import { resolveEngineUrl } from "./resolveEngineUrl";
+import { pluginManager } from "@/core/plugins/PluginManager";
+
+// Mock PluginManager
+vi.mock("@/core/plugins/PluginManager", () => ({
+  pluginManager: {
+    getPlugin: vi.fn(),
+    getManifest: vi.fn(),
+  },
+}));
+
+describe("EngineManifest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetManifestCache();
+    global.fetch = vi.fn() as any;
+  });
+
+  it("should fetch manifest from local engine and cache it", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ plugins: ["plugin-a", "plugin-b"] }),
+    });
+
+    const plugins = await fetchLocalEngineManifest();
+    expect(plugins).toEqual(["plugin-a", "plugin-b"]);
+    expect(localEngineHasPlugin("plugin-a")).toBe(true);
+    expect(localEngineHasPlugin("plugin-c")).toBe(false);
+    
+    // Second call should used cache
+    await fetchLocalEngineManifest();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return null and cache failure if local engine is missing", async () => {
+    (global.fetch as any).mockRejectedValue(new Error("Connection refused"));
+
+    const plugins = await fetchLocalEngineManifest();
+    expect(plugins).toBeNull();
+    
+    // Should not retry fetch
+    await fetchLocalEngineManifest();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveEngineUrl", () => {
+  beforeEach(() => {
+    resetManifestCache();
+    vi.clearAllMocks();
+  });
+
+  it("should prioritize local engine if plugin is found there", async () => {
+    // Setup local manifest
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ plugins: ["plugin-local"] }),
+    });
+    await fetchLocalEngineManifest();
+
+    const url = resolveEngineUrl("plugin-local");
+    expect(url).toContain("localhost:5000/stream");
+  });
+
+  it("should fall back to plugin's custom streamUrl if not local", () => {
+    (pluginManager.getPlugin as any).mockReturnValue({
+      plugin: {
+        getServerConfig: () => ({ streamUrl: "ws://custom-engine/stream" })
+      }
+    });
+
+    const url = resolveEngineUrl("plugin-custom");
+    expect(url).toBe("ws://custom-engine/stream");
+  });
+
+  it("should fall back to manifest streamUrl if provided", () => {
+    (pluginManager.getPlugin as any).mockReturnValue(undefined);
+    (pluginManager.getManifest as any).mockReturnValue({
+      dataSource: { streamUrl: "ws://manifest-engine/stream" }
+    });
+
+    const url = resolveEngineUrl("plugin-manifest");
+    expect(url).toBe("ws://manifest-engine/stream");
+  });
+
+  it("should use default cloud engine as last resort", () => {
+    (pluginManager.getPlugin as any).mockReturnValue(undefined);
+    (pluginManager.getManifest as any).mockReturnValue(undefined);
+
+    const url = resolveEngineUrl("unknown-plugin");
+    expect(url).toContain("worldwideview.dev/stream");
+  });
+});

--- a/src/core/data/WsClient.test.ts
+++ b/src/core/data/WsClient.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { wsClient } from "./WsClient";
+import { dataBus } from "./DataBus";
+import { pluginManager } from "../plugins/PluginManager";
+
+// Mock DataBus
+vi.mock("./DataBus", () => ({
+  dataBus: {
+    emit: vi.fn(),
+  },
+}));
+
+// Mock PluginManager
+vi.mock("../plugins/PluginManager", () => ({
+  pluginManager: {
+    getPlugin: vi.fn(),
+  },
+}));
+
+// Mock Store
+vi.mock("../state/store", () => ({
+  useStore: {
+    getState: vi.fn(() => ({
+      entitiesByPlugin: {},
+      setLayerLoading: vi.fn(),
+    })),
+  },
+}));
+
+describe("WsClient", () => {
+  let mockWs: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    // Mock WebSocket global
+    mockWs = {
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 0, // CONNECTING
+    };
+
+    global.WebSocket = vi.fn().mockImplementation(function() {
+      return mockWs;
+    }) as any;
+    Object.assign(global.WebSocket, {
+      CONNECTING: 0,
+      OPEN: 1,
+      CLOSING: 2,
+      CLOSED: 3,
+    });
+
+    // Clear singleton state
+    (wsClient as any).engines.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should create a new WebSocket connection when subscribing to a new engine", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    
+    expect(global.WebSocket).toHaveBeenCalledWith("ws://engine-1/stream");
+  });
+
+  it("should reuse an existing connection for the same engine URL", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    wsClient.subscribe("plugin-b", "ws://engine-1/stream");
+
+    expect(global.WebSocket).toHaveBeenCalledTimes(1);
+  });
+
+  it("should send a subscribe action once the socket is open", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    
+    // Simulate open
+    mockWs.readyState = 1; // OPEN
+    mockWs.onopen();
+
+    expect(mockWs.send).toHaveBeenCalledWith(
+      JSON.stringify({ action: "subscribe", pluginId: "plugin-a" })
+    );
+  });
+
+  it("should attempt to reconnect after 5s if the connection is closed while subscriptions exist", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    mockWs.onclose();
+
+    expect(global.WebSocket).toHaveBeenCalledTimes(1); // Initial
+    
+    vi.advanceTimersByTime(5000);
+    
+    expect(global.WebSocket).toHaveBeenCalledTimes(2); // Reconnect
+  });
+
+  it("should close the connection after 30s if all plugins unsubscribe", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    wsClient.unsubscribe("plugin-a", "ws://engine-1/stream");
+
+    // Should not close immediately (grace period)
+    expect(mockWs.close).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(30000);
+
+    expect(mockWs.close).toHaveBeenCalled();
+  });
+
+  it("should handle data messages and emit dataUpdated via DataBus", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    
+    const mockEntities = [{ id: "1", type: "point", lat: 10, lng: 20 }];
+    const message = {
+      type: "data",
+      pluginId: "plugin-a",
+      payload: mockEntities
+    };
+
+    mockWs.onmessage({ data: JSON.stringify(message) });
+
+    expect(dataBus.emit).toHaveBeenCalledWith("dataUpdated", expect.objectContaining({
+      pluginId: "plugin-a",
+      entities: expect.arrayContaining([
+        expect.objectContaining({ id: "1" })
+      ])
+    }));
+  });
+
+  it("should use plugin's custom mapWebsocketPayload if available", () => {
+    const mockPlugin = {
+      mapWebsocketPayload: vi.fn((payload) => payload.map((e: any) => ({ ...e, custom: true })))
+    };
+    (pluginManager.getPlugin as any).mockReturnValue({ plugin: mockPlugin });
+
+    wsClient.subscribe("plugin-custom", "ws://engine-1/stream");
+    
+    const mockEntities = [{ id: "1" }];
+    const message = {
+      type: "data",
+      pluginId: "plugin-custom",
+      payload: mockEntities
+    };
+
+    mockWs.onmessage({ data: JSON.stringify(message) });
+
+    expect(mockPlugin.mapWebsocketPayload).toHaveBeenCalled();
+    expect(dataBus.emit).toHaveBeenCalledWith("dataUpdated", expect.objectContaining({
+      entities: [expect.objectContaining({ custom: true })]
+    }));
+  });
+
+  it("should cancel cleanup timer if a new subscription is added during grace period", () => {
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    wsClient.unsubscribe("plugin-a", "ws://engine-1/stream");
+    
+    // Cleanup timer is running
+    wsClient.subscribe("plugin-b", "ws://engine-1/stream");
+    
+    vi.advanceTimersByTime(30000);
+    expect(mockWs.close).not.toHaveBeenCalled();
+  });
+
+  it("should print connections to console", () => {
+    const groupSpy = vi.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+    const tableSpy = vi.spyOn(console, "table").mockImplementation(() => {});
+    wsClient.subscribe("plugin-a", "ws://engine-1/stream");
+    wsClient.printConnections();
+    expect(groupSpy).toHaveBeenCalled();
+    expect(tableSpy).toHaveBeenCalled();
+  });
+});

--- a/src/core/filters/filterEngine.test.ts
+++ b/src/core/filters/filterEngine.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { applyFilters } from "./filterEngine";
+import type { GeoEntity, FilterDefinition, FilterValue } from "@/core/plugins/PluginTypes";
+
+/**
+ * Helper to keep the fixture set small and on-spec. `GeoEntity` requires
+ * `latitude`, `longitude`, `timestamp`, and `properties`; everything
+ * else (label, altitude, heading, speed) is optional. We omit the
+ * optional fields except where a specific test exercises them.
+ */
+function entity(overrides: Partial<GeoEntity> & Pick<GeoEntity, "id" | "pluginId" | "properties">): GeoEntity {
+    return {
+        latitude: 0,
+        longitude: 0,
+        timestamp: new Date(0),
+        ...overrides,
+    };
+}
+
+describe("applyFilters", () => {
+    it("returns the original array unchanged when no active filters are provided", () => {
+        const entities: GeoEntity[] = [
+            entity({ id: "1", pluginId: "test", properties: {} }),
+            entity({ id: "2", pluginId: "test", properties: {} }),
+        ];
+
+        expect(applyFilters(entities, [], {})).toEqual(entities);
+    });
+
+    it("returns a subset (or equal) of the input when filtering by text", () => {
+        const entities: GeoEntity[] = [
+            entity({ id: "1", pluginId: "test", label: "alpha", properties: { name: "alpha" } }),
+            entity({ id: "2", pluginId: "test", label: "beta", properties: { name: "beta" } }),
+            entity({ id: "3", pluginId: "test", label: "gamma", properties: { name: "gamma" } }),
+        ];
+        const definitions: FilterDefinition[] = [
+            { id: "name", label: "Name", type: "text", propertyKey: "name" },
+        ];
+        const activeFilters: Record<string, FilterValue> = {
+            name: { type: "text", value: "a" },
+        };
+
+        const result = applyFilters(entities, definitions, activeFilters);
+
+        expect(result.length).toBeLessThanOrEqual(entities.length);
+        for (const item of result) expect(entities).toContainEqual(item);
+    });
+
+    it("handles each filter type and the missing-definition / unknown-type fallbacks", () => {
+        const entities: GeoEntity[] = [
+            entity({
+                id: "1",
+                pluginId: "test",
+                label: "test1",
+                properties: { category: "A", speed: 50, active: true, invalidNum: "NaN" },
+            }),
+            entity({
+                id: "2",
+                pluginId: "test",
+                label: "test2",
+                properties: { category: "B", speed: 100, active: false, noProp: undefined },
+            }),
+        ];
+
+        // 1. Missing definition — filter is silently ignored
+        expect(
+            applyFilters(entities, [], { missing: { type: "boolean", value: true } }),
+        ).toEqual(entities);
+
+        // 2. Select filter
+        const selectDef: FilterDefinition = {
+            id: "cat",
+            label: "Category",
+            type: "select",
+            propertyKey: "category",
+        };
+        expect(applyFilters(entities, [selectDef], { cat: { type: "select", values: ["A"] } })).toEqual([
+            entities[0],
+        ]);
+        expect(applyFilters(entities, [selectDef], { cat: { type: "select", values: [] } })).toEqual(
+            entities,
+        ); // empty select == no filter
+        expect(applyFilters(entities, [selectDef], { cat: { type: "select", values: ["C"] } })).toEqual(
+            [],
+        );
+
+        // 3. Range filter — note: `range` is a NESTED config on FilterDefinition
+        const rangeDef: FilterDefinition = {
+            id: "spd",
+            label: "Speed",
+            type: "range",
+            propertyKey: "speed",
+            range: { min: 0, max: 200, step: 1 },
+        };
+        expect(applyFilters(entities, [rangeDef], { spd: { type: "range", min: 60, max: 150 } })).toEqual(
+            [entities[1]],
+        );
+
+        const invalidRangeDef: FilterDefinition = {
+            id: "inv",
+            label: "Invalid",
+            type: "range",
+            propertyKey: "invalidNum",
+            range: { min: 0, max: 200, step: 1 },
+        };
+        // entities[0] has invalidNum: "NaN" → fails; entities[1] has it undefined → 0 → matches
+        expect(
+            applyFilters(entities, [invalidRangeDef], { inv: { type: "range", min: 0, max: 100 } }),
+        ).toEqual([entities[1]]);
+
+        // 4. Boolean filter
+        const boolDef: FilterDefinition = {
+            id: "act",
+            label: "Active",
+            type: "boolean",
+            propertyKey: "active",
+        };
+        expect(applyFilters(entities, [boolDef], { act: { type: "boolean", value: false } })).toEqual([
+            entities[1],
+        ]);
+
+        // 5. Unknown filter type — falls through unchanged
+        const unknownDef: FilterDefinition = {
+            id: "unk",
+            label: "Unknown",
+            type: "unknown" as unknown as FilterDefinition["type"],
+            propertyKey: "active",
+        };
+        expect(
+            applyFilters(entities, [unknownDef], {
+                unk: { type: "unknown" as unknown as FilterValue["type"] } as unknown as FilterValue,
+            }),
+        ).toEqual(entities);
+
+        // 6. Text filter with empty value — no filtering
+        const textDef: FilterDefinition = {
+            id: "txt",
+            label: "Text",
+            type: "text",
+            propertyKey: "label",
+        };
+        expect(applyFilters(entities, [textDef], { txt: { type: "text", value: "" } })).toEqual(
+            entities,
+        );
+    });
+});

--- a/src/core/plugins/PluginManager.test.ts
+++ b/src/core/plugins/PluginManager.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * PluginManager is the orchestrator everything else routes through —
+ * register, enable, disable, fetch coordination, cache + bus updates.
+ * Bugs here have wide blast radius: pins disappear, layers never load,
+ * the agent bus stops driving the UI.
+ *
+ * Testing philosophy: we let the real `dataBus`, `cacheLayer`, and
+ * `pollingManager` through (each is covered by its own unit tests) so
+ * these tests verify the *observable* interaction between PluginManager
+ * and the data layer — events fired, cache entries written, plugins
+ * shown as enabled in the public API. Tests pin contracts that
+ * downstream refactors should preserve, not implementation details
+ * that should be allowed to change.
+ *
+ * Mocked: the Zustand store, analytics, engine-URL resolution, the
+ * local-engine manifest fetcher, and the manifest loader. None are
+ * load-bearing for these assertions; they otherwise drag in Cesium or
+ * heavy framework setup.
+ */
+
+vi.mock("@/core/state/store", () => ({
+    useStore: {
+        getState: () => ({
+            setLayerLoading: () => {},
+            dataConfig: { pluginSettings: {}, pollingIntervals: {} },
+            isPlaybackMode: false,
+            currentTime: new Date(),
+            showErrorToast: undefined,
+        }),
+        subscribe: () => () => {},
+    },
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: () => {} }));
+vi.mock("@/core/data/resolveEngineUrl", () => ({
+    resolveEngineUrl: () => "wss://test.example/stream",
+}));
+vi.mock("@/core/data/engineManifest", () => ({
+    fetchLocalEngineManifest: async () => null,
+}));
+vi.mock("./loadPluginFromManifest", () => ({
+    loadPluginFromManifest: vi.fn(),
+}));
+
+import { pluginManager } from "./PluginManager";
+import { dataBus } from "@/core/data/DataBus";
+import { cacheLayer } from "@/core/data/CacheLayer";
+import { loadPluginFromManifest } from "./loadPluginFromManifest";
+import type { GeoEntity, WorldPlugin } from "@/core/plugins/PluginTypes";
+
+function makePlugin(overrides: Partial<WorldPlugin> = {}): WorldPlugin {
+    return {
+        id: "test-plugin",
+        name: "Test Plugin",
+        description: "for tests",
+        icon: "Box",
+        category: "custom",
+        version: "1.0.0",
+        initialize: async () => {},
+        destroy: () => {},
+        fetch: async () => [],
+        getPollingInterval: () => 0,
+        getLayerConfig: () => ({
+            color: "#fff",
+            clusterEnabled: false,
+            clusterDistance: 50,
+        }),
+        renderEntity: () => ({ type: "point" }),
+        ...overrides,
+    };
+}
+
+function makeEntity(id: string, pluginId: string): GeoEntity {
+    return {
+        id,
+        pluginId,
+        latitude: 0,
+        longitude: 0,
+        timestamp: new Date(),
+        properties: {},
+    };
+}
+
+beforeEach(() => {
+    cacheLayer.clear();
+});
+
+afterEach(() => {
+    // PluginManager doesn't expose a registry-clear; destroy() runs the
+    // teardown the AppShell uses at unmount.
+    pluginManager.destroy();
+    dataBus.removeAllListeners();
+    vi.clearAllMocks();
+});
+
+describe("PluginManager.registerPlugin", () => {
+    it("stores the plugin and emits pluginRegistered with the default interval", async () => {
+        const handler = vi.fn();
+        dataBus.on("pluginRegistered", handler);
+        const plugin = makePlugin({ id: "reg-1", getPollingInterval: () => 30_000 });
+
+        await pluginManager.registerPlugin(plugin);
+
+        expect(pluginManager.getPlugin("reg-1")).toBeDefined();
+        expect(handler).toHaveBeenCalledWith({
+            pluginId: "reg-1",
+            defaultInterval: 30_000,
+        });
+    });
+
+    it("ignores a second registerPlugin with the same id and warns", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        await pluginManager.registerPlugin(makePlugin({ id: "dup", name: "first" }));
+        await pluginManager.registerPlugin(makePlugin({ id: "dup", name: "second" }));
+
+        expect(pluginManager.getPlugin("dup")?.plugin.name).toBe("first");
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+});
+
+describe("PluginManager.enablePlugin", () => {
+    it("flips enabled=true and emits layerToggled(true)", async () => {
+        const layerHandler = vi.fn();
+        dataBus.on("layerToggled", layerHandler);
+        await pluginManager.registerPlugin(makePlugin({ id: "en-1" }));
+
+        await pluginManager.enablePlugin("en-1");
+
+        expect(pluginManager.getPlugin("en-1")?.enabled).toBe(true);
+        expect(layerHandler).toHaveBeenCalledWith({ pluginId: "en-1", enabled: true });
+    });
+
+    it("emits a fresh dataUpdated from cache before kicking off polling", async () => {
+        const dataHandler = vi.fn();
+        const cachedEntities = [makeEntity("e1", "en-2")];
+        cacheLayer.set("en-2", cachedEntities, 60_000);
+        await pluginManager.registerPlugin(makePlugin({ id: "en-2" }));
+        dataBus.on("dataUpdated", dataHandler);
+
+        await pluginManager.enablePlugin("en-2");
+
+        expect(dataHandler).toHaveBeenCalledWith({
+            pluginId: "en-2",
+            entities: cachedEntities,
+        });
+    });
+});
+
+describe("PluginManager.disablePlugin", () => {
+    it("clears entities and emits layerToggled(false) + dataUpdated([])", async () => {
+        const layerHandler = vi.fn();
+        const dataHandler = vi.fn();
+        await pluginManager.registerPlugin(makePlugin({ id: "dis-1" }));
+        await pluginManager.enablePlugin("dis-1");
+
+        dataBus.on("layerToggled", layerHandler);
+        dataBus.on("dataUpdated", dataHandler);
+        pluginManager.disablePlugin("dis-1");
+
+        expect(pluginManager.getPlugin("dis-1")?.enabled).toBe(false);
+        expect(pluginManager.getEntities("dis-1")).toEqual([]);
+        expect(layerHandler).toHaveBeenCalledWith({ pluginId: "dis-1", enabled: false });
+        expect(dataHandler).toHaveBeenCalledWith({ pluginId: "dis-1", entities: [] });
+    });
+});
+
+describe("PluginManager — data flow contract", () => {
+    it("a plugin's onDataUpdate writes through to the cache and emits dataUpdated", async () => {
+        const dataHandler = vi.fn();
+        dataBus.on("dataUpdated", dataHandler);
+        await pluginManager.registerPlugin(makePlugin({ id: "df-1" }));
+
+        const managed = pluginManager.getPlugin("df-1");
+        const entities = [makeEntity("a", "df-1"), makeEntity("b", "df-1")];
+        managed!.context.onDataUpdate(entities);
+
+        // Cache populated for the plugin id
+        expect(cacheLayer.get("df-1")).toEqual(entities);
+        // Bus emits with the same entities
+        expect(dataHandler).toHaveBeenCalledWith({
+            pluginId: "df-1",
+            entities,
+        });
+        // Public accessor reflects the update
+        expect(pluginManager.getEntities("df-1")).toEqual(entities);
+    });
+});
+
+describe("PluginManager — getAllEntities filters by enabled flag", () => {
+    it("excludes entities owned by a disabled plugin", async () => {
+        await pluginManager.registerPlugin(makePlugin({ id: "ae-on" }));
+        await pluginManager.registerPlugin(makePlugin({ id: "ae-off" }));
+        await pluginManager.enablePlugin("ae-on");
+        // ae-off intentionally not enabled
+
+        // Both plugins receive data updates...
+        pluginManager.getPlugin("ae-on")!.context.onDataUpdate([
+            makeEntity("on-1", "ae-on"),
+        ]);
+        pluginManager.getPlugin("ae-off")!.context.onDataUpdate([
+            makeEntity("off-1", "ae-off"),
+        ]);
+
+        // ...but getAllEntities only returns entities from enabled plugins.
+        const all = pluginManager.getAllEntities();
+        expect(all.map((e) => e.id)).toEqual(["on-1"]);
+    });
+});
+
+describe("PluginManager.updateTimeRange", () => {
+    it("calls plugin.fetch on every enabled plugin with the new range", async () => {
+        const fetchSpy = vi.fn(async () => []);
+        await pluginManager.registerPlugin(
+            makePlugin({ id: "tr-on", fetch: fetchSpy }),
+        );
+        await pluginManager.registerPlugin(
+            makePlugin({ id: "tr-off", fetch: vi.fn(async () => []) }),
+        );
+        await pluginManager.enablePlugin("tr-on");
+        // tr-off stays disabled
+
+        const timeRange = {
+            start: new Date("2026-01-01"),
+            end: new Date("2026-01-02"),
+        };
+        await pluginManager.updateTimeRange(timeRange);
+
+        // Enabled plugin's fetch was called with the new range
+        expect(fetchSpy).toHaveBeenCalledWith(timeRange);
+        // Disabled plugin's fetch was NOT called
+        const disabledPluginFetch = pluginManager.getPlugin("tr-off")!.plugin.fetch as ReturnType<typeof vi.fn>;
+        expect(disabledPluginFetch).not.toHaveBeenCalled();
+    });
+});
+
+describe("PluginManager.destroy", () => {
+    it("calls plugin.destroy on each registered plugin and clears the registry", async () => {
+        const destroySpy1 = vi.fn();
+        const destroySpy2 = vi.fn();
+        await pluginManager.registerPlugin(
+            makePlugin({ id: "d-1", destroy: destroySpy1 }),
+        );
+        await pluginManager.registerPlugin(
+            makePlugin({ id: "d-2", destroy: destroySpy2 }),
+        );
+
+        pluginManager.destroy();
+
+        expect(destroySpy1).toHaveBeenCalled();
+        expect(destroySpy2).toHaveBeenCalled();
+        expect(pluginManager.getAllPlugins()).toEqual([]);
+    });
+});
+
+describe("PluginManager.togglePlugin", () => {
+    it("flips a plugin between enabled and disabled across successive calls", async () => {
+        await pluginManager.registerPlugin(makePlugin({ id: "tg-1" }));
+        expect(pluginManager.getPlugin("tg-1")?.enabled).toBe(false);
+
+        // togglePlugin is sync but calls async enablePlugin; wait for
+        // the state flip to land.
+        pluginManager.togglePlugin("tg-1");
+        await vi.waitFor(() =>
+            expect(pluginManager.getPlugin("tg-1")?.enabled).toBe(true),
+        );
+
+        // Second toggle should flip it off — disablePlugin is sync, so
+        // no waitFor needed.
+        pluginManager.togglePlugin("tg-1");
+        expect(pluginManager.getPlugin("tg-1")?.enabled).toBe(false);
+    });
+});
+
+describe("PluginManager.loadFromManifest", () => {
+    it("delegates to loadPluginFromManifest and registers the result", async () => {
+        const fakePlugin = makePlugin({ id: "lm-1", name: "From Manifest" });
+        (loadPluginFromManifest as ReturnType<typeof vi.fn>).mockResolvedValue(
+            fakePlugin,
+        );
+
+        await pluginManager.loadFromManifest({
+            id: "lm-1",
+            name: "From Manifest",
+            version: "1.0.0",
+            type: "data-layer",
+            format: "bundle",
+            trust: "built-in",
+            capabilities: ["data:own"],
+            category: "custom",
+            icon: "Box",
+            entry: "/dev/null",
+        } as never);
+
+        expect(loadPluginFromManifest).toHaveBeenCalled();
+        expect(pluginManager.getPlugin("lm-1")).toBeDefined();
+        expect(pluginManager.getPlugin("lm-1")?.plugin.name).toBe("From Manifest");
+    });
+});

--- a/src/core/plugins/loadPluginFromManifest.test.ts
+++ b/src/core/plugins/loadPluginFromManifest.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loadPluginFromManifest, ManifestLoadError } from "./loadPluginFromManifest";
+import { validateManifest } from "./validateManifest";
+
+vi.mock("./validateManifest", () => ({
+  validateManifest: vi.fn(),
+}));
+
+describe("loadPluginFromManifest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw ManifestLoadError if validation fails", async () => {
+    (validateManifest as any).mockReturnValue({
+      valid: false,
+      errors: ["Missing ID"],
+    });
+
+    const manifest: any = { id: "test" };
+    await expect(loadPluginFromManifest(manifest)).rejects.toThrow(ManifestLoadError);
+    await expect(loadPluginFromManifest(manifest)).rejects.toThrow("Invalid manifest: Missing ID");
+  });
+
+  it("should attempt to load bundle if manifest is valid", async () => {
+    (validateManifest as any).mockReturnValue({ valid: true, errors: [] });
+    
+    // We can't easily mock the dynamic import of an arbitrary string in this environment
+    // without complex setup, so we expect it to fail with a specific error from the catch block
+    const manifest: any = { id: "test", entry: "http://invalid-path.js" };
+    
+    await expect(loadPluginFromManifest(manifest)).rejects.toThrow(ManifestLoadError);
+    await expect(loadPluginFromManifest(manifest)).rejects.toThrow("Failed to load plugin");
+  });
+
+  // Note: Testing the actual instantiation logic of loadBundlePlugin 
+  // requires a real ESM module or a more sophisticated mock for the import() call.
+  // Given the constraints, we have verified the high-level orchestration.
+});

--- a/src/core/plugins/loaders/DeclarativePlugin.test.ts
+++ b/src/core/plugins/loaders/DeclarativePlugin.test.ts
@@ -204,4 +204,156 @@ describe("DeclarativePlugin", () => {
         expect(opts.color).toBe("#ff0000");
         expect(opts.labelText).toBe("Test");
     });
+
+    test("destroy clears context", async () => {
+        const plugin = new DeclarativePlugin(makeManifest());
+        await plugin.initialize({} as any);
+        // We can't strictly observe context, but we can verify it doesn't throw
+        expect(() => plugin.destroy()).not.toThrow();
+    });
+
+    test("fetch uses query auth if specified", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ features: [] }),
+        }));
+        
+        const originalEnv = process.env;
+        process.env = { ...originalEnv, API_KEY: "secret123" };
+
+        const plugin = new DeclarativePlugin(makeManifest({
+            dataSource: {
+                url: "https://api.example.com/data?type=test",
+                method: "GET",
+                pollInterval: 60000,
+                format: "geojson",
+                auth: { type: "query", key: "token", envVar: "API_KEY" }
+            }
+        }));
+
+        await plugin.fetch({ start: new Date(), end: new Date() });
+
+        expect(fetch).toHaveBeenCalledWith(
+            "https://api.example.com/data?type=test&token=secret123",
+            expect.any(Object)
+        );
+
+        process.env = originalEnv;
+    });
+
+    test("fetch does not use query auth if envVar is missing", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ features: [] }),
+        }));
+        
+        const originalEnv = process.env;
+        process.env = { ...originalEnv };
+        delete process.env.MISSING_KEY;
+
+        const plugin = new DeclarativePlugin(makeManifest({
+            dataSource: {
+                url: "https://api.example.com/data",
+                method: "GET",
+                pollInterval: 60000,
+                format: "geojson",
+                auth: { type: "query", key: "token", envVar: "MISSING_KEY" }
+            }
+        }));
+        
+        await plugin.fetch({ start: new Date(), end: new Date() });
+        
+        expect(fetch).toHaveBeenCalledWith(
+            "https://api.example.com/data",
+            expect.any(Object)
+        );
+        
+        process.env = originalEnv;
+    });
+
+    test("fetch uses header auth if specified", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ features: [] }),
+        }));
+        
+        const originalEnv = process.env;
+        process.env = { ...originalEnv, HEADER_KEY: "bearer 123" };
+
+        const plugin = new DeclarativePlugin(makeManifest({
+            dataSource: {
+                url: "https://api.example.com/data",
+                method: "GET",
+                pollInterval: 60000,
+                format: "geojson",
+                auth: { type: "header", key: "Authorization", envVar: "HEADER_KEY" }
+            }
+        }));
+        
+        await plugin.fetch({ start: new Date(), end: new Date() });
+        
+        expect(fetch).toHaveBeenCalledWith(
+            "https://api.example.com/data",
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    "Authorization": "bearer 123"
+                })
+            })
+        );
+        
+        process.env = originalEnv;
+    });
+
+    test("fetch handles request body", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ features: [] }),
+        }));
+
+        const plugin = new DeclarativePlugin(makeManifest({
+            dataSource: {
+                url: "https://api.example.com/data",
+                method: "POST",
+                pollInterval: 60000,
+                format: "geojson",
+                body: { query: "test" }
+            }
+        }));
+        
+        await plugin.fetch({ start: new Date(), end: new Date() });
+        
+        expect(fetch).toHaveBeenCalledWith(
+            "https://api.example.com/data",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ query: "test" })
+            })
+        );
+    });
+
+    test("fetch returns empty if mapping is missing", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ features: [] }),
+        }));
+
+        const plugin = new DeclarativePlugin(makeManifest({
+            fieldMapping: undefined
+        }));
+        
+        const result = await plugin.fetch({ start: new Date(), end: new Date() });
+        expect(result).toEqual([]);
+    });
+
+    test("renderEntity returns billboard correctly", () => {
+        const plugin = new DeclarativePlugin(makeManifest({
+            rendering: {
+                entityType: "billboard",
+                icon: "/icon.png"
+            }
+        }));
+        const opts = plugin.renderEntity({} as any);
+        expect(opts.type).toBe("billboard");
+        expect(opts.iconUrl).toBe("/icon.png");
+    });
 });

--- a/src/core/plugins/loaders/getNestedValue.test.ts
+++ b/src/core/plugins/loaders/getNestedValue.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "vitest";
+import fc from "fast-check";
 import { getNestedValue } from "./getNestedValue";
 
 describe("getNestedValue", () => {
@@ -44,5 +45,50 @@ describe("getNestedValue", () => {
     test("handles string values at path", () => {
         const obj = { properties: { mag: "5.2" } };
         expect(getNestedValue(obj, "properties.mag")).toBe("5.2");
+    });
+
+    describe("Property-based testing", () => {
+        test("never throws an exception regardless of object structure or path", () => {
+            fc.assert(
+                fc.property(
+                    fc.object(),
+                    fc.string(),
+                    (obj, path) => {
+                        // The core property: getNestedValue should be safe and never throw
+                        // It should either return a value or undefined
+                        try {
+                            getNestedValue(obj, path);
+                            return true;
+                        } catch (e) {
+                            return false; // Should never reach here
+                        }
+                    }
+                ),
+                { numRuns: 1000 }
+            );
+        });
+
+        test("always returns undefined for empty path if object is truthy", () => {
+            fc.assert(
+                fc.property(
+                    fc.object(),
+                    (obj) => {
+                        expect(getNestedValue(obj, "")).toBeUndefined();
+                    }
+                )
+            );
+        });
+
+        test("always returns undefined when object is null or undefined", () => {
+            fc.assert(
+                fc.property(
+                    fc.string(),
+                    (path) => {
+                        expect(getNestedValue(null, path)).toBeUndefined();
+                        expect(getNestedValue(undefined, path)).toBeUndefined();
+                    }
+                )
+            );
+        });
     });
 });

--- a/src/core/plugins/loaders/mapGeoJsonToEntities.test.ts
+++ b/src/core/plugins/loaders/mapGeoJsonToEntities.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from "vitest";
+import { mapGeoJsonToEntities } from "./mapGeoJsonToEntities";
+
+describe("mapGeoJsonToEntities", () => {
+    test("handles valid geojson with full mapping", () => {
+        const data = {
+            features: [
+                {
+                    id: "feat-1",
+                    geometry: { type: "Point", coordinates: [174, -36, 10] },
+                    properties: { speed: 100, heading: 90, time: "2026-05-14T00:00:00Z", label: "Test" }
+                }
+            ]
+        };
+
+        const entities = mapGeoJsonToEntities(data, {
+            id: "id",
+            latitude: "geometry.coordinates[1]",
+            longitude: "geometry.coordinates[0]",
+            altitude: "geometry.coordinates[2]",
+            speed: "properties.speed",
+            heading: "properties.heading",
+            timestamp: "properties.time",
+            label: "properties.label",
+            properties: { custom: "properties.speed" }
+        }, "plugin1");
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].altitude).toBe(10);
+        expect(entities[0].speed).toBe(100);
+        expect(entities[0].heading).toBe(90);
+        expect(entities[0].timestamp.toISOString()).toBe("2026-05-14T00:00:00.000Z");
+        expect(entities[0].properties.custom).toBe(100);
+    });
+
+    test("handles missing properties definition", () => {
+        const data = {
+            features: [
+                {
+                    geometry: { type: "Point", coordinates: [174, -36] },
+                    properties: {}
+                }
+            ]
+        };
+
+        const entities = mapGeoJsonToEntities(data, {
+            id: "id",
+            latitude: "geometry.coordinates[1]",
+            longitude: "geometry.coordinates[0]",
+        }, "plugin1");
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].properties).toEqual({});
+        expect(entities[0].id).toBe("plugin1-0"); // fallback to index
+    });
+
+    test("handles asNumber edge cases (null, non-finite)", () => {
+        const data = {
+            features: [
+                {
+                    id: "feat-2",
+                    geometry: { type: "Point", coordinates: [174, -36] },
+                    properties: { speed: null, heading: "NaN", alt: "Infinity" }
+                }
+            ]
+        };
+
+        const entities = mapGeoJsonToEntities(data, {
+            id: "id",
+            latitude: "geometry.coordinates[1]",
+            longitude: "geometry.coordinates[0]",
+            speed: "properties.speed",
+            heading: "properties.heading",
+            altitude: "properties.alt"
+        }, "plugin1");
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].speed).toBeUndefined(); // null -> undefined
+        expect(entities[0].heading).toBeUndefined(); // NaN -> undefined
+        expect(entities[0].altitude).toBeUndefined(); // Infinity -> undefined
+    });
+
+    test("handles parseTimestamp edge cases (invalid string, fallback)", () => {
+        const data = {
+            features: [
+                {
+                    geometry: { type: "Point", coordinates: [174, -36] },
+                    properties: { time1: "invalid-date", time2: null }
+                }
+            ]
+        };
+
+        const entities = mapGeoJsonToEntities(data, {
+            id: "id",
+            latitude: "geometry.coordinates[1]",
+            longitude: "geometry.coordinates[0]",
+            timestamp: "properties.time1"
+        }, "plugin1");
+
+        expect(entities).toHaveLength(1);
+        // Invalid string falls back to current date, we just check it's a valid date
+        expect(entities[0].timestamp).toBeInstanceOf(Date);
+        expect(isNaN(entities[0].timestamp.getTime())).toBe(false);
+
+        const entities2 = mapGeoJsonToEntities(data, {
+            id: "id",
+            latitude: "geometry.coordinates[1]",
+            longitude: "geometry.coordinates[0]",
+            timestamp: "properties.time2"
+        }, "plugin1");
+
+        expect(entities2).toHaveLength(1);
+        expect(entities2[0].timestamp).toBeInstanceOf(Date);
+        expect(isNaN(entities2[0].timestamp.getTime())).toBe(false);
+    });
+});

--- a/src/core/plugins/loaders/mapJsonToEntities.test.ts
+++ b/src/core/plugins/loaders/mapJsonToEntities.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "vitest";
+import { mapJsonToEntities } from "./mapJsonToEntities";
+
+describe("mapJsonToEntities", () => {
+    test("handles arrayPath resolution", () => {
+        const data = {
+            wrapper: {
+                items: [
+                    { id: 1, lat: 10, lon: 20 }
+                ]
+            }
+        };
+
+        const entities = mapJsonToEntities(data, {
+            id: "id",
+            latitude: "lat",
+            longitude: "lon"
+        }, "plugin1", "wrapper.items");
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].id).toBe("plugin1-1");
+    });
+
+    test("handles non-array resolution gracefully", () => {
+        const data = { wrapper: { items: "not-an-array" } };
+
+        const entities = mapJsonToEntities(data, {
+            id: "id",
+            latitude: "lat",
+            longitude: "lon"
+        }, "plugin1", "wrapper.items");
+
+        expect(entities).toEqual([]);
+    });
+
+    test("handles asNumber and parseTimestamp edge cases", () => {
+        const data = [
+            { id: 1, lat: 10, lon: 20, speed: null, alt: "Infinity", time: "invalid-date" }
+        ];
+
+        const entities = mapJsonToEntities(data, {
+            id: "id",
+            latitude: "lat",
+            longitude: "lon",
+            speed: "speed",
+            altitude: "alt",
+            timestamp: "time"
+        }, "plugin1");
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].speed).toBeUndefined();
+        expect(entities[0].altitude).toBeUndefined();
+        expect(entities[0].timestamp).toBeInstanceOf(Date);
+        expect(isNaN(entities[0].timestamp.getTime())).toBe(false);
+    });
+
+    test("skips items missing lat or lon", () => {
+        const data = [
+            { id: 1, lat: 10 }, // missing lon
+            { id: 2, lon: 20 }, // missing lat
+            { id: 3, lat: null, lon: 20 }
+        ];
+
+        const entities = mapJsonToEntities(data, {
+            id: "id",
+            latitude: "lat",
+            longitude: "lon"
+        }, "plugin1");
+
+        expect(entities).toEqual([]);
+    });
+});

--- a/src/core/plugins/validateManifest.test.ts
+++ b/src/core/plugins/validateManifest.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { validateManifest } from "./validateManifest";
+
+describe("validateManifest", () => {
+  it("should validate a correct manifest", () => {
+    const manifest: any = {
+      id: "test-plugin",
+      name: "Test Plugin",
+      version: "1.0.0",
+      type: "data-layer",
+      trust: "verified",
+      capabilities: ["streaming"],
+      entry: "/plugins/test.js"
+    };
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should flag missing required fields", () => {
+    const result = validateManifest({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Missing required field: id");
+    expect(result.errors).toContain("Missing required field: name");
+    expect(result.errors).toContain("Missing required field: version");
+    expect(result.errors).toContain("Missing required field: entry");
+  });
+
+  it("should flag invalid entry URLs", () => {
+    const manifest: any = {
+      id: "p1", name: "n1", version: "1", type: "data-layer", trust: "verified", 
+      capabilities: ["c1"], entry: "https://hacker.com/malicious.js"
+    };
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("entry URL must be a relative path, CDN, localhost, or worldwideview.dev domain");
+  });
+
+  it("should require extends for extensions", () => {
+    const manifest: any = {
+      id: "p1", name: "n1", version: "1", type: "extension", trust: "verified", 
+      capabilities: ["c1"], entry: "/p.js"
+    };
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Extension plugins require a non-empty extends array");
+  });
+});

--- a/src/core/state/StateSlices.test.ts
+++ b/src/core/state/StateSlices.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createGlobeSlice } from "./globeSlice";
+import { createLayersSlice } from "./layersSlice";
+import { createUISlice } from "./uiSlice";
+import { createDataSlice } from "./dataSlice";
+import { createConfigSlice } from "./configSlice";
+import { createFavoritesSlice } from "./favoritesSlice";
+import { createTimelineSlice } from "./timelineSlice";
+import { createFilterSlice } from "./filterSlice";
+
+describe("State Slices", () => {
+  describe("GlobeSlice", () => {
+    it("should set camera position", () => {
+      let state: any = {};
+      const set = (update: any) => { state = { ...state, ...update }; };
+      const slice = createGlobeSlice(set, () => ({} as any), {} as any);
+      
+      slice.setCameraPosition(10, 20, 30);
+      expect(state.cameraLat).toBe(10);
+      expect(state.cameraLon).toBe(20);
+      expect(state.cameraAlt).toBe(30);
+    });
+  });
+
+  describe("LayersSlice", () => {
+    it("should toggle layer", () => {
+      let state: any = { layers: { "p1": { enabled: false } } };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createLayersSlice(set, () => state as any, {} as any);
+      
+      slice.toggleLayer("p1");
+      expect(state.layers["p1"].enabled).toBe(true);
+    });
+
+    it("should init layer if missing", () => {
+      let state: any = { layers: {} };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createLayersSlice(set, () => state as any, {} as any);
+      
+      slice.initLayer("p2", true);
+      expect(state.layers["p2"]).toEqual({ enabled: true, entityCount: 0, loading: false });
+    });
+  });
+
+  describe("UISlice", () => {
+    beforeEach(() => {
+      vi.stubGlobal("localStorage", {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+      });
+      vi.stubGlobal("document", {
+        documentElement: {
+          setAttribute: vi.fn(),
+        },
+      });
+    });
+
+    it("should toggle theme", () => {
+      let state: any = { theme: "black" };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createUISlice(set, () => state as any, {} as any);
+      
+      slice.toggleTheme();
+      expect(state.theme).toBe("light");
+      expect(document.documentElement.setAttribute).toHaveBeenCalledWith("data-theme", "light");
+    });
+
+    it("should add floating stream", () => {
+      let state: any = { floatingStreams: [] };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createUISlice(set, () => state as any, {} as any);
+      
+      slice.addFloatingStream({ id: "s1", label: "Stream 1", streamUrl: "url", isIframe: false });
+      expect(state.floatingStreams.length).toBe(1);
+      expect(state.floatingStreams[0].id).toBe("s1");
+    });
+  });
+
+  describe("DataSlice", () => {
+    it("should set entities and keep selectedEntity fresh", () => {
+      let state: any = { 
+        entitiesByPlugin: {}, 
+        selectedEntity: { id: "1", pluginId: "p1", name: "Old Name" } 
+      };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const get = () => state;
+      const slice = createDataSlice(set, get, {} as any);
+
+      const newEntities = [{ id: "1", pluginId: "p1", name: "New Name" } as any];
+      slice.setEntities("p1", newEntities);
+
+      expect(state.entitiesByPlugin["p1"]).toEqual(newEntities);
+      expect(state.selectedEntity.name).toBe("New Name");
+    });
+  });
+
+  describe("ConfigSlice", () => {
+    it("should update data config", () => {
+      let state: any = { dataConfig: { cacheEnabled: false } };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createConfigSlice(set, () => ({} as any), {} as any);
+
+      slice.updateDataConfig({ cacheEnabled: true });
+      expect(state.dataConfig.cacheEnabled).toBe(true);
+    });
+
+    it("should set polling interval", () => {
+      let state: any = { dataConfig: { pollingIntervals: {} } };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createConfigSlice(set, () => ({} as any), {} as any);
+
+      slice.setPollingInterval("p1", 5000);
+      expect(state.dataConfig.pollingIntervals["p1"]).toBe(5000);
+    });
+  });
+
+  describe("FavoritesSlice", () => {
+    beforeEach(() => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true }) as any;
+      vi.stubGlobal("document", { cookie: "" });
+    });
+
+    it("should add favorite and trigger sync", () => {
+      let state: any = { favorites: [] };
+      const set = (update: any) => { state = { ...state, ...update }; };
+      const slice = createFavoritesSlice(set, () => state as any, {} as any);
+
+      const entity = { id: "e1", pluginId: "p1", label: "Entity 1" };
+      slice.addFavorite(entity as any, "Plugin 1");
+
+      expect(state.favorites.length).toBe(1);
+      expect(state.favorites[0].id).toBe("e1");
+      expect(global.fetch).toHaveBeenCalledWith("/api/user/favorites", expect.any(Object));
+    });
+
+    it("should sync to cookies in demo mode", () => {
+      // requires mocking isDemo to true
+    });
+  });
+
+  describe("TimelineSlice", () => {
+    it("should set time window and calculate range", () => {
+      let state: any = { timeWindow: "1h", timeRange: null };
+      const set = (update: any) => { state = { ...state, ...update }; };
+      const slice = createTimelineSlice(set, () => ({} as any), {} as any);
+
+      slice.setTimeWindow("6h");
+      expect(state.timeWindow).toBe("6h");
+      expect(state.timeRange.start).toBeInstanceOf(Date);
+      expect(state.timeRange.end).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("FilterSlice", () => {
+    it("should set and clear filters", () => {
+      let state: any = { filters: {} };
+      const set = (fn: any) => { state = { ...state, ...fn(state) }; };
+      const slice = createFilterSlice(set, () => ({} as any), {} as any);
+
+      slice.setFilter("p1", "f1", { type: "boolean", value: true });
+      expect(state.filters["p1"]["f1"]).toEqual({ type: "boolean", value: true });
+
+      slice.clearFilters("p1");
+      expect(state.filters["p1"]).toBeUndefined();
+    });
+  });
+});

--- a/src/core/state/configSlice.test.ts
+++ b/src/core/state/configSlice.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createConfigSlice, ConfigSlice } from './configSlice';
+
+describe('configSlice', () => {
+    let store: StoreApi<ConfigSlice>;
+
+    beforeEach(() => {
+        // Mock localStorage
+        vi.stubGlobal('localStorage', {
+            getItem: vi.fn(),
+            setItem: vi.fn(),
+            clear: vi.fn(),
+        });
+        
+        store = createStore<ConfigSlice>((set, get, api) => createConfigSlice(set as any, get as any, api as any));
+    });
+
+    it('initializes with default config', () => {
+        const state = store.getState();
+        expect(state.dataConfig.cacheEnabled).toBe(true);
+        expect(state.mapConfig.antiAliasing).toBe('fxaa');
+    });
+
+    it('updates data config', () => {
+        store.getState().updateDataConfig({ cacheEnabled: false, maxConcurrentRequests: 10 });
+        const state = store.getState();
+        
+        expect(state.dataConfig.cacheEnabled).toBe(false);
+        expect(state.dataConfig.maxConcurrentRequests).toBe(10);
+        // Ensure other properties are untouched
+        expect(state.dataConfig.cacheMaxAge).toBe(3600000);
+    });
+
+    it('updates map config and syncs baseLayerId to localStorage', () => {
+        store.getState().updateMapConfig({ showFps: true, baseLayerId: 'satellite' });
+        const state = store.getState();
+        
+        expect(state.mapConfig.showFps).toBe(true);
+        expect(state.mapConfig.baseLayerId).toBe('satellite');
+        // Ensure localStorage was called
+        expect(localStorage.setItem).toHaveBeenCalledWith('wwv_map_layer', 'satellite');
+    });
+
+    it('updates map config without baseLayerId does not touch localStorage', () => {
+        store.getState().updateMapConfig({ showFps: true });
+        
+        expect(localStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('sets polling interval for a plugin', () => {
+        store.getState().setPollingInterval('plugin-a', 5000);
+        const state = store.getState();
+        
+        expect(state.dataConfig.pollingIntervals['plugin-a']).toBe(5000);
+    });
+
+    it('updates plugin settings deeply', () => {
+        // Initial set
+        store.getState().updatePluginSettings('plugin-a', { param1: 'value1' });
+        expect(store.getState().dataConfig.pluginSettings['plugin-a']).toEqual({ param1: 'value1' });
+        
+        // Update set (should merge)
+        store.getState().updatePluginSettings('plugin-a', { param2: 'value2' });
+        expect(store.getState().dataConfig.pluginSettings['plugin-a']).toEqual({ 
+            param1: 'value1',
+            param2: 'value2'
+        });
+    });
+});

--- a/src/core/state/dataSlice.test.ts
+++ b/src/core/state/dataSlice.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createDataSlice, DataSlice } from './dataSlice';
+import type { GeoEntity } from '@/core/plugins/PluginTypes';
+
+// We need a mock store that includes selectedEntity to test the cross-slice update behavior
+interface MockAppStore extends DataSlice {
+    selectedEntity: GeoEntity | null;
+}
+
+describe('dataSlice', () => {
+    let store: StoreApi<MockAppStore>;
+
+    beforeEach(() => {
+        store = createStore<MockAppStore>((set, get, api) => {
+            const dataSlice = createDataSlice(set as any, get as any, api as any);
+            return {
+                ...dataSlice,
+                selectedEntity: null,
+            };
+        });
+    });
+
+    it('initializes with empty entities', () => {
+        expect(store.getState().entitiesByPlugin).toEqual({});
+    });
+
+    it('sets entities for a plugin', () => {
+        const mockEntities = [{ id: 'e1', pluginId: 'plugin-a' } as GeoEntity];
+        store.getState().setEntities('plugin-a', mockEntities);
+        
+        expect(store.getState().entitiesByPlugin['plugin-a']).toEqual(mockEntities);
+    });
+
+    it('updates selectedEntity if new data for the same entity arrives', () => {
+        // Initial selected entity
+        const oldEntity = { id: 'e1', pluginId: 'plugin-a', name: 'Old Name' } as any as GeoEntity;
+        store.setState({ selectedEntity: oldEntity });
+        
+        // New data arrives with updated name
+        const freshEntity = { id: 'e1', pluginId: 'plugin-a', name: 'New Name' } as any as GeoEntity;
+        store.getState().setEntities('plugin-a', [freshEntity]);
+        
+        expect(store.getState().selectedEntity).toEqual(freshEntity);
+    });
+
+    it('does not update selectedEntity if new data does not contain it', () => {
+        const oldEntity = { id: 'e1', pluginId: 'plugin-a', name: 'Old Name' } as any as GeoEntity;
+        store.setState({ selectedEntity: oldEntity });
+        
+        // New data arrives but the entity is missing
+        store.getState().setEntities('plugin-a', [{ id: 'e2', pluginId: 'plugin-a' } as GeoEntity]);
+        
+        expect(store.getState().selectedEntity).toEqual(oldEntity);
+    });
+
+    it('clears entities for a specific plugin', () => {
+        const mockEntitiesA = [{ id: 'e1', pluginId: 'plugin-a' } as GeoEntity];
+        const mockEntitiesB = [{ id: 'e2', pluginId: 'plugin-b' } as GeoEntity];
+        
+        store.getState().setEntities('plugin-a', mockEntitiesA);
+        store.getState().setEntities('plugin-b', mockEntitiesB);
+        
+        store.getState().clearEntities('plugin-a');
+        
+        expect(store.getState().entitiesByPlugin['plugin-a']).toBeUndefined();
+        expect(store.getState().entitiesByPlugin['plugin-b']).toEqual(mockEntitiesB);
+    });
+
+    it('gets all entities across plugins flattened', () => {
+        const mockEntitiesA = [{ id: 'e1', pluginId: 'plugin-a' } as GeoEntity];
+        const mockEntitiesB = [{ id: 'e2', pluginId: 'plugin-b' } as GeoEntity];
+        
+        store.getState().setEntities('plugin-a', mockEntitiesA);
+        store.getState().setEntities('plugin-b', mockEntitiesB);
+        
+        const all = store.getState().getAllEntities();
+        
+        expect(all).toHaveLength(2);
+        expect(all).toContainEqual(mockEntitiesA[0]);
+        expect(all).toContainEqual(mockEntitiesB[0]);
+    });
+});

--- a/src/core/state/favoritesSlice.test.ts
+++ b/src/core/state/favoritesSlice.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createFavoritesSlice, FavoritesSlice, FavoriteItem } from './favoritesSlice';
+import type { GeoEntity } from '@/core/plugins/PluginTypes';
+
+// Mock the edition module so we can control `isDemo`
+vi.mock('@/core/edition', () => ({
+    isDemo: true // We'll override this in specific tests using vi.mocked if needed, but for now we default to true to test cookie logic
+}));
+import { isDemo } from '@/core/edition';
+
+describe('favoritesSlice', () => {
+    let store: StoreApi<FavoritesSlice>;
+
+    beforeEach(() => {
+        // Reset document.cookie and mock fetch
+        Object.defineProperty(document, 'cookie', {
+            writable: true,
+            value: '',
+        });
+        
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({}));
+        
+        store = createStore<FavoritesSlice>((set, get, api) => createFavoritesSlice(set as any, get as any, api as any));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const mockEntity = { id: 'entity-1', pluginId: 'plugin-a', label: 'Test Entity' } as GeoEntity;
+
+    it('initializes with empty favorites', () => {
+        expect(store.getState().favorites).toEqual([]);
+    });
+
+    it('initializes favorites from a provided array', () => {
+        const initialFavs: FavoriteItem[] = [{ id: 'fav-1', pluginId: 'p-1', label: 'L1', pluginName: 'PN1', lastSeen: 100 }];
+        store.getState().initFavorites(initialFavs);
+        expect(store.getState().favorites).toEqual(initialFavs);
+    });
+
+    it('adds a new favorite, sets lastSeen, and syncs cookie in demo mode', () => {
+        const now = 1000000;
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+        
+        store.getState().addFavorite(mockEntity, 'Plugin A', 'icon-stub');
+        
+        const favs = store.getState().favorites;
+        expect(favs).toHaveLength(1);
+        expect(favs[0]).toEqual(expect.objectContaining({
+            id: 'entity-1',
+            pluginId: 'plugin-a',
+            label: 'Test Entity',
+            pluginName: 'Plugin A',
+            icon: 'icon-stub',
+            lastSeen: now
+        }));
+        
+        // Check cookie
+        expect(document.cookie).toContain('wwv_favorites');
+        
+        vi.useRealTimers();
+    });
+
+    it('prevents adding duplicate favorites by id', () => {
+        store.getState().addFavorite(mockEntity, 'Plugin A');
+        store.getState().addFavorite(mockEntity, 'Plugin A'); // Should be ignored
+        
+        expect(store.getState().favorites).toHaveLength(1);
+    });
+
+    it('removes a favorite and syncs cookie in demo mode', () => {
+        store.getState().addFavorite(mockEntity, 'Plugin A');
+        expect(store.getState().favorites).toHaveLength(1);
+        
+        store.getState().removeFavorite('entity-1');
+        expect(store.getState().favorites).toHaveLength(0);
+        
+        // Check cookie serialization updates
+        const decodedCookie = decodeURIComponent(document.cookie.replace('wwv_favorites=', ''));
+        expect(decodedCookie).toContain('[]'); // empty array after removal
+    });
+
+    describe('cloud mode (isDemo = false)', () => {
+        beforeEach(() => {
+            // Because isDemo is a constant exported from a module, standard vi.mock overriding per-test 
+            // for constants is tricky without resetModules. 
+            // We'll test the API logic by overriding it internally or just acknowledging we'd need to mock the import dynamically.
+            // For simplicity in this suite without full dynamic import mocking, we'll verify the fetch behavior 
+            // by overriding the constant property if possible, or using a separate module mock.
+        });
+        
+        // Note: To properly test fetch vs cookie branches, we'd typically inject `isDemo` 
+        // or test it in an isolated test file. Since we defaulted to `isDemo: true`, 
+        // fetch should NOT be called. Let's verify that.
+        it('does not call fetch API when in demo mode', () => {
+            store.getState().addFavorite(mockEntity, 'Plugin A');
+            expect(fetch).not.toHaveBeenCalled();
+            
+            store.getState().removeFavorite('entity-1');
+            expect(fetch).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/core/state/filterSlice.test.ts
+++ b/src/core/state/filterSlice.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createFilterSlice, FilterSlice } from './filterSlice';
+import type { FilterValue } from '@/core/plugins/PluginTypes';
+
+describe('filterSlice', () => {
+    let store: StoreApi<FilterSlice>;
+
+    beforeEach(() => {
+        store = createStore<FilterSlice>((set, get, api) => createFilterSlice(set as any, get as any, api as any));
+    });
+
+    it('initializes with empty filters', () => {
+        const state = store.getState();
+        expect(state.filters).toEqual({});
+    });
+
+    it('sets a specific filter for a plugin', () => {
+        const filterVal: FilterValue = { type: 'boolean', value: true };
+        store.getState().setFilter('plugin-a', 'show-active', filterVal);
+        
+        const state = store.getState();
+        expect(state.filters['plugin-a']).toBeDefined();
+        expect(state.filters['plugin-a']['show-active']).toEqual(filterVal);
+    });
+
+    it('updates an existing filter without overwriting other filters for the same plugin', () => {
+        const filterVal1: FilterValue = { type: 'boolean', value: true };
+        const filterVal2: FilterValue = { type: 'select', values: ['option1'] };
+        
+        store.getState().setFilter('plugin-a', 'filter-1', filterVal1);
+        store.getState().setFilter('plugin-a', 'filter-2', filterVal2);
+        
+        let state = store.getState();
+        expect(state.filters['plugin-a']['filter-1']).toEqual(filterVal1);
+        expect(state.filters['plugin-a']['filter-2']).toEqual(filterVal2);
+        
+        // Update filter-1
+        const updatedFilterVal1: FilterValue = { type: 'boolean', value: false };
+        store.getState().setFilter('plugin-a', 'filter-1', updatedFilterVal1);
+        
+        state = store.getState();
+        expect(state.filters['plugin-a']['filter-1']).toEqual(updatedFilterVal1);
+        expect(state.filters['plugin-a']['filter-2']).toEqual(filterVal2); // Still preserved
+    });
+
+    it('clears all filters for a specific plugin', () => {
+        store.getState().setFilter('plugin-a', 'f1', { type: 'boolean', value: true });
+        store.getState().setFilter('plugin-b', 'f2', { type: 'boolean', value: false });
+        
+        store.getState().clearFilters('plugin-a');
+        
+        const state = store.getState();
+        expect(state.filters['plugin-a']).toBeUndefined();
+        expect(state.filters['plugin-b']).toBeDefined(); // plugin-b untouched
+    });
+
+    it('clears all filters globally', () => {
+        store.getState().setFilter('plugin-a', 'f1', { type: 'boolean', value: true });
+        store.getState().setFilter('plugin-b', 'f2', { type: 'boolean', value: false });
+        
+        store.getState().clearAllFilters();
+        
+        const state = store.getState();
+        expect(state.filters).toEqual({});
+    });
+});

--- a/src/core/state/geojsonSlice.test.ts
+++ b/src/core/state/geojsonSlice.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createGeoJsonSlice, GeoJsonSlice, ImportedLayer } from './geojsonSlice';
+
+describe('geojsonSlice', () => {
+    let store: StoreApi<GeoJsonSlice>;
+
+    const mockLayer: ImportedLayer = {
+        id: 'layer-1',
+        name: 'Test Layer',
+        description: 'A test geojson layer',
+        color: '#ff0000',
+        visible: true,
+        featureCollection: { type: 'FeatureCollection', features: [] }
+    };
+
+    beforeEach(() => {
+        store = createStore<GeoJsonSlice>((set, get, api) => createGeoJsonSlice(set as any, get as any, api as any));
+    });
+
+    it('initializes with empty importedLayers', () => {
+        expect(store.getState().importedLayers).toEqual([]);
+    });
+
+    it('adds an imported layer', () => {
+        store.getState().addImportedLayer(mockLayer);
+        const layers = store.getState().importedLayers;
+        
+        expect(layers).toHaveLength(1);
+        expect(layers[0]).toEqual(mockLayer);
+    });
+
+    it('removes an imported layer by id', () => {
+        store.getState().addImportedLayer(mockLayer);
+        store.getState().addImportedLayer({ ...mockLayer, id: 'layer-2' });
+        
+        store.getState().removeImportedLayer('layer-1');
+        const layers = store.getState().importedLayers;
+        
+        expect(layers).toHaveLength(1);
+        expect(layers[0].id).toBe('layer-2');
+    });
+
+    it('toggles visibility of an imported layer', () => {
+        store.getState().addImportedLayer(mockLayer); // initially visible: true
+        
+        store.getState().toggleImportedLayerVisibility('layer-1');
+        expect(store.getState().importedLayers[0].visible).toBe(false);
+        
+        store.getState().toggleImportedLayerVisibility('layer-1');
+        expect(store.getState().importedLayers[0].visible).toBe(true);
+    });
+
+    it('updates specific fields of an imported layer', () => {
+        store.getState().addImportedLayer(mockLayer);
+        
+        store.getState().updateImportedLayer('layer-1', { 
+            name: 'Updated Name', 
+            color: '#00ff00' 
+        });
+        
+        const layer = store.getState().importedLayers[0];
+        expect(layer.name).toBe('Updated Name');
+        expect(layer.color).toBe('#00ff00');
+        // Unchanged fields remain the same
+        expect(layer.description).toBe('A test geojson layer');
+        expect(layer.visible).toBe(true);
+    });
+});

--- a/src/core/state/globeSlice.test.ts
+++ b/src/core/state/globeSlice.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createGlobeSlice, GlobeSlice } from './globeSlice';
+
+describe('globeSlice', () => {
+    let store: StoreApi<GlobeSlice>;
+
+    beforeEach(() => {
+        // Create an isolated vanilla store specifically for this slice
+        store = createStore<GlobeSlice>((set, get, api) => createGlobeSlice(set as any, get as any, api as any));
+    });
+
+    it('sets initial camera state correctly', () => {
+        const state = store.getState();
+        expect(state.cameraLat).toBe(20);
+        expect(state.cameraLon).toBe(0);
+        expect(state.cameraAlt).toBe(20000000);
+        expect(state.cameraHeading).toBe(0);
+        expect(state.cameraPitch).toBe(-90);
+        expect(state.cameraRoll).toBe(0);
+        expect(state.isAnimating).toBe(false);
+        expect(state.fps).toBe(0);
+    });
+
+    it('updates camera position atomically', () => {
+        store.getState().setCameraPosition(45, -90, 1000);
+        const state = store.getState();
+        
+        expect(state.cameraLat).toBe(45);
+        expect(state.cameraLon).toBe(-90);
+        expect(state.cameraAlt).toBe(1000);
+    });
+
+    it('resets orientation to defaults when not provided in position update', () => {
+        // First set custom orientation
+        store.getState().setCameraPosition(45, -90, 1000, 45, -45, 15);
+        // Then set without orientation
+        store.getState().setCameraPosition(50, -80, 2000);
+        const state = store.getState();
+        
+        expect(state.cameraHeading).toBe(0);
+        expect(state.cameraPitch).toBe(-90);
+        expect(state.cameraRoll).toBe(0);
+    });
+
+    it('updates custom orientation when provided', () => {
+        store.getState().setCameraPosition(45, -90, 1000, 180, -30, 45);
+        const state = store.getState();
+        
+        expect(state.cameraHeading).toBe(180);
+        expect(state.cameraPitch).toBe(-30);
+        expect(state.cameraRoll).toBe(45);
+    });
+
+    it('toggles animation state', () => {
+        store.getState().setAnimating(true);
+        expect(store.getState().isAnimating).toBe(true);
+        
+        store.getState().setAnimating(false);
+        expect(store.getState().isAnimating).toBe(false);
+    });
+
+    it('records frames per second', () => {
+        store.getState().setFps(60);
+        expect(store.getState().fps).toBe(60);
+    });
+});

--- a/src/core/state/layersSlice.test.ts
+++ b/src/core/state/layersSlice.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createLayersSlice, LayersSlice } from './layersSlice';
+
+describe('layersSlice', () => {
+    let store: StoreApi<LayersSlice>;
+
+    beforeEach(() => {
+        store = createStore<LayersSlice>((set, get, api) => createLayersSlice(set as any, get as any, api as any));
+    });
+
+    it('initializes with empty layers', () => {
+        const state = store.getState();
+        expect(state.layers).toEqual({});
+    });
+
+    it('initializes a new layer with default values', () => {
+        store.getState().initLayer('test-plugin');
+        const state = store.getState();
+        expect(state.layers['test-plugin']).toEqual({
+            enabled: false,
+            entityCount: 0,
+            loading: false
+        });
+    });
+
+    it('initializes a new layer with explicitly requested enabled status', () => {
+        store.getState().initLayer('test-plugin', true);
+        const state = store.getState();
+        expect(state.layers['test-plugin'].enabled).toBe(true);
+    });
+
+    it('does not overwrite an existing layer upon re-initialization', () => {
+        store.getState().initLayer('test-plugin', true);
+        store.getState().setEntityCount('test-plugin', 42);
+        
+        // Re-initialize
+        store.getState().initLayer('test-plugin', false);
+        const state = store.getState();
+        
+        // Should preserve previous state
+        expect(state.layers['test-plugin'].enabled).toBe(true);
+        expect(state.layers['test-plugin'].entityCount).toBe(42);
+    });
+
+    it('toggles layer enabled status', () => {
+        store.getState().initLayer('test-plugin', false);
+        
+        store.getState().toggleLayer('test-plugin');
+        expect(store.getState().layers['test-plugin'].enabled).toBe(true);
+        
+        store.getState().toggleLayer('test-plugin');
+        expect(store.getState().layers['test-plugin'].enabled).toBe(false);
+    });
+
+    it('explicitly sets layer enabled status', () => {
+        store.getState().initLayer('test-plugin', false);
+        
+        store.getState().setLayerEnabled('test-plugin', true);
+        expect(store.getState().layers['test-plugin'].enabled).toBe(true);
+        
+        store.getState().setLayerEnabled('test-plugin', true); // Should remain true
+        expect(store.getState().layers['test-plugin'].enabled).toBe(true);
+    });
+
+    it('updates entity count', () => {
+        store.getState().initLayer('test-plugin');
+        
+        store.getState().setEntityCount('test-plugin', 150);
+        expect(store.getState().layers['test-plugin'].entityCount).toBe(150);
+    });
+
+    it('updates loading status', () => {
+        store.getState().initLayer('test-plugin');
+        
+        store.getState().setLayerLoading('test-plugin', true);
+        expect(store.getState().layers['test-plugin'].loading).toBe(true);
+        
+        store.getState().setLayerLoading('test-plugin', false);
+        expect(store.getState().layers['test-plugin'].loading).toBe(false);
+    });
+});

--- a/src/core/state/timelineSlice.test.ts
+++ b/src/core/state/timelineSlice.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createTimelineSlice, TimelineSlice } from './timelineSlice';
+import type { TimeWindow } from '@/core/plugins/PluginTypes';
+
+describe('timelineSlice', () => {
+    let store: StoreApi<TimelineSlice>;
+
+    beforeEach(() => {
+        // Freeze time for consistent tests
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-13T12:00:00Z'));
+        
+        store = createStore<TimelineSlice>((set, get, api) => createTimelineSlice(set as any, get as any, api as any));
+    });
+
+    it('initializes with correct defaults', () => {
+        const state = store.getState();
+        expect(state.timeWindow).toBe('24h');
+        expect(state.isPlaying).toBe(false);
+        expect(state.playbackSpeed).toBe(1);
+        expect(state.isPlaybackMode).toBe(false);
+        expect(state.timelineAvailability).toEqual({});
+        
+        // timeRange should be 24h behind current time
+        const expectedStart = new Date(Date.now() - 86400000);
+        expect(state.timeRange.start.getTime()).toBe(expectedStart.getTime());
+        expect(state.timeRange.end.getTime()).toBe(Date.now());
+    });
+
+    it('updates time window and dynamically recalculates time range', () => {
+        store.getState().setTimeWindow('1h' as TimeWindow);
+        const state = store.getState();
+        
+        expect(state.timeWindow).toBe('1h');
+        const expectedStart = new Date(Date.now() - 3600000); // 1 hour
+        expect(state.timeRange.start.getTime()).toBe(expectedStart.getTime());
+    });
+
+    it('sets current time', () => {
+        const newTime = new Date('2026-05-13T10:00:00Z');
+        store.getState().setCurrentTime(newTime);
+        expect(store.getState().currentTime).toBe(newTime);
+    });
+
+    it('sets exact time range', () => {
+        const range = { start: new Date('2026-01-01'), end: new Date('2026-01-02') };
+        store.getState().setTimeRange(range);
+        expect(store.getState().timeRange).toEqual(range);
+    });
+
+    it('sets playback states', () => {
+        store.getState().setPlaying(true);
+        expect(store.getState().isPlaying).toBe(true);
+        
+        store.getState().setPlaybackSpeed(5);
+        expect(store.getState().playbackSpeed).toBe(5);
+        
+        store.getState().setPlaybackMode(true);
+        expect(store.getState().isPlaybackMode).toBe(true);
+        
+        store.getState().setPlaybackTime(10000);
+        expect(store.getState().playbackTime).toBe(10000);
+    });
+
+    it('sets timeline availability for plugins', () => {
+        const availability = [{ start: 100, end: 200 }];
+        store.getState().setTimelineAvailability('plugin-a', availability);
+        
+        expect(store.getState().timelineAvailability['plugin-a']).toEqual(availability);
+    });
+});

--- a/src/core/state/uiSlice.test.ts
+++ b/src/core/state/uiSlice.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createUISlice, UISlice, FloatingStream } from './uiSlice';
+import type { GeoEntity } from '@/core/plugins/PluginTypes';
+
+// Mock the analytics module to prevent actual tracking during tests
+vi.mock('@/lib/analytics', () => ({
+    trackEvent: vi.fn(),
+}));
+
+describe('uiSlice', () => {
+    let store: StoreApi<UISlice>;
+
+    beforeEach(() => {
+        // Reset local storage and document element
+        vi.stubGlobal('localStorage', {
+            getItem: vi.fn(),
+            setItem: vi.fn(),
+            clear: vi.fn(),
+        });
+        document.documentElement.removeAttribute('data-theme');
+        store = createStore<UISlice>((set, get, api) => createUISlice(set as any, get as any, api as any));
+    });
+
+    it('initializes with correct default state', () => {
+        const state = store.getState();
+        expect(state.leftSidebarOpen).toBe(true);
+        expect(state.rightSidebarOpen).toBe(false);
+        expect(state.configPanelOpen).toBe(true);
+        expect(state.filterPanelOpen).toBe(false);
+        expect(state.selectedEntity).toBeNull();
+        expect(state.floatingStreams).toEqual([]);
+        expect(state.activeConfigTab).toBe('filters');
+        expect(state.timelineOpen).toBe(true);
+    });
+
+    it('toggles simple boolean states', () => {
+        store.getState().toggleLeftSidebar();
+        expect(store.getState().leftSidebarOpen).toBe(false);
+
+        store.getState().toggleRightSidebar();
+        expect(store.getState().rightSidebarOpen).toBe(true);
+
+        store.getState().toggleConfigPanel();
+        expect(store.getState().configPanelOpen).toBe(false);
+
+        store.getState().toggleFilterPanel();
+        expect(store.getState().filterPanelOpen).toBe(true);
+
+        store.getState().setTimelineOpen(false);
+        expect(store.getState().timelineOpen).toBe(false);
+
+        store.getState().setFeedbackDialogOpen(true);
+        expect(store.getState().feedbackDialogOpen).toBe(true);
+    });
+
+    it('toggles themes cyclically and updates DOM/localStorage', () => {
+        // Start with black
+        store.getState().setTheme('black');
+        
+        store.getState().toggleTheme();
+        expect(store.getState().theme).toBe('light');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+        expect(localStorage.setItem).toHaveBeenCalledWith('wwv-theme', 'light');
+
+        store.getState().toggleTheme();
+        expect(store.getState().theme).toBe('legacy');
+
+        store.getState().toggleTheme();
+        expect(store.getState().theme).toBe('dark');
+
+        store.getState().toggleTheme();
+        expect(store.getState().theme).toBe('black');
+    });
+
+    it('sets specific theme directly', () => {
+        store.getState().setTheme('legacy');
+        expect(store.getState().theme).toBe('legacy');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('legacy');
+    });
+
+    it('handles setting selected entity and related UI panels', () => {
+        const mockEntity = { id: 'e1', pluginId: 'test' } as GeoEntity;
+        
+        // When setting entity, right sidebar and config should open
+        store.getState().setSelectedEntity(mockEntity);
+        let state = store.getState();
+        expect(state.selectedEntity).toEqual(mockEntity);
+        expect(state.rightSidebarOpen).toBe(true);
+        expect(state.configPanelOpen).toBe(true);
+        expect(state.mobileRightPanelGlow).toBe(true);
+        expect(state.activeConfigTab).toBe('intel');
+
+        // When unsetting entity, panels should stay open, but glow and entity reset
+        store.getState().setSelectedEntity(null);
+        state = store.getState();
+        expect(state.selectedEntity).toBeNull();
+        expect(state.rightSidebarOpen).toBe(true); // Should remain true
+        expect(state.configPanelOpen).toBe(true); // Should remain true
+        expect(state.mobileRightPanelGlow).toBe(false);
+    });
+
+    it('sets hovered entity and position', () => {
+        const mockEntity = { id: 'e2', pluginId: 'test' } as GeoEntity;
+        store.getState().setHoveredEntity(mockEntity, { x: 100, y: 200 });
+        
+        const state = store.getState();
+        expect(state.hoveredEntity).toEqual(mockEntity);
+        expect(state.hoveredScreenPosition).toEqual({ x: 100, y: 200 });
+    });
+
+    it('manages floating streams', () => {
+        const newStream: Omit<FloatingStream, "position" | "size"> = {
+            id: 'stream-1',
+            streamUrl: 'http://test',
+            isIframe: true,
+            label: 'Test Stream'
+        };
+
+        // Add
+        store.getState().addFloatingStream(newStream);
+        let state = store.getState();
+        expect(state.floatingStreams.length).toBe(1);
+        expect(state.floatingStreams[0].id).toBe('stream-1');
+        // Check default size and position
+        expect(state.floatingStreams[0].size).toEqual({ width: 400, height: 260 });
+
+        // Update
+        store.getState().updateFloatingStream('stream-1', { isMinimized: true });
+        state = store.getState();
+        expect(state.floatingStreams[0].isMinimized).toBe(true);
+
+        // Prevent duplicates
+        store.getState().addFloatingStream(newStream);
+        expect(store.getState().floatingStreams.length).toBe(1);
+
+        // Remove
+        store.getState().removeFloatingStream('stream-1');
+        expect(store.getState().floatingStreams.length).toBe(0);
+    });
+
+    it('manages error toasts', () => {
+        store.getState().showErrorToast('Test error message');
+        expect(store.getState().errorToastMessage).toBe('Test error message');
+
+        store.getState().clearErrorToast();
+        expect(store.getState().errorToastMessage).toBeNull();
+    });
+
+    it('manages mobile panels and glow', () => {
+        store.getState().setOpenMobilePanel('right');
+        expect(store.getState().openMobilePanel).toBe('right');
+        expect(store.getState().mobileRightPanelGlow).toBe(false); // Should clear glow when opening right panel
+
+        // Clicking same panel closes it
+        store.getState().setOpenMobilePanel('right');
+        expect(store.getState().openMobilePanel).toBeNull();
+    });
+});

--- a/src/lib/AuthConfig.test.ts
+++ b/src/lib/AuthConfig.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { authConfig } from "./auth.config";
+import { isDemo } from "@/core/edition";
+
+vi.mock("@/core/edition", () => ({
+  isDemo: false,
+}));
+
+describe("authConfig", () => {
+  const authorized = authConfig.callbacks?.authorized as any;
+
+  it("should allow access to API routes without auth", () => {
+    const mockRequest = { nextUrl: { pathname: "/api/test" } };
+    expect(authorized({ auth: null, request: mockRequest })).toBe(true);
+  });
+
+  it("should allow access to setup and login pages without auth", () => {
+    expect(authorized({ auth: null, request: { nextUrl: { pathname: "/setup" } } })).toBe(true);
+    expect(authorized({ auth: null, request: { nextUrl: { pathname: "/login" } } })).toBe(true);
+  });
+
+  it("should block access to dashboard if not logged in (non-demo)", () => {
+    const mockRequest = { nextUrl: { pathname: "/" } };
+    expect(authorized({ auth: null, request: mockRequest })).toBe(false);
+  });
+
+  it("should allow access to dashboard if logged in (non-demo)", () => {
+    const mockRequest = { nextUrl: { pathname: "/" } };
+    const mockAuth = { user: { name: "test" } };
+    expect(authorized({ auth: mockAuth, request: mockRequest })).toBe(true);
+  });
+
+  it("should allow access to dashboard if in demo mode", () => {
+    // Manually override mock behavior if possible, or use a separate file
+    // For this test we'll assume isDemo returns true (requires different mock setup)
+  });
+});

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { trackEvent } from "./analytics";
+
+describe("analytics", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", { umami: { track: vi.fn() } });
+  });
+
+  it("should call window.umami.track if available", () => {
+    trackEvent("test-event", { key: "val" });
+    expect(window.umami!.track).toHaveBeenCalledWith("test-event", { key: "val" });
+  });
+
+  it("should not throw if umami is missing", () => {
+    vi.stubGlobal("window", {});
+    expect(() => trackEvent("test")).not.toThrow();
+  });
+
+  it("should not throw if track fails", () => {
+    vi.stubGlobal("window", {
+      umami: {
+        track: () => { throw new Error("Blocked"); }
+      }
+    });
+    expect(() => trackEvent("test")).not.toThrow();
+  });
+});

--- a/src/lib/geojson/converter.test.ts
+++ b/src/lib/geojson/converter.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { convertToGeoJson } from "./converter";
 import { detectGeoFields } from "./fieldDetector";
+import fc from "fast-check";
 
 // ── Field Detector ──────────────────────────────────────────────
 
@@ -133,5 +134,35 @@ describe("convertToGeoJson", () => {
     expect(result.features[1].properties).toEqual({
       category: "nature", active: false,
     });
+  });
+
+  test("property test: correctly converts arrays of random objects with valid auto-detected coords", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            lat: fc.double({ min: -90, max: 90, noNaN: true }),
+            lon: fc.double({ min: -180, max: 180, noNaN: true }),
+            randomProp: fc.string(),
+          }),
+          { minLength: 1, maxLength: 100 }
+        ),
+        (data) => {
+          const result = convertToGeoJson(data);
+          expect(result.type).toBe("FeatureCollection");
+          expect(result.features).toHaveLength(data.length);
+
+          for (let i = 0; i < data.length; i++) {
+            const f = result.features[i];
+            const row = data[i];
+            expect(f.geometry.type).toBe("Point");
+            expect(f.geometry.coordinates).toEqual([row.lon, row.lat]);
+            expect(f.properties.randomProp).toBe(row.randomProp);
+            expect(f.properties).not.toHaveProperty("lat");
+            expect(f.properties).not.toHaveProperty("lon");
+          }
+        }
+      )
+    );
   });
 });

--- a/src/lib/geojson/normalizer.test.ts
+++ b/src/lib/geojson/normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { normalizeToGeoJson } from "./normalizer";
+import fc from "fast-check";
 
 describe("normalizeToGeoJson", () => {
   test("passes through a valid FeatureCollection", () => {
@@ -160,5 +161,56 @@ describe("normalizeToGeoJson", () => {
 
   test("throws on unrecognized format", () => {
     expect(() => normalizeToGeoJson({ foo: "bar" })).toThrow("Unrecognized");
+  });
+
+  test("handles MultiPolygon geometry", () => {
+    const input = {
+      type: "Feature",
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [[[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]],
+      },
+      properties: {},
+    };
+    const result = normalizeToGeoJson(input);
+    expect(result.geometryTypes).toEqual(["MultiPolygon"]);
+  });
+
+  test("throws when input parses to a non-object/array", () => {
+    expect(() => normalizeToGeoJson(123)).toThrow("Input must be a JSON object or array");
+    expect(() => normalizeToGeoJson("123")).toThrow("Input must be a JSON object or array");
+  });
+
+  test("property: handles random coordinate inputs autonomously", () => {
+    // This property test autonomously generates random float pairs to test edge-cases
+    fc.assert(
+      fc.property(
+        fc.float({ noDefaultInfinity: true, noNaN: true }),
+        fc.float({ noDefaultInfinity: true, noNaN: true }),
+        (lon, lat) => {
+          const input = {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [lon, lat] },
+            properties: {},
+          };
+
+          try {
+            const result = normalizeToGeoJson(input);
+            // normalizer skips coordinates outside valid bounds [-180, 180], [-90, 90]
+            if (lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+              expect(result.skippedCount).toBe(1);
+            } else {
+              expect(result.skippedCount).toBe(0);
+              expect(result.collection.features[0].geometry.coordinates).toEqual([lon, lat]);
+            }
+          } catch (e: any) {
+            // Normalizer explicitly throws if ALL features are skipped
+            if (e.message !== "No features with valid geometry found.") {
+              throw e;
+            }
+          }
+        }
+      )
+    );
   });
 });

--- a/src/lib/marketplace/cors.test.ts
+++ b/src/lib/marketplace/cors.test.ts
@@ -10,6 +10,11 @@ function fakeRequest(origin?: string): Request {
 
 describe("CORS utility", () => {
     describe("corsHeaders", () => {
+        it("returns empty object if no origin is provided", () => {
+            const headers = corsHeaders(fakeRequest(""));
+            expect(headers).toEqual({});
+        });
+
         it("returns allowed origin for localhost:3001", () => {
             const headers = corsHeaders(fakeRequest("http://localhost:3001"));
             expect(headers["Access-Control-Allow-Origin"]).toBe("http://localhost:3001");

--- a/src/lib/marketplace/marketplaceToken.test.ts
+++ b/src/lib/marketplace/marketplaceToken.test.ts
@@ -97,4 +97,25 @@ describe("marketplaceToken", () => {
             await expect(verifyMarketplaceToken(noSub)).rejects.toThrow("subject");
         });
     });
+
+    describe("revokeMarketplaceToken", () => {
+        it("revokes a token and rejects it on verify", async () => {
+            const { revokeMarketplaceToken } = await import("./marketplaceToken");
+            const token = await issueMarketplaceToken(TEST_USER_ID);
+            const payload = await verifyMarketplaceToken(token);
+            
+            expect(payload.jti).toBeDefined();
+            
+            // Revoke it
+            revokeMarketplaceToken(payload.jti!);
+            
+            // Now it should throw
+            await expect(verifyMarketplaceToken(token)).rejects.toThrow("revoked");
+        });
+
+        it("does nothing when passed an empty jti", async () => {
+            const { revokeMarketplaceToken } = await import("./marketplaceToken");
+            expect(() => revokeMarketplaceToken("")).not.toThrow();
+        });
+    });
 });

--- a/src/lib/origin.test.ts
+++ b/src/lib/origin.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getRequestOrigin } from "./origin";
+
+describe("getRequestOrigin", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it("should prioritize x-forwarded-host", () => {
+    const headers = new Map([
+      ["x-forwarded-host", "myapp.com"],
+      ["x-forwarded-proto", "https"]
+    ]);
+    const mockRequest: any = {
+      headers: { get: (key: string) => headers.get(key) },
+      nextUrl: { origin: "http://0.0.0.0:3000" },
+      url: "http://0.0.0.0:3000/api"
+    };
+
+    const origin = getRequestOrigin(mockRequest);
+    expect(origin).toBe("https://myapp.com");
+  });
+
+  it("should fall back to host header if no forwarded host", () => {
+    const headers = new Map([
+      ["host", "localhost:3000"]
+    ]);
+    const mockRequest: any = {
+      headers: { get: (key: string) => headers.get(key) },
+      nextUrl: { origin: "http://0.0.0.0:3000" },
+    };
+
+    const origin = getRequestOrigin(mockRequest);
+    expect(origin).toBe("http://localhost:3000");
+  });
+
+  it("should fall back to env var if headers are missing or invalid", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://cloud.wwv.dev";
+    const headers = new Map([
+      ["host", "0.0.0.0:3000"]
+    ]);
+    const mockRequest: any = {
+      headers: { get: (key: string) => headers.get(key) },
+      nextUrl: { origin: "http://0.0.0.0:3000" },
+    };
+
+    const origin = getRequestOrigin(mockRequest);
+    expect(origin).toBe("https://cloud.wwv.dev");
+  });
+
+  it("should replace 0.0.0.0 with localhost as last resort", () => {
+    const mockRequest: any = {
+      headers: { get: () => null },
+      nextUrl: { origin: "http://0.0.0.0:3000" },
+    };
+
+    const origin = getRequestOrigin(mockRequest);
+    expect(origin).toBe("http://localhost:3000");
+  });
+});

--- a/src/lib/rateLimit.test.ts
+++ b/src/lib/rateLimit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { RateLimiter, getClientIp } from "./rateLimit";
+import fc from "fast-check";
 
 describe("RateLimiter", () => {
     let limiter: RateLimiter;
@@ -60,6 +61,20 @@ describe("RateLimiter", () => {
             }, 60);
         });
     });
+
+    it("cleans up expired entries", () => {
+        const localLimiter = new RateLimiter({ windowMs: 100, maxRequests: 5 });
+        localLimiter.check("ip-cleanup");
+        
+        // Force the store resetAt to be in the past
+        const entry = (localLimiter as any).store.get("ip-cleanup");
+        entry.resetAt = Date.now() - 1000;
+        
+        (localLimiter as any).cleanup();
+        
+        expect((localLimiter as any).store.has("ip-cleanup")).toBe(false);
+        localLimiter.destroy();
+    });
 });
 
 describe("getClientIp", () => {
@@ -80,5 +95,34 @@ describe("getClientIp", () => {
     it("returns 'unknown' when no IP headers present", () => {
         const req = new Request("http://localhost");
         expect(getClientIp(req)).toBe("unknown");
+    });
+
+    it("property test: x-forwarded-for always returns the first IP in a list", () => {
+        fc.assert(
+            fc.property(
+                fc.array(fc.ipV4(), { minLength: 1, maxLength: 10 }),
+                (ips) => {
+                    const headerValue = ips.join(", ");
+                    const req = new Request("http://localhost", {
+                        headers: { "x-forwarded-for": headerValue },
+                    });
+                    expect(getClientIp(req)).toBe(ips[0]);
+                }
+            )
+        );
+    });
+
+    it("property test: x-real-ip is used when x-forwarded-for is absent", () => {
+        fc.assert(
+            fc.property(
+                fc.ipV4(),
+                (ip) => {
+                    const req = new Request("http://localhost", {
+                        headers: { "x-real-ip": ip },
+                    });
+                    expect(getClientIp(req)).toBe(ip);
+                }
+            )
+        );
     });
 });

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "pnpm",
+  "testRunner": "vitest",
+  "plugins": ["@stryker-mutator/vitest-runner"],
+  "reporters": ["html", "clear-text", "progress"],
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": true,
+  "mutate": [
+    "src/core/**/*.ts",
+    "src/core/**/*.tsx",
+    "src/lib/**/*.ts",
+    "!src/**/*.test.ts",
+    "!src/**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Why

Four overlapping test-infra PRs (#113, #114, #117, #118) each contributed real value but also significant redundancy with each other and with code already on main. Consolidating them into a single coherent batch removes:

- 8 collisions in #113 with tests already on main (`CacheLayer`, `DataBus`, `PollingManager`, `cors`, `marketplaceToken`, `repository`, `rateLimit`, `edition`, `seedDefaultPlugins`)
- A naming inconsistency (#113 used `.spec.ts`, everywhere else uses `.test.ts`)
- A filename collision (`stryker.conf.json` in #114 vs `stryker.config.json` in #117)
- Conflicting stryker config decisions (different `mutate` scope, different `coverageAnalysis` mode)
- The `package.json` `version`-bump hairball (three of the PRs each bumped to different versions)
- A few tautological tests that pass on "the standard library still works"

Same shape and bar as #110 / #111: small, focused, behavior-pinning tests. Each test answers one question — *what specific regression does it catch that I'd otherwise find from a user bug report?*

## Verification

```
Test Files  38 passed (38)
Tests       271 passed (271)
```

137 tests on `main` before this PR; +134 from this consolidation, no regressions, `pnpm exec tsc --noEmit` clean.

## What's in the PR

### Stryker mutation-testing setup

- **`stryker.config.json`** — hybrid config: `coverageAnalysis: "perTest"` (5–10× speedup), `ignoreStatic: true` (drops false-positive mutants in module-load code), `mutate` scope of `src/core/**` + `src/lib/**` covering logic-heavy layers without dragging the React component surface into noise.
- **`.github/workflows/mutation-testing.yml`** — runs Stryker weekly (Sundays 22:00 US Eastern / 03:00 UTC Monday) plus `workflow_dispatch` for on-demand. Per-PR triggering would be too expensive (10–30 min per run even with `perTest`).
- **`package.json`** — adds `@stryker-mutator/core`, `@stryker-mutator/vitest-runner`, and `fast-check` as devDeps. New `test:mutate` script.

### New test files (22)

| Area | Files |
|------|-------|
| Plugin lifecycle | `PluginManager.test.ts`, `loadPluginFromManifest.test.ts`, `validateManifest.test.ts`, `mapGeoJsonToEntities.test.ts`, `mapJsonToEntities.test.ts` |
| Data layer | `DataUtils.test.ts`, `WsClient.test.ts` |
| State (Zustand slices) | `StateSlices.test.ts`, `configSlice.test.ts`, `dataSlice.test.ts`, `favoritesSlice.test.ts`, `filterSlice.test.ts`, `geojsonSlice.test.ts`, `globeSlice.test.ts`, `layersSlice.test.ts`, `timelineSlice.test.ts`, `uiSlice.test.ts` |
| Filters | `filterEngine.test.ts` |
| Library | `AuthConfig.test.ts`, `analytics.test.ts`, `origin.test.ts` |

`PluginManager.test.ts` is the centerpiece: 11 tests pinning the orchestrator's contract — register/enable/disable observable behavior, `handleDataUpdate` data flow contract, `getAllEntities` filters by enabled, `updateTimeRange` reaches enabled plugins, `destroy` teardown, `togglePlugin` state flip, `loadFromManifest` delegation. Mocks only the heavy external bits (Zustand store, analytics, engine-URL resolver); lets real `dataBus`/`cacheLayer`/`pollingManager` through so the test asserts on *observable* events and state, not internal mock calls. Bugs we hit in development (aviation cache-wipe, layer-toggle sync) are pinned by these.

### Test files extended (9)

Property-based and edge-case additions to existing tests:

- `getNestedValue.test.ts` (+46), `converter.test.ts` (+31), `normalizer.test.ts` (+52), `rateLimit.test.ts` (+44) — `fast-check` property tests
- `DeclarativePlugin.test.ts` (+147) — new tests plus type fixes for `DataSourceConfig` required fields
- `cors.test.ts` (+5), `marketplaceToken.test.ts` (+21) — edge cases
- `filterEngine.test.ts` — type-corrected against actual SDK shapes (uses `latitude`/`longitude` not `position.{lat,lon}`, nested `range: { min, max, step }` config)

## What's *not* in this PR (intentionally)

- **Duplicate tests for code already on main.** `.spec.ts` versions of `CacheLayer`/`DataBus`/`PollingManager`/`cors`/`marketplaceToken`/`repository`/`rateLimit`/`edition`/`seedDefaultPlugins` were dropped — those modules already have `.test.ts` files from #110/prior.
- **Tautological tests.** A few accessor-only tests from #113 dropped per the bar set on #110/#111: each test must catch a specific bug class that two different broken implementations would fail differently on.
- **`version` bump in `package.json`.** Three of the contributing PRs each bumped the version, conflicting with each other. Recommend reserving version bumps for explicit release commits — feature/test PRs should leave the field alone.
- **A duplicate `stryker.conf.json`.** #114 used that filename; #117 used `stryker.config.json`. Stryker accepts both but only loads one (alphabetical resolution). Picked `stryker.config.json` as the canonical name.

## What supersedes what

| Contributing PR | Disposition after this lands |
|-----------------|------------------------------|
| #113 | Close — its 17 new tests are here; 8 collision files dropped |
| #114 | Close — its CI workflow shape is here with a weekly+manual trigger; its config decisions chosen deliberately vs #117's |
| #117 | Close — its full deps and 4 test extensions are here |
| #118 | Close — the type-corrected versions of its 6 test files are here (incorporating the typefix commit pushed to that branch yesterday) |

Each contributing PR is credited via `Co-Authored-By: silvertakana` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)