### PR TITLE
fix(docker): add multi-platform build support for linux/arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,6 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- The published `ghcr.io/silvertakana/worldwideview:latest` image only contains a `linux/amd64` manifest
- `docker pull` fails on ARM64 hosts (Apple Silicon, AWS Graviton, Raspberry Pi) with `no matching manifest for linux/arm64/v8`
- Adds `docker/setup-qemu-action@v3` for cross-platform emulation
- Adds `platforms: linux/amd64,linux/arm64` to the build-push step

## Details

Verified that all base images (`node:26-alpine`, `alpine`) and native dependencies (`sharp`, `prisma`, `esbuild`, `better-sqlite3`, `@sentry/cli`, `protobufjs`) ship arm64 prebuilts for Linux/Alpine. No Dockerfile changes needed.

**Note:** `ghcr.io/silvertakana/wwv-data-engine:latest` is also amd64-only but is built in a separate repo.

## Test plan

- [ ] CI builds both platforms without error
- [ ] `docker manifest inspect ghcr.io/silvertakana/worldwideview:latest` shows both `amd64` and `arm64` entries after merge

Closes #119