### PR TITLE
fix(engineManifest): correct local engine port (5001) + honor data-engine env var

### DIFF
--- a/src/core/data/engineManifest.ts
+++ b/src/core/data/engineManifest.ts
@@ -5,9 +5,35 @@
 let localManifest: string[] | null = null;
 let manifestFetched = false;
 
+/**
+ * Resolve the base URL of the local data engine.
+ *
+ * Priority:
+ *   1. `NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL` env var — if the operator
+ *      pointed plugins at a specific engine URL (most common in
+ *      self-host setups), use that. We strip any trailing `/stream`
+ *      since the var is sometimes set to the WebSocket URL.
+ *   2. `localhost:5001` — matches the port wwv-data-engine's
+ *      docker-compose.yaml binds. The previous default of 5000 was
+ *      always wrong: the engine has listened on 5001 since the v2
+ *      refactor. Port 5000 is also famously hijacked on macOS by the
+ *      AirPlay Receiver, which would return 403 to any GET regardless
+ *      of whether an engine was running, so it produced misleading
+ *      "no local engine" results on every macOS dev machine.
+ */
 function getLocalEngineBase() {
-    if (typeof window === "undefined") return "http://localhost:5000";
-    return `${window.location.protocol}//${window.location.hostname}:5000`;
+    const envUrl = process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
+    if (envUrl) {
+        // Strip a trailing `/stream` if present (the var is sometimes
+        // set to the WebSocket URL); also normalize ws[s]:// to http[s]://.
+        return envUrl
+            .replace(/\/stream\/?$/, "")
+            .replace(/^ws:\/\//, "http://")
+            .replace(/^wss:\/\//, "https://")
+            .replace(/\/+$/, "");
+    }
+    if (typeof window === "undefined") return "http://localhost:5001";
+    return `${window.location.protocol}//${window.location.hostname}:5001`;
 }
 
 /**


### PR DESCRIPTION
## Symptoms

Browser console spew on every fresh boot:

\`\`\`
GET http://localhost:5000/manifest net::ERR_FAILED 403 (Forbidden)
\`\`\`

…followed by downstream noise as plugins fall back to the cloud engine. Cloud often 404s for self-host operators who set up their own engine — e.g. aviation plugin requesting \`https://dataenginev2.worldwideview.dev/api/aviation?lookback=15m\` and getting back \"seeder not running.\"

## Two intertwined bugs

### 1. Wrong port

\`engineManifest.ts\` polls \`localhost:5000/manifest\` to detect a local engine. But \`wwv-data-engine\`'s \`docker-compose.yaml\` binds the engine to **port 5001** — and has done since the v2 refactor. The detection has been reporting \"no local engine\" even when one is running, which causes every plugin to fall back to the cloud engine on every toggle.

Extra mess: **macOS hijacks port 5000 for the AirPlay Receiver**, which silently returns \`403\` to every GET. So on any macOS dev machine, this produces a confusing 403 in the browser console even when no engine is running at all. The error is misleading — it makes it look like there's an auth problem with the engine, when really the request is hitting Apple's local HTTP server.

### 2. \`NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL\` is ignored

Every other code path that needs the engine URL respects the env var (\`resolveEngineUrl\`, plugin context injection, etc.). But \`engineManifest\` runs its own hardcoded detection. So even when an operator points the rest of the app at a custom engine, manifest detection fails silently against \`localhost\`.

## Fix

Read the env var first, fall back to \`localhost:5001\` if not set:

\`\`\`typescript
function getLocalEngineBase() {
    const envUrl = process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
    if (envUrl) {
        return envUrl
            .replace(/\\/stream\\/?$/, \"\")
            .replace(/^ws:\\/\\//, \"http://\")
            .replace(/^wss:\\/\\//, \"https://\")
            .replace(/\\/+$/, \"\");
    }
    if (typeof window === \"undefined\") return \"http://localhost:5001\";
    return \\`\\${window.location.protocol}//\\${window.location.hostname}:5001\\`;
}
\`\`\`

Same normalization the rest of the app uses — strips trailing \`/stream\`, swaps \`ws[s]://\` for \`http[s]://\`. One-file change.

## Verification

- \`pnpm exec tsc --noEmit\` clean
- Existing \`engineManifest.test.ts\` tests still pass (they mock \`fetch\` and don't care about the URL shape; happy to add an env-var-precedence test in a follow-up).
- Manual: with \`NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL\` unset, the request goes to \`localhost:5001\` and either succeeds (engine running) or fails quickly with the cached-failure pattern. No more spurious AirPlay 403.

## Side effects worth knowing

This fix also indirectly resolves several confusing downstream errors in self-host setups — plugins that fall back to the cloud because local-detection failed will now correctly route to the local engine, eliminating the \"seeder not running\" 404s that the cloud engine returns for self-host-only seeders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)