### PR TITLE
chore(deps): pin form-data + fast-uri overrides to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,11 @@
   },
   "pnpm": {
     "overrides": {
-      "@spz-loader/core": "0.3.0"
+      "@spz-loader/core": "0.3.0",
+      "form-data@<2.5.4": "^2.5.5",
+      "form-data@>=3.0.0 <3.0.4": "^3.0.4",
+      "form-data@>=4.0.0 <4.0.4": "^4.0.5",
+      "fast-uri@<3.1.2": "^3.1.2"
     },
     "onlyBuiltDependencies": [
       "@prisma/engines",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   '@spz-loader/core': 0.3.0
+  form-data@<2.5.4: ^2.5.5
+  form-data@>=3.0.0 <3.0.4: ^3.0.4
+  form-data@>=4.0.0 <4.0.4: ^4.0.5
+  fast-uri@<3.1.2: ^3.1.2
 
 importers:
 
@@ -3227,8 +3231,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -3282,8 +3286,8 @@ packages:
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
 
   forwarded-parse@2.1.2:
@@ -7594,14 +7598,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8627,7 +8631,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -8679,11 +8683,14 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  form-data@2.3.3:
+  form-data@2.5.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
       mime-types: 2.1.35
+      safe-buffer: 5.2.1
 
   forwarded-parse@2.1.2: {}
 
@@ -9909,7 +9916,7 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 2.3.3
+      form-data: 2.5.5
       har-validator: 5.1.5
       http-signature: 1.2.0
       is-typedarray: 1.0.0


### PR DESCRIPTION
## Summary

Resolves three high+critical advisories that sit in `main`'s current dependency tree, surfaced by the dependency audit added in #104. None of them are caused by #104 — the audit just makes them visible.

| Severity | Advisory | Where it lives |
|---|---|---|
| CRITICAL | [GHSA-fjxv-7rqg-78g4](https://github.com/advisories/GHSA-fjxv-7rqg-78g4) `form-data <2.5.4` (unsafe random boundary) | `insecam-api@0.0.3 → request@2.88.2 → form-data@2.3.3` |
| HIGH | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) `fast-uri <=3.1.0` (path traversal) | `@sentry/nextjs → @sentry/webpack-plugin → webpack → schema-utils → ajv → fast-uri@3.1.0` (15 paths) |
| HIGH | [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) `fast-uri <=3.1.1` (host confusion) | same chain as above |

The form-data CVE has been in `main` since the advisory was published 2025-07-21 (10 months). Both fast-uri advisories were published 2026-05-08 (5 days ago) — fresh.

## Approach

Uses **scoped pnpm overrides** keyed on the vulnerable version ranges, so each major release line is patched in place rather than forced into a single version:

```json
"pnpm": {
  "overrides": {
    "form-data@<2.5.4":         "^2.5.5",
    "form-data@>=3.0.0 <3.0.4": "^3.0.4",
    "form-data@>=4.0.0 <4.0.4": "^4.0.5",
    "fast-uri@<3.1.2":          "^3.1.2"
  }
}
```

This matters because `request@2.88.2` (the parent that brings form-data) is long-abandoned. A naive `"form-data": ">=2.5.5"` override would pull the latest available (4.0.5) and risk a major-version API mismatch with `request`. The scoped form keeps form-data on its 2.x line (2.3.3 → 2.5.5, a patch bump) while still patching the CVE.

The 3.x and 4.x overrides are pre-emptive — no current matches in the tree, but they future-proof against new deps pulling vulnerable form-data versions.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement
- [x] Security / dependency hygiene

## Verification

```sh
pnpm install
pnpm audit --audit-level high; echo "exit: $?"
# exit: 0
```

Before this PR: 1 critical + 2 high + 5 moderate.
After this PR: 0 critical + 0 high + 5 moderate (all below CI threshold).

Lockfile delta is small (25 lines): only the two affected packages move, plus the override declarations.

```
fast-uri@3.1.0  ->  3.1.2
form-data@2.3.3 ->  2.5.5
```

## Remaining moderate findings (out of scope)

The five remaining moderate advisories are below the CI `--audit-level high` threshold and not addressed here. Worth a follow-up:

| Advisory | Fix path |
|---|---|
| `request` SSRF | No fix available — `request` is abandoned. Long-term: replace `request` inside `insecam-api` with `fetch` or `undici`. |
| `tough-cookie <4.1.3` prototype pollution | Override-able to `^4.1.3` (also via the `request` chain). |
| `qs <6.14.1` bracket-notation DoS | Override-able to `^6.14.1`. |
| `@hono/node-server <1.19.13` middleware bypass | Override-able to `^1.19.13`. |
| `postcss <8.5.10` XSS via unescaped `</style>` | Override-able to `^8.5.10`. |

Happy to bundle these into a follow-up PR; kept out of this one so the change set stays narrowly focused on the CI-failing advisories.

## Unblocks

- **#104** (CI: trigger on push to main and add dependency audit) — currently failing CI because main's tree has the three CVEs above. Once this lands, #104 rebases clean and merges. Sequenced this way so the dependency fix is maintainer-attributed rather than dumped on the contributor who only added the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)