### PR TITLE
fix(setup): logo + Sign In button rendering white-on-white

### DIFF
--- a/src/app/setup/setup.module.css
+++ b/src/app/setup/setup.module.css
@@ -22,7 +22,14 @@
     height: 48px;
     margin: 0 auto 1rem;
     border-radius: 0px;
-    background: rgb(var(--accent-rgb, 200, 30, 30));
+    /*
+     * Setup page is pre-auth and pre-theme — `--accent-rgb` defaults
+     * to `255, 255, 255` (white) in theme-tokens.css, which makes
+     * `rgb(255, 255, 255)` + `color: #fff` render invisible. Use an
+     * explicit brand color so the logo is visible before any theme
+     * applies.
+     */
+    background: rgb(200, 30, 30);
     color: #fff;
     font-weight: 700;
     font-size: 1.25rem;
@@ -71,7 +78,7 @@
 }
 
 .input:focus {
-    border-color: rgb(var(--accent-rgb, 200, 30, 30));
+    border-color: rgb(200, 30, 30);
 }
 
 .error {
@@ -83,7 +90,7 @@
 .button {
     margin-top: 0.75rem;
     padding: 0.7rem;
-    background: rgb(var(--accent-rgb, 200, 30, 30));
+    background: rgb(200, 30, 30);
     color: #fff;
     border: none;
     border-radius: 0px;


### PR DESCRIPTION
## Repro

Fresh install on port 3010 → first boot → \`/setup\`. The \"W\" logo (red square at the top of the card) doesn't render, and the \"Sign In\" button shows as a blank rectangle. Inspecting the DOM:

\`\`\`html
<div class=\"setup_logo__YLw7p\">W</div>
<button type=\"submit\" class=\"setup_button__Y8ArD\">Sign In</button>
\`\`\`

Both elements have content, both have white text (\`color: #fff\`), both have a white background. Invisible.

## Root cause

\`src/app/setup/setup.module.css\` uses \`rgb(var(--accent-rgb, 200, 30, 30))\` for three properties (\`.logo\` bg, \`.button\` bg, \`.input:focus\` border).

CSS \`var()\` syntax is \`var(--name, <fallback>)\` — everything after the first comma is the fallback. So the intent is \"use \`--accent-rgb\` if defined, otherwise \`200, 30, 30\`.\"

But \`theme-tokens.css\` defines:

\`\`\`css
:root {
    --accent-rgb: 255, 255, 255;   /* line 22 */
}
\`\`\`

So \`--accent-rgb\` is *always defined* when the setup page renders, the fallback never kicks in, and the rules resolve to \`rgb(255, 255, 255)\`. Combined with the existing \`color: #fff\`, the logo and button become white-on-white.

The themed views elsewhere (cyan accent, dark accent) override \`--accent-rgb\` correctly so this only bites pre-theme pages — setup is the most visible one.

## Fix

The setup flow is pre-auth and pre-theme; it shouldn't be inheriting the accent at all. Replace the three \`var()\` references with an explicit brand red (\`rgb(200, 30, 30)\` — same as the originally-intended fallback color) so the page is readable regardless of which theme is active.

Three identical edits in \`setup.module.css\`. No JS, no other files.

## Verification

After this patch, on the same fresh \`/setup\` page, the red \"W\" logo renders and the \"Sign In\" button shows white text on a red background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)