### PR TITLE
feat(globe): add OSM 3D Buildings overlay for non-Google imagery layers

### DIFF
--- a/src/components/panels/GraphicsSettings.tsx
+++ b/src/components/panels/GraphicsSettings.tsx
@@ -25,6 +25,7 @@ const DEFAULT_GRAPHICS = {
     shadowsEnabled: false,
     enableLighting: false,
     showFps: false,
+    showOsmBuildings: true,
 };
 
 const RESOLUTION_OPTIONS = [
@@ -55,10 +56,10 @@ export function GraphicsSettings() {
 
     // Save to cookie on change
     useEffect(() => {
-        const { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps } = mapConfig;
-        const graphicsToSave = { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps };
+        const { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps, showOsmBuildings } = mapConfig;
+        const graphicsToSave = { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps, showOsmBuildings };
         document.cookie = `wwv_graphics=${encodeURIComponent(JSON.stringify(graphicsToSave))}; path=/; max-age=31536000`; // 1 year
-    }, [mapConfig.resolutionScale, mapConfig.antiAliasing, mapConfig.maxScreenSpaceError, mapConfig.shadowsEnabled, mapConfig.enableLighting, mapConfig.showFps]);
+    }, [mapConfig.resolutionScale, mapConfig.antiAliasing, mapConfig.maxScreenSpaceError, mapConfig.shadowsEnabled, mapConfig.enableLighting, mapConfig.showFps, mapConfig.showOsmBuildings]);
 
     const toggle = (key: string, current: boolean) => {
         update({ [key]: !current });
@@ -144,6 +145,16 @@ export function GraphicsSettings() {
                     className={`gfx-toggle ${mapConfig.enableLighting ? "gfx-toggle--on" : ""}`}
                     onClick={() => toggle("enableLighting", mapConfig.enableLighting)}
                     aria-label="Toggle Globe Lighting"
+                />
+            </div>
+
+            {/* 3D Buildings */}
+            <div className="gfx-settings__row">
+                <span className="gfx-settings__label">3D Buildings</span>
+                <button
+                    className={`gfx-toggle ${mapConfig.showOsmBuildings ? "gfx-toggle--on" : ""}`}
+                    onClick={() => toggle("showOsmBuildings", mapConfig.showOsmBuildings)}
+                    aria-label="Toggle 3D Buildings"
                 />
             </div>
 

--- a/src/core/globe/useImageryManager.ts
+++ b/src/core/globe/useImageryManager.ts
@@ -3,7 +3,9 @@ import {
     Viewer as CesiumViewer,
     ImageryLayer,
     SceneMode,
-    Cesium3DTileset
+    Cesium3DTileset,
+    Cesium3DTileStyle,
+    createOsmBuildingsAsync
 } from "cesium";
 import { useStore } from "@/core/state/store";
 import { createImageryProvider, createOsmProvider } from "./ImageryProviderFactory";
@@ -12,12 +14,14 @@ export function useImageryManager(viewer: CesiumViewer | null, viewerReady: bool
     const baseLayerId = useStore((s) => s.mapConfig.baseLayerId);
     const fallbackLayerId = useStore((s) => s.mapConfig.fallbackLayerId);
     const sceneMode = useStore((s) => s.mapConfig.sceneMode);
-    
+    const showOsmBuildings = useStore((s) => s.mapConfig.showOsmBuildings);
+
     // Resolve runtime truth:
     const activeLayerId = fallbackLayerId || baseLayerId;
 
     const currentImageryLayerRef = useRef<ImageryLayer | null>(null);
     const googleTilesetRef = useRef<Cesium3DTileset | null>(null);
+    const osmBuildingsRef = useRef<Cesium3DTileset | null>(null);
 
     // 1. Manage Scene Mode (2D / 3D / Columbus)
     useEffect(() => {
@@ -51,9 +55,8 @@ export function useImageryManager(viewer: CesiumViewer | null, viewerReady: bool
 
             for (let i = 0; i < primitives.length; i++) {
                 const p = primitives.get(i);
-                // Simple check for Google Tileset - usually it's the only 3DTileset 
-                // added during initialization or has custom properties
-                if (p instanceof Cesium3DTileset) {
+                // Find the Google tileset — skip any tagged as OSM buildings
+                if (p instanceof Cesium3DTileset && !(p as any)._wwvOsmBuildings) {
                     foundTileset = p;
                     break;
                 }
@@ -107,7 +110,43 @@ export function useImageryManager(viewer: CesiumViewer | null, viewerReady: bool
         updateImagery();
     }, [viewer, viewerReady, baseLayerId, fallbackLayerId]);
 
+    // 3. Manage OSM 3D Buildings (only in 3D mode, not with Google Photorealistic tiles)
+    const isGoogle3D = activeLayerId === "google-3d";
+    const is3DMode = sceneMode === 3;
+    useEffect(() => {
+        if (!viewer || !viewerReady || viewer.isDestroyed()) return;
+
+        const shouldShow = showOsmBuildings && !isGoogle3D && is3DMode;
+
+        if (shouldShow && !osmBuildingsRef.current) {
+            let cancelled = false;
+            createOsmBuildingsAsync().then((tileset) => {
+                if (cancelled || !viewer || viewer.isDestroyed()) {
+                    tileset.destroy();
+                    return;
+                }
+                (tileset as any)._wwvOsmBuildings = true;
+                tileset.maximumScreenSpaceError = 16;
+                tileset.style = new Cesium3DTileStyle({
+                    color: "color('#E0DDD5')",
+                });
+                viewer.scene.primitives.add(tileset);
+                osmBuildingsRef.current = tileset;
+            }).catch((err) => {
+                console.warn("[useImageryManager] Failed to load OSM 3D Buildings:", err);
+            });
+            return () => { cancelled = true; };
+        }
+
+        if (!shouldShow && osmBuildingsRef.current) {
+            if (!viewer.isDestroyed()) {
+                viewer.scene.primitives.remove(osmBuildingsRef.current);
+            }
+            osmBuildingsRef.current = null;
+        }
+    }, [viewer, viewerReady, isGoogle3D, is3DMode, showOsmBuildings]);
+
     return {
-        isGoogle3D: activeLayerId === "google-3d"
+        isGoogle3D
     };
 }

--- a/src/core/state/configSlice.ts
+++ b/src/core/state/configSlice.ts
@@ -61,6 +61,8 @@ export interface MapConfig {
     fallbackLayerId: string | null;
     /** The active scene mode (2D, 2.5D, or 3D). */
     sceneMode: 1 | 2 | 3;
+    /** Whether OSM 3D Buildings are shown on non-Google imagery layers. */
+    showOsmBuildings: boolean;
 }
 
 /**
@@ -108,6 +110,7 @@ export const createConfigSlice: StateCreator<AppStore, [], [], ConfigSlice> = (s
         baseLayerId: (typeof window !== "undefined" && window.localStorage && typeof window.localStorage.getItem === "function") ? (localStorage.getItem("wwv_map_layer") || "google-3d") : "google-3d",
         fallbackLayerId: null,
         sceneMode: 3,
+        showOsmBuildings: true,
     },
     updateDataConfig: (config) =>
         set((state) => ({


### PR DESCRIPTION
## Summary

Implements #18. When the active base layer is flat imagery (Bing, OSM, ArcGIS, etc.) rather than Google Photorealistic 3D Tiles, this loads Cesium's OSM Buildings tileset (Ion asset 96188) to provide extruded 3D building geometry on top of the satellite/map imagery. This gives a faux-3D city experience even without a Google Maps API key.

Buildings are automatically hidden when switching to Google 3D (which ships its own building geometry), 2D mode, or Columbus View.

## Type of Change

- [x] New feature

## Related Issue

Closes #18

## Changes Made

**`src/core/state/configSlice.ts`**
- Added `showOsmBuildings: boolean` to the `MapConfig` interface, defaulting to `true`

**`src/core/globe/useImageryManager.ts`**
- Imported `createOsmBuildingsAsync` and `Cesium3DTileStyle` from Cesium
- Added `osmBuildingsRef` to track the tileset primitive across renders
- New effect (section 3) handles the full lifecycle: creates the tileset when `showOsmBuildings && !isGoogle3D && is3DMode`, removes it otherwise
- Tags the OSM tileset with `_wwvOsmBuildings = true` so the existing Google tileset detection loop (which iterates all `Cesium3DTileset` primitives) correctly skips it. Without this tag, toggling away from Google 3D would hide the OSM buildings tileset since the loop treats every `Cesium3DTileset` as the Google tileset
- Sets `maximumScreenSpaceError = 16` on the tileset to keep tile request volume reasonable at city zoom levels
- Applies a static `Cesium3DTileStyle` with color `#E0DDD5` (light concrete) so buildings render with a visible color even when scene lighting is disabled (the default). Without this, buildings render solid black because there is no light source illuminating the 3D geometry
- Async cleanup uses a `cancelled` flag to prevent a stale tileset from being added if the effect re-runs or unmounts before `createOsmBuildingsAsync` resolves

**`src/components/panels/GraphicsSettings.tsx`**
- Added "3D Buildings" toggle button in the Graphics section (between Globe Lighting and Show FPS)
- Added `showOsmBuildings` to the cookie persistence logic and dependency array
- Added `showOsmBuildings: true` to the reset defaults object

## Testing

- [x] I ran `npx vitest run` and all tests pass (243/243, 6 pre-existing failures from missing `fast-check`/`openid-client` modules)
- [x] I manually tested this in the browser against the local dev server
- [x] `npx tsc --noEmit` produces zero errors in the changed files (pre-existing errors only)

### Manual test results

- Loaded globe without Google Maps API key, fell back to Bing Aerial imagery
- Zoomed into a coastal Florida city and confirmed 3D building geometry rendered on top of flat satellite imagery
- Confirmed buildings appear with a light concrete color rather than black
- Toggled "3D Buildings" off in Graphics Settings (Imagery panel > Graphics section), buildings removed from the scene
- Toggled back on, buildings reloaded
- Requires `NEXT_PUBLIC_CESIUM_ION_TOKEN` to be set (OSM Buildings are a Cesium Ion asset). Without it, the feature degrades silently with a console warning

## Screenshots / Recordings

OSM 3D Buildings rendering on flat Bing Aerial imagery (Florida coastline):

<img width="1470" height="956" alt="Screenshot 2026-05-14 at 10 43 30 PM" src="https://github.com/user-attachments/assets/def310ed-45e8-43cb-8860-fe0d56d3bd7b" />

## Notes for Reviewer

- `createOsmBuildingsAsync()` loads from Cesium Ion (asset 96188), so it requires a valid Ion token. The app already reads `NEXT_PUBLIC_CESIUM_ION_TOKEN` and sets `Ion.defaultAccessToken` in `GlobeView.tsx`. If no token is set, the async call fails and is caught silently.
- `depthTestAgainstTerrain` is already enabled in `useViewerInitialization.ts`, which helps mitigate z-fighting between building bases and the terrain surface.
- The `_wwvOsmBuildings` tag on the tileset is a lightweight way to distinguish it from the Google tileset without refactoring the existing primitive iteration logic. If more tileset types are added in the future, a more structured tagging approach (e.g. a custom property map) might be worth considering.