### PR TITLE
fix(setup): remove broken legacy migration banner from setup page

### DIFF
--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -33,13 +33,6 @@ export default function SetupPage() {
                 <h1 className={styles.title}>Welcome to WorldWideView</h1>
                 <p className={styles.subtitle}>Create your admin account to get started</p>
 
-                {/* Legacy Data Detection Banner */}
-                <div className={styles.legacyNotice}>
-                    <strong>💡 Upgrading from an older version?</strong>
-                    <p>We've detected legacy SQLite data. Once your new Postgres database is connected, you can import your favorites by running the migration command in your terminal.</p>
-                    <code>docker compose exec wwv node scripts/migrate-legacy.mjs</code>
-                </div>
-
                 <form onSubmit={handleSubmit} className={styles.form}>
                     <label className={styles.label} htmlFor="name">
                         Display Name

--- a/src/app/setup/setup.module.css
+++ b/src/app/setup/setup.module.css
@@ -103,27 +103,3 @@
 .button:hover { opacity: 0.9; }
 .button:disabled { opacity: 0.5; cursor: not-allowed; }
 
-.legacyNotice {
-    margin: 1.5rem 0;
-    padding: 1rem;
-    background: rgba(255, 191, 0, 0.05);
-    border: 1px solid rgba(255, 191, 0, 0.3);
-    text-align: left;
-    font-size: 0.8rem;
-    color: #ffbf00;
-}
-
-.legacyNotice strong {
-    display: block;
-    margin-bottom: 0.4rem;
-}
-
-.legacyNotice code {
-    display: block;
-    margin-top: 0.75rem;
-    padding: 0.5rem;
-    background: #000;
-    color: #0f0;
-    font-family: 'JetBrains Mono', monospace;
-    word-break: break-all;
-}


### PR DESCRIPTION
## Summary

- The setup page (`/setup`) unconditionally renders a banner telling users to run `scripts/migrate-legacy.mjs`
- That script does not exist anywhere in the repo or the Docker image
- Every user who hits `/setup` sees the broken command, including fresh installs with zero legacy data

## Why removing the banner is safe

- The banner was hardcoded JSX with no conditional logic. It rendered for all users, not just upgraders.
- No state, props, API calls, or other components depend on it.
- The `docker-entrypoint.sh` (lines 9-28) already handles actual legacy detection: it checks for `prisma/dev.db` and prints a migration warning in the container logs. That path is untouched.
- Only two files changed, deletions only: the banner markup from `page.tsx` and the unused `.legacyNotice` styles from `setup.module.css`.

## Test plan

- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] `npx vitest run` -- 230/230 tests pass (4 pre-existing failures from missing `fast-check` dep, unrelated)
- [ ] `grep -rn legacyNotice` returns zero results
- [ ] `/setup` page renders correctly without the banner

Closes #129