### PR TITLE
feat(api): add ISS Tracker proxy routes

### DIFF
--- a/src/app/api/iss/positions/route.ts
+++ b/src/app/api/iss/positions/route.ts
@@ -5,23 +5,15 @@ export const revalidate = 60;
 const WTIA_POSITIONS_URL = "https://api.wheretheiss.at/v1/satellites/25544/positions";
 const MAX_TIMESTAMPS = 10;
 
-interface IssPosition {
-    latitude: number;
-    longitude: number;
-    altitude: number;
-    velocity: number;
-    visibility: string;
-    timestamp: number;
-}
-
-function isValidPosition(item: unknown): item is IssPosition {
-    if (typeof item !== "object" || item === null) return false;
-    const d = item as Record<string, unknown>;
+function isValidPosition(item: any): boolean {
     return (
-        Number.isFinite(d.latitude)
-        && Number.isFinite(d.longitude)
-        && Number.isFinite(d.altitude)
-        && Number.isFinite(d.timestamp)
+        item != null
+        && typeof item === "object"
+        && Number.isFinite(item.latitude)
+        && Number.isFinite(item.longitude)
+        && Number.isFinite(item.altitude)
+        && Number.isFinite(item.velocity)
+        && Number.isFinite(item.timestamp)
     );
 }
 

--- a/src/app/api/iss/positions/route.ts
+++ b/src/app/api/iss/positions/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 60;
+
+const WTIA_POSITIONS_URL = "https://api.wheretheiss.at/v1/satellites/25544/positions";
+const MAX_TIMESTAMPS = 10;
+
+interface IssPosition {
+    latitude: number;
+    longitude: number;
+    altitude: number;
+    velocity: number;
+    visibility: string;
+    timestamp: number;
+}
+
+function isValidPosition(item: unknown): item is IssPosition {
+    if (typeof item !== "object" || item === null) return false;
+    const d = item as Record<string, unknown>;
+    return (
+        Number.isFinite(d.latitude)
+        && Number.isFinite(d.longitude)
+        && Number.isFinite(d.altitude)
+        && Number.isFinite(d.timestamp)
+    );
+}
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+    const timestampsParam = searchParams.get("timestamps");
+
+    if (!timestampsParam) {
+        return NextResponse.json(
+            { error: "Missing required 'timestamps' query parameter" },
+            { status: 400 },
+        );
+    }
+
+    const timestamps = timestampsParam
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => /^\d+$/.test(t));
+
+    if (timestamps.length === 0) {
+        return NextResponse.json(
+            { error: "No valid timestamps provided" },
+            { status: 400 },
+        );
+    }
+
+    if (timestamps.length > MAX_TIMESTAMPS) {
+        return NextResponse.json(
+            { error: `Maximum ${MAX_TIMESTAMPS} timestamps allowed per request` },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const url = `${WTIA_POSITIONS_URL}?timestamps=${timestamps.join(",")}&units=kilometers`;
+
+        const response = await fetch(url, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch ISS positions" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+        const positions = (Array.isArray(data) ? data : [])
+            .filter(isValidPosition)
+            .map((p) => ({
+                latitude: p.latitude,
+                longitude: p.longitude,
+                altitude: p.altitude,
+                velocity: p.velocity,
+                visibility: p.visibility,
+                timestamp: p.timestamp,
+            }));
+
+        return NextResponse.json({ positions });
+    } catch (error) {
+        console.error("[IssPositionsRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch ISS positions" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/iss/route.ts
+++ b/src/app/api/iss/route.ts
@@ -4,28 +4,15 @@ export const revalidate = 10;
 
 const WTIA_URL = "https://api.wheretheiss.at/v1/satellites/25544";
 
-interface IssApiResponse {
-    name: string;
-    id: number;
-    latitude: number;
-    longitude: number;
-    altitude: number;
-    velocity: number;
-    visibility: string;
-    footprint: number;
-    timestamp: number;
-    units: string;
-}
-
-function isValidResponse(data: unknown): data is IssApiResponse {
-    if (typeof data !== "object" || data === null) return false;
-    const d = data as Record<string, unknown>;
+function isValidResponse(data: any): boolean {
     return (
-        Number.isFinite(d.latitude)
-        && Number.isFinite(d.longitude)
-        && Number.isFinite(d.altitude)
-        && Number.isFinite(d.velocity)
-        && Number.isFinite(d.timestamp)
+        data != null
+        && typeof data === "object"
+        && Number.isFinite(data.latitude)
+        && Number.isFinite(data.longitude)
+        && Number.isFinite(data.altitude)
+        && Number.isFinite(data.velocity)
+        && Number.isFinite(data.timestamp)
     );
 }
 

--- a/src/app/api/iss/route.ts
+++ b/src/app/api/iss/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 10;
+
+const WTIA_URL = "https://api.wheretheiss.at/v1/satellites/25544";
+
+interface IssApiResponse {
+    name: string;
+    id: number;
+    latitude: number;
+    longitude: number;
+    altitude: number;
+    velocity: number;
+    visibility: string;
+    footprint: number;
+    timestamp: number;
+    units: string;
+}
+
+function isValidResponse(data: unknown): data is IssApiResponse {
+    if (typeof data !== "object" || data === null) return false;
+    const d = data as Record<string, unknown>;
+    return (
+        Number.isFinite(d.latitude)
+        && Number.isFinite(d.longitude)
+        && Number.isFinite(d.altitude)
+        && Number.isFinite(d.velocity)
+        && Number.isFinite(d.timestamp)
+    );
+}
+
+export async function GET() {
+    try {
+        const response = await fetch(WTIA_URL, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch ISS position" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+
+        if (!isValidResponse(data)) {
+            return NextResponse.json(
+                { error: "Invalid ISS position data" },
+                { status: 502 },
+            );
+        }
+
+        return NextResponse.json({
+            id: data.id,
+            name: data.name,
+            latitude: data.latitude,
+            longitude: data.longitude,
+            altitude: data.altitude,
+            velocity: data.velocity,
+            visibility: data.visibility,
+            footprint: data.footprint,
+            timestamp: data.timestamp,
+            units: data.units,
+        });
+    } catch (error) {
+        console.error("[IssRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch ISS position" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/iss/tle/route.ts
+++ b/src/app/api/iss/tle/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 3600;
+
+const WTIA_TLE_URL = "https://api.wheretheiss.at/v1/satellites/25544/tles/latest";
+
+interface TleApiResponse {
+    requested_timestamp: number;
+    tle_timestamp: number;
+    id: string;
+    name: string;
+    header: string;
+    line1: string;
+    line2: string;
+}
+
+function isValidTle(data: unknown): data is TleApiResponse {
+    if (typeof data !== "object" || data === null) return false;
+    const d = data as Record<string, unknown>;
+    return (
+        typeof d.line1 === "string"
+        && typeof d.line2 === "string"
+        && d.line1.length > 0
+        && d.line2.length > 0
+        && Number.isFinite(d.tle_timestamp)
+    );
+}
+
+export async function GET() {
+    try {
+        const response = await fetch(WTIA_TLE_URL, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch ISS TLE data" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+
+        if (!isValidTle(data)) {
+            return NextResponse.json(
+                { error: "Invalid ISS TLE data" },
+                { status: 502 },
+            );
+        }
+
+        return NextResponse.json({
+            id: data.id,
+            name: data.name,
+            header: data.header,
+            line1: data.line1,
+            line2: data.line2,
+            tleTimestamp: data.tle_timestamp,
+        });
+    } catch (error) {
+        console.error("[IssTleRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch ISS TLE data" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/iss/tle/route.ts
+++ b/src/app/api/iss/tle/route.ts
@@ -4,25 +4,15 @@ export const revalidate = 3600;
 
 const WTIA_TLE_URL = "https://api.wheretheiss.at/v1/satellites/25544/tles/latest";
 
-interface TleApiResponse {
-    requested_timestamp: number;
-    tle_timestamp: number;
-    id: string;
-    name: string;
-    header: string;
-    line1: string;
-    line2: string;
-}
-
-function isValidTle(data: unknown): data is TleApiResponse {
-    if (typeof data !== "object" || data === null) return false;
-    const d = data as Record<string, unknown>;
+function isValidTle(data: any): boolean {
     return (
-        typeof d.line1 === "string"
-        && typeof d.line2 === "string"
-        && d.line1.length > 0
-        && d.line2.length > 0
-        && Number.isFinite(d.tle_timestamp)
+        data != null
+        && typeof data === "object"
+        && typeof data.line1 === "string"
+        && typeof data.line2 === "string"
+        && data.line1.length > 0
+        && data.line2.length > 0
+        && Number.isFinite(data.tle_timestamp)
     );
 }
 

--- a/src/plugins/iss/issApi.test.ts
+++ b/src/plugins/iss/issApi.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+import {
+    beforeEach, describe, expect, it, vi
+} from "vitest";
+import { GET } from "@/app/api/iss/route";
+
+const validResponse = {
+    name: "iss",
+    id: 25544,
+    latitude: -34.814,
+    longitude: 170.22,
+    altitude: 431.6,
+    velocity: 27545.56,
+    visibility: "daylight",
+    footprint: 4566.04,
+    timestamp: 1778894864,
+    daynum: 2461176.56,
+    solar_lat: 19.07,
+    solar_lon: 157.16,
+    units: "kilometers",
+};
+
+describe("/api/iss", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns validated ISS position data", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => validResponse,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.id).toBe(25544);
+        expect(json.latitude).toBe(-34.814);
+        expect(json.longitude).toBe(170.22);
+        expect(json.altitude).toBe(431.6);
+        expect(json.velocity).toBe(27545.56);
+        expect(json.visibility).toBe("daylight");
+        expect(json.timestamp).toBe(1778894864);
+    });
+
+    it("strips extra fields from upstream response", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => validResponse,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(json).not.toHaveProperty("daynum");
+        expect(json).not.toHaveProperty("solar_lat");
+        expect(json).not.toHaveProperty("solar_lon");
+    });
+
+    it("returns 502 when upstream API fails", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 503,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Failed to fetch ISS position" });
+    });
+
+    it("returns 502 when response has invalid coordinates", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                ...validResponse,
+                latitude: "not-a-number",
+            }),
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Invalid ISS position data" });
+    });
+
+    it("returns 502 when fetch throws a network error", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(
+            new Error("Network error"),
+        ));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Failed to fetch ISS position" });
+    });
+});

--- a/src/plugins/iss/issApi.test.ts
+++ b/src/plugins/iss/issApi.test.ts
@@ -87,6 +87,19 @@ describe("/api/iss", () => {
         expect(json).toEqual({ error: "Invalid ISS position data" });
     });
 
+    it("returns 502 when upstream returns null body", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => null,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Invalid ISS position data" });
+    });
+
     it("returns 502 when fetch throws a network error", async () => {
         vi.stubGlobal("fetch", vi.fn().mockRejectedValue(
             new Error("Network error"),

--- a/src/plugins/iss/issPositions.test.ts
+++ b/src/plugins/iss/issPositions.test.ts
@@ -102,14 +102,35 @@ describe("/api/iss/positions", () => {
             ok: true,
             json: async () => [
                 validPositions[0],
-                { latitude: "bad", longitude: 0, altitude: 0, timestamp: 0 },
+                { latitude: "bad", longitude: 0, altitude: 0, velocity: 0, timestamp: 0 },
+                { latitude: 10, longitude: 20, altitude: 400, velocity: NaN, timestamp: 123 },
             ],
         }));
 
-        const response = await GET(makeRequest("1778894864,1778894874"));
+        const response = await GET(makeRequest("1778894864,1778894874,1778894884"));
         const json = await response.json();
 
         expect(json.positions).toHaveLength(1);
+    });
+
+    it("returns 400 when timestamps param is empty string", async () => {
+        const response = await GET(makeRequest(""));
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toContain("timestamps");
+    });
+
+    it("returns 502 when fetch throws a network error", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(
+            new Error("Network error"),
+        ));
+
+        const response = await GET(makeRequest("1778894864"));
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Failed to fetch ISS positions" });
     });
 
     it("returns 502 when upstream API fails", async () => {

--- a/src/plugins/iss/issPositions.test.ts
+++ b/src/plugins/iss/issPositions.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import {
+    beforeEach, describe, expect, it, vi
+} from "vitest";
+import { GET } from "@/app/api/iss/positions/route";
+
+const validPositions = [
+    {
+        name: "iss",
+        id: 25544,
+        latitude: -34.814,
+        longitude: 170.22,
+        altitude: 431.6,
+        velocity: 27545.56,
+        visibility: "daylight",
+        footprint: 4566.04,
+        timestamp: 1778894864,
+        daynum: 2461176.56,
+        units: "kilometers",
+    },
+    {
+        name: "iss",
+        id: 25544,
+        latitude: -34.389,
+        longitude: 170.77,
+        altitude: 431.38,
+        velocity: 27546.15,
+        visibility: "daylight",
+        footprint: 4564.91,
+        timestamp: 1778894874,
+        daynum: 2461176.56,
+        units: "kilometers",
+    },
+];
+
+function makeRequest(timestamps: string): Request {
+    return new Request(`http://localhost:3000/api/iss/positions?timestamps=${timestamps}`);
+}
+
+describe("/api/iss/positions", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns validated position data for given timestamps", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => validPositions,
+        }));
+
+        const response = await GET(makeRequest("1778894864,1778894874"));
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.positions).toHaveLength(2);
+        expect(json.positions[0].latitude).toBe(-34.814);
+        expect(json.positions[1].timestamp).toBe(1778894874);
+    });
+
+    it("strips extra fields from position responses", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => validPositions,
+        }));
+
+        const response = await GET(makeRequest("1778894864"));
+        const json = await response.json();
+
+        expect(json.positions[0]).not.toHaveProperty("name");
+        expect(json.positions[0]).not.toHaveProperty("footprint");
+        expect(json.positions[0]).not.toHaveProperty("daynum");
+    });
+
+    it("returns 400 when timestamps parameter is missing", async () => {
+        const request = new Request("http://localhost:3000/api/iss/positions");
+        const response = await GET(request);
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toContain("timestamps");
+    });
+
+    it("returns 400 when timestamps are not numeric", async () => {
+        const response = await GET(makeRequest("abc,def"));
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toContain("No valid timestamps");
+    });
+
+    it("returns 400 when exceeding maximum timestamps", async () => {
+        const ts = Array.from({ length: 11 }, (_, i) => String(1778894864 + i)).join(",");
+        const response = await GET(makeRequest(ts));
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toContain("Maximum");
+    });
+
+    it("filters out invalid positions from upstream", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => [
+                validPositions[0],
+                { latitude: "bad", longitude: 0, altitude: 0, timestamp: 0 },
+            ],
+        }));
+
+        const response = await GET(makeRequest("1778894864,1778894874"));
+        const json = await response.json();
+
+        expect(json.positions).toHaveLength(1);
+    });
+
+    it("returns 502 when upstream API fails", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 503,
+        }));
+
+        const response = await GET(makeRequest("1778894864"));
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Failed to fetch ISS positions" });
+    });
+});

--- a/src/plugins/iss/issTle.test.ts
+++ b/src/plugins/iss/issTle.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import {
+    beforeEach, describe, expect, it, vi
+} from "vitest";
+import { GET } from "@/app/api/iss/tle/route";
+
+const validTle = {
+    requested_timestamp: 1778894871,
+    tle_timestamp: 1778772971,
+    id: "25544",
+    name: "iss",
+    header: "ISS (ZARYA)",
+    line1: "1 25544U 98067A   26134.65013167  .00004878  00000+0  95926-4 0  9996",
+    line2: "2 25544  51.6311 106.1165 0007514  58.4526 301.7195 15.49215603566555",
+};
+
+describe("/api/iss/tle", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns validated TLE data", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => validTle,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.id).toBe("25544");
+        expect(json.header).toBe("ISS (ZARYA)");
+        expect(json.line1).toContain("25544U");
+        expect(json.line2).toContain("51.6311");
+        expect(json.tleTimestamp).toBe(1778772971);
+    });
+
+    it("normalizes tle_timestamp to tleTimestamp", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => validTle,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(json).toHaveProperty("tleTimestamp");
+        expect(json).not.toHaveProperty("tle_timestamp");
+        expect(json).not.toHaveProperty("requested_timestamp");
+    });
+
+    it("returns 502 when upstream API fails", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Failed to fetch ISS TLE data" });
+    });
+
+    it("returns 502 when TLE lines are empty", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                ...validTle,
+                line1: "",
+            }),
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Invalid ISS TLE data" });
+    });
+
+    it("returns 502 when fetch throws a network error", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(
+            new Error("DNS resolution failed"),
+        ));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Failed to fetch ISS TLE data" });
+    });
+});

--- a/src/plugins/iss/issTle.test.ts
+++ b/src/plugins/iss/issTle.test.ts
@@ -79,6 +79,19 @@ describe("/api/iss/tle", () => {
         expect(json).toEqual({ error: "Invalid ISS TLE data" });
     });
 
+    it("returns 502 when upstream returns null body", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => null,
+        }));
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json).toEqual({ error: "Invalid ISS TLE data" });
+    });
+
     it("returns 502 when fetch throws a network error", async () => {
         vi.stubGlobal("fetch", vi.fn().mockRejectedValue(
             new Error("DNS resolution failed"),


### PR DESCRIPTION
## Summary

Server-side proxy routes for the ISS Tracker plugin (#8). Wraps the
[Where the ISS at?](https://wheretheiss.at/) REST API behind three
Next.js route handlers with input validation, field stripping, and
ISR caching.

### Routes

| Endpoint | Method | Cache | Description |
|---|---|---|---|
| `/api/iss` | GET | 10s | Current position, altitude, velocity, visibility |
| `/api/iss/tle` | GET | 1hr | Latest Two-Line Element set (NORAD 25544) for client-side orbit prediction via satellite.js |
| `/api/iss/positions?timestamps=t1,t2,...` | GET | 60s | Batch historical positions (max 10) for trail rendering |

### Validation

- All numeric fields checked with `Number.isFinite()` (rejects NaN, Infinity, non-numbers)
- Positions route: timestamps validated to digits-only via regex, capped at 10 per request
- Upstream responses are explicitly field-picked to strip internal API data (`daynum`, `solar_lat`, `solar_lon`, etc.)
- Null/malformed upstream responses return 502 with consistent `{ error }` shape

### Tests

21 test cases across 3 files:

- `issApi.test.ts` (6) - valid response, field stripping, upstream 502, invalid coords, null body, network error
- `issTle.test.ts` (6) - valid TLE, field normalization (snake_case to camelCase), upstream 502, empty lines, null body, network error
- `issPositions.test.ts` (9) - valid batch, field stripping, missing param, non-numeric input, overflow cap, invalid position filtering, empty string, network error, upstream 502

### Pattern

Follows the same architecture as the earthquake route (`src/app/api/earthquake/route.ts`):
- Hardcoded upstream URLs (no SSRF surface)
- `next: { revalidate }` for ISR data caching
- `User-Agent: WorldWideView/1.0` header
- 502 for all upstream failures

## Test plan

- [x] `npx vitest run src/plugins/iss/` passes (21/21)
- [x] `npx vitest run` full suite passes (329/329, zero regressions)
- [x] `npx eslint src/app/api/iss/ src/plugins/iss/` returns 0 errors (warnings match earthquake route baseline)
- [x] No changes to Dockerfile, docker-compose, next.config, tsconfig, or package.json

Closes #8