### PR TITLE
feat(globe): add weather radar overlay with OpenWeatherMap tile proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ NEXT_PUBLIC_AUTH_HOST_URL=
 # Example: OPENSKY_CREDENTIALS=acct1-id:acct1-secret,acct2-id:acct2-secret
 OPENSKY_CREDENTIALS=
 
+# OpenWeatherMap — Weather radar tile overlays (free tier: 1,000 calls/day)
+# Sign up at https://openweathermap.org/api and copy your API key.
+OPENWEATHERMAP_API_KEY=
+
 # ACLED API — Civil Unrest & Conflict data (free for non-commercial use)
 # Register at https://developer.acleddata.com/ to obtain credentials.
 # Data is updated weekly (Mondays) with global protest, riot, and violence events.

--- a/src/app/api/weather/layers/route.ts
+++ b/src/app/api/weather/layers/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 3600;
+
+const LAYERS = [
+    { id: "clouds_new", name: "Clouds", description: "Cloud coverage" },
+    { id: "precipitation_new", name: "Precipitation", description: "Rain and snow" },
+    { id: "pressure_new", name: "Sea Level Pressure", description: "Atmospheric pressure" },
+    { id: "wind_new", name: "Wind Speed", description: "Wind speed and direction" },
+    { id: "temp_new", name: "Temperature", description: "Surface temperature" },
+];
+
+export async function GET() {
+    const configured = !!process.env.OPENWEATHERMAP_API_KEY;
+
+    return NextResponse.json({
+        configured,
+        tileUrlTemplate: configured ? "/api/weather/tile/{z}/{x}/{y}?layer={layer}" : null,
+        layers: LAYERS,
+    });
+}

--- a/src/app/api/weather/layers/route.ts
+++ b/src/app/api/weather/layers/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from "next/server";
+import { WEATHER_LAYERS, type WeatherLayer } from "@/lib/weatherLayers";
 
 export const revalidate = 3600;
 
-const LAYERS = [
-    { id: "clouds_new", name: "Clouds", description: "Cloud coverage" },
-    { id: "precipitation_new", name: "Precipitation", description: "Rain and snow" },
-    { id: "pressure_new", name: "Sea Level Pressure", description: "Atmospheric pressure" },
-    { id: "wind_new", name: "Wind Speed", description: "Wind speed and direction" },
-    { id: "temp_new", name: "Temperature", description: "Surface temperature" },
-];
+const LAYER_META: Record<WeatherLayer, { name: string; description: string }> = {
+    clouds_new: { name: "Clouds", description: "Cloud coverage" },
+    precipitation_new: { name: "Precipitation", description: "Rain and snow" },
+    pressure_new: { name: "Sea Level Pressure", description: "Atmospheric pressure" },
+    wind_new: { name: "Wind Speed", description: "Wind speed and direction" },
+    temp_new: { name: "Temperature", description: "Surface temperature" },
+};
+
+const LAYERS = WEATHER_LAYERS.map((id) => ({ id, ...LAYER_META[id] }));
 
 export async function GET() {
     const configured = !!process.env.OPENWEATHERMAP_API_KEY;

--- a/src/app/api/weather/tile/[z]/[x]/[y]/route.ts
+++ b/src/app/api/weather/tile/[z]/[x]/[y]/route.ts
@@ -1,24 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
+import { WEATHER_LAYERS, isValidWeatherLayer } from "@/lib/weatherLayers";
 
 export const revalidate = 600;
 
-const ALLOWED_LAYERS = [
-    "clouds_new",
-    "precipitation_new",
-    "pressure_new",
-    "wind_new",
-    "temp_new",
-] as const;
+const MAX_ZOOM = 18;
 
-type WeatherLayer = (typeof ALLOWED_LAYERS)[number];
-
-function isValidLayer(layer: string): layer is WeatherLayer {
-    return ALLOWED_LAYERS.includes(layer as WeatherLayer);
+function isValidTileCoord(value: string, zoom?: number): boolean {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 0) return false;
+    if (zoom !== undefined) {
+        if (n >= Math.pow(2, zoom)) return false;
+    }
+    return true;
 }
 
-function isValidTileCoord(value: string): boolean {
+function isValidZoom(value: string): boolean {
     const n = Number(value);
-    return Number.isInteger(n) && n >= 0;
+    return Number.isInteger(n) && n >= 0 && n <= MAX_ZOOM;
 }
 
 export async function GET(
@@ -28,14 +26,22 @@ export async function GET(
     const { z, x, y } = await params;
     const layer = req.nextUrl.searchParams.get("layer");
 
-    if (!layer || !isValidLayer(layer)) {
+    if (!layer || !isValidWeatherLayer(layer)) {
         return NextResponse.json(
-            { error: `Invalid layer. Must be one of: ${ALLOWED_LAYERS.join(", ")}` },
+            { error: `Invalid layer. Must be one of: ${WEATHER_LAYERS.join(", ")}` },
             { status: 400 },
         );
     }
 
-    if (!isValidTileCoord(z) || !isValidTileCoord(x) || !isValidTileCoord(y)) {
+    if (!isValidZoom(z)) {
+        return NextResponse.json(
+            { error: "Invalid tile coordinates" },
+            { status: 400 },
+        );
+    }
+
+    const zNum = Number(z);
+    if (!isValidTileCoord(x, zNum) || !isValidTileCoord(y, zNum)) {
         return NextResponse.json(
             { error: "Invalid tile coordinates" },
             { status: 400 },
@@ -74,8 +80,7 @@ export async function GET(
                 "Cache-Control": "public, max-age=600, stale-while-revalidate=300",
             },
         });
-    } catch (error) {
-        console.error("[WeatherTile] Error:", error);
+    } catch {
         return NextResponse.json(
             { error: "Failed to fetch weather tile" },
             { status: 502 },

--- a/src/app/api/weather/tile/[z]/[x]/[y]/route.ts
+++ b/src/app/api/weather/tile/[z]/[x]/[y]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const revalidate = 600;
+
+const ALLOWED_LAYERS = [
+    "clouds_new",
+    "precipitation_new",
+    "pressure_new",
+    "wind_new",
+    "temp_new",
+] as const;
+
+type WeatherLayer = (typeof ALLOWED_LAYERS)[number];
+
+function isValidLayer(layer: string): layer is WeatherLayer {
+    return ALLOWED_LAYERS.includes(layer as WeatherLayer);
+}
+
+function isValidTileCoord(value: string): boolean {
+    const n = Number(value);
+    return Number.isInteger(n) && n >= 0;
+}
+
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ z: string; x: string; y: string }> },
+) {
+    const { z, x, y } = await params;
+    const layer = req.nextUrl.searchParams.get("layer");
+
+    if (!layer || !isValidLayer(layer)) {
+        return NextResponse.json(
+            { error: `Invalid layer. Must be one of: ${ALLOWED_LAYERS.join(", ")}` },
+            { status: 400 },
+        );
+    }
+
+    if (!isValidTileCoord(z) || !isValidTileCoord(x) || !isValidTileCoord(y)) {
+        return NextResponse.json(
+            { error: "Invalid tile coordinates" },
+            { status: 400 },
+        );
+    }
+
+    const apiKey = process.env.OPENWEATHERMAP_API_KEY;
+    if (!apiKey) {
+        return NextResponse.json(
+            { error: "Weather API not configured" },
+            { status: 503 },
+        );
+    }
+
+    const tileUrl = `https://tile.openweathermap.org/map/${layer}/${z}/${x}/${y}.png?appid=${apiKey}`;
+
+    try {
+        const response = await fetch(tileUrl, {
+            headers: { "User-Agent": "WorldWideView/1.0" },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch weather tile" },
+                { status: 502 },
+            );
+        }
+
+        const buffer = await response.arrayBuffer();
+
+        return new Response(buffer, {
+            status: 200,
+            headers: {
+                "Content-Type": "image/png",
+                "Cache-Control": "public, max-age=600, stale-while-revalidate=300",
+            },
+        });
+    } catch (error) {
+        console.error("[WeatherTile] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch weather tile" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/components/panels/GraphicsSettings.tsx
+++ b/src/components/panels/GraphicsSettings.tsx
@@ -11,6 +11,7 @@
 import React, { useEffect } from "react";
 import { useStore } from "@/core/state/store";
 import { trackEvent } from "@/lib/analytics";
+import { WEATHER_LAYERS } from "@/lib/weatherLayers";
 import "./graphics-settings.css";
 
 /**
@@ -19,24 +20,22 @@ import "./graphics-settings.css";
  */
 const DEFAULT_GRAPHICS = {
     resolutionScale: 1.0,
-    enableFxaa: false,
-    msaaSamples: 1,
+    antiAliasing: "fxaa" as const,
     maxScreenSpaceError: 16,
     shadowsEnabled: false,
     enableLighting: false,
     showFps: false,
     showOsmBuildings: true,
-    weatherOverlay: null,
+    weatherOverlay: null as string | null,
 };
 
-const WEATHER_OPTIONS = [
-    { label: "Off", value: "" },
-    { label: "Clouds", value: "clouds_new" },
-    { label: "Precipitation", value: "precipitation_new" },
-    { label: "Temperature", value: "temp_new" },
-    { label: "Wind Speed", value: "wind_new" },
-    { label: "Pressure", value: "pressure_new" },
-];
+const WEATHER_LABEL: Record<string, string> = {
+    clouds_new: "Clouds",
+    precipitation_new: "Precipitation",
+    temp_new: "Temperature",
+    wind_new: "Wind Speed",
+    pressure_new: "Pressure",
+};
 
 const RESOLUTION_OPTIONS = [
     { label: "0.5×", value: 0.5 },
@@ -86,14 +85,14 @@ export function GraphicsSettings() {
             className="gfx-settings__select"
             value={mapConfig.resolutionScale}
             onChange={(e) => {
-                        const v = parseFloat(e.target.value);
-                        update({ resolutionScale: v });
-                        trackEvent("graphics-setting", { key: "resolutionScale", value: v });
-                    }}
+              const v = parseFloat(e.target.value);
+              update({ resolutionScale: v });
+              trackEvent("graphics-setting", { key: "resolutionScale", value: v });
+            }}
           >
             {RESOLUTION_OPTIONS.map((o) => (
               <option key={o.value} value={o.value}>{o.label}</option>
-                    ))}
+            ))}
           </select>
         </div>
 
@@ -104,14 +103,14 @@ export function GraphicsSettings() {
             className="gfx-settings__select"
             value={mapConfig.antiAliasing}
             onChange={(e) => {
-                        const v = e.target.value as "none" | "fxaa" | "msaa2x" | "msaa4x" | "msaa8x";
-                        update({ antiAliasing: v });
-                        trackEvent("graphics-setting", { key: "antiAliasing", value: v });
-                    }}
+              const v = e.target.value as "none" | "fxaa" | "msaa2x" | "msaa4x" | "msaa8x";
+              update({ antiAliasing: v });
+              trackEvent("graphics-setting", { key: "antiAliasing", value: v });
+            }}
           >
             {AA_OPTIONS.map((o) => (
               <option key={o.value} value={o.value}>{o.label}</option>
-                    ))}
+            ))}
           </select>
         </div>
 
@@ -127,13 +126,13 @@ export function GraphicsSettings() {
               step={1}
               value={mapConfig.maxScreenSpaceError}
               onChange={(e) => {
-                            const v = parseInt(e.target.value, 10);
-                            update({ maxScreenSpaceError: v });
-                        }}
+                const v = parseInt(e.target.value, 10);
+                update({ maxScreenSpaceError: v });
+              }}
               onPointerUp={() => trackEvent("graphics-setting", {
-                            key: "maxScreenSpaceError",
-                            value: mapConfig.maxScreenSpaceError,
-                        })}
+                key: "maxScreenSpaceError",
+                value: mapConfig.maxScreenSpaceError,
+              })}
             />
             <span className="gfx-settings__slider-value">{mapConfig.maxScreenSpaceError}</span>
           </div>
@@ -176,14 +175,15 @@ export function GraphicsSettings() {
             className="gfx-settings__select"
             value={mapConfig.weatherOverlay || ""}
             onChange={(e) => {
-                        const v = e.target.value || null;
-                        update({ weatherOverlay: v });
-                        trackEvent("graphics-setting", { key: "weatherOverlay", value: v || "off" });
-                    }}
+              const v = e.target.value || null;
+              update({ weatherOverlay: v });
+              trackEvent("graphics-setting", { key: "weatherOverlay", value: v || "off" });
+            }}
           >
-            {WEATHER_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-                    ))}
+            <option value="">Off</option>
+            {WEATHER_LAYERS.map((id) => (
+              <option key={id} value={id}>{WEATHER_LABEL[id] ?? id}</option>
+            ))}
           </select>
         </div>
 
@@ -202,9 +202,9 @@ export function GraphicsSettings() {
             className="btn"
             style={{ width: "100%", height: 32 }}
             onClick={() => {
-                        update({ ...DEFAULT_GRAPHICS });
-                        trackEvent("graphics-setting-reset");
-                    }}
+              update({ ...DEFAULT_GRAPHICS });
+              trackEvent("graphics-setting-reset");
+            }}
           >
             Reset to Defaults
           </button>

--- a/src/components/panels/GraphicsSettings.tsx
+++ b/src/components/panels/GraphicsSettings.tsx
@@ -26,7 +26,17 @@ const DEFAULT_GRAPHICS = {
     enableLighting: false,
     showFps: false,
     showOsmBuildings: true,
+    weatherOverlay: null,
 };
+
+const WEATHER_OPTIONS = [
+    { label: "Off", value: "" },
+    { label: "Clouds", value: "clouds_new" },
+    { label: "Precipitation", value: "precipitation_new" },
+    { label: "Temperature", value: "temp_new" },
+    { label: "Wind Speed", value: "wind_new" },
+    { label: "Pressure", value: "pressure_new" },
+];
 
 const RESOLUTION_OPTIONS = [
     { label: "0.5×", value: 0.5 },
@@ -57,10 +67,10 @@ export function GraphicsSettings() {
     // Save to cookie on change
      
     useEffect(() => {
-        const { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps, showOsmBuildings } = mapConfig;
-        const graphicsToSave = { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps, showOsmBuildings };
+        const { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps, showOsmBuildings, weatherOverlay } = mapConfig;
+        const graphicsToSave = { resolutionScale, antiAliasing, maxScreenSpaceError, shadowsEnabled, enableLighting, showFps, showOsmBuildings, weatherOverlay };
         document.cookie = `wwv_graphics=${encodeURIComponent(JSON.stringify(graphicsToSave))}; path=/; max-age=31536000`; // 1 year
-    }, [mapConfig.resolutionScale, mapConfig.antiAliasing, mapConfig.maxScreenSpaceError, mapConfig.shadowsEnabled, mapConfig.enableLighting, mapConfig.showFps, mapConfig.showOsmBuildings]);
+    }, [mapConfig.resolutionScale, mapConfig.antiAliasing, mapConfig.maxScreenSpaceError, mapConfig.shadowsEnabled, mapConfig.enableLighting, mapConfig.showFps, mapConfig.showOsmBuildings, mapConfig.weatherOverlay]);
 
     const toggle = (key: string, current: boolean) => {
         update({ [key]: !current });
@@ -157,6 +167,24 @@ export function GraphicsSettings() {
             onClick={() => toggle("showOsmBuildings", mapConfig.showOsmBuildings)}
             aria-label="Toggle 3D Buildings"
           />
+        </div>
+
+        {/* Weather Overlay */}
+        <div className="gfx-settings__row">
+          <span className="gfx-settings__label">Weather</span>
+          <select
+            className="gfx-settings__select"
+            value={mapConfig.weatherOverlay || ""}
+            onChange={(e) => {
+                        const v = e.target.value || null;
+                        update({ weatherOverlay: v });
+                        trackEvent("graphics-setting", { key: "weatherOverlay", value: v || "off" });
+                    }}
+          >
+            {WEATHER_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+          </select>
         </div>
 
         {/* Show FPS */}

--- a/src/core/globe/useImageryManager.ts
+++ b/src/core/globe/useImageryManager.ts
@@ -170,38 +170,29 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
     // 4. Manage Weather Overlay (semi-transparent tile layer on top of base imagery)
     useEffect(() => {
         if (!viewer || !viewerReady || viewer.isDestroyed()) return;
-
-        // Remove existing weather layer
-        if (weatherLayerRef.current) {
-            viewer.imageryLayers.remove(weatherLayerRef.current);
-            weatherLayerRef.current = null;
-        }
-
         if (!weatherOverlay) return;
 
-        let cancelled = false;
-        let addedLayer: ImageryLayer | null = null;
+        let layer: ImageryLayer | null = null;
 
         try {
             const provider = new UrlTemplateImageryProvider({
                 url: `/api/weather/tile/{z}/{x}/{y}?layer=${weatherOverlay}`,
             });
-            const layer = new ImageryLayer(provider, { alpha: 0.6 });
-
-            if (cancelled || viewer.isDestroyed()) return;
-
-            viewer.imageryLayers.add(layer);
-            addedLayer = layer;
-            weatherLayerRef.current = layer;
+            layer = new ImageryLayer(provider, { alpha: 0.6 });
         } catch (err) {
             console.warn("[useImageryManager] Failed to load weather overlay:", err);
+            return;
         }
 
+        if (viewer.isDestroyed()) return;
+
+        viewer.imageryLayers.add(layer);
+        weatherLayerRef.current = layer;
+
         return () => {
-            cancelled = true;
-            if (addedLayer && !viewer.isDestroyed()) {
-                viewer.imageryLayers.remove(addedLayer);
-                if (weatherLayerRef.current === addedLayer) {
+            if (layer && !viewer.isDestroyed()) {
+                viewer.imageryLayers.remove(layer);
+                if (weatherLayerRef.current === layer) {
                     weatherLayerRef.current = null;
                 }
             }

--- a/src/core/globe/useImageryManager.ts
+++ b/src/core/globe/useImageryManager.ts
@@ -7,6 +7,7 @@ import {
     Cesium3DTileset,
     Cesium3DTileStyle,
     Terrain,
+    UrlTemplateImageryProvider,
     createOsmBuildingsAsync
 } from "cesium";
 import { useStore } from "@/core/state/store";
@@ -18,6 +19,7 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
     const fallbackLayerId = useStore((s) => s.mapConfig.fallbackLayerId);
     const sceneMode = useStore((s) => s.mapConfig.sceneMode);
     const showOsmBuildings = useStore((s) => s.mapConfig.showOsmBuildings);
+    const weatherOverlay = useStore((s) => s.mapConfig.weatherOverlay);
 
     // Resolve runtime truth:
     const activeLayerId = fallbackLayerId || baseLayerId;
@@ -25,6 +27,7 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
     const currentImageryLayerRef = useRef<ImageryLayer | null>(null);
     const osmBuildingsRef = useRef<Cesium3DTileset | null>(null);
     const terrainActiveRef = useRef(false);
+    const weatherLayerRef = useRef<ImageryLayer | null>(null);
 
     // 1. Manage Scene Mode (2D / 3D / Columbus)
     useEffect(() => {
@@ -163,6 +166,37 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
             osmBuildingsRef.current = null;
         }
     }, [viewer, viewerReady, isGoogle3D, is3DMode, showOsmBuildings]);
+
+    // 4. Manage Weather Overlay (semi-transparent tile layer on top of base imagery)
+    useEffect(() => {
+        if (!viewer || !viewerReady || viewer.isDestroyed()) return;
+
+        // Remove existing weather layer
+        if (weatherLayerRef.current) {
+            viewer.imageryLayers.remove(weatherLayerRef.current);
+            weatherLayerRef.current = null;
+        }
+
+        if (!weatherOverlay) return;
+
+        try {
+            const provider = new UrlTemplateImageryProvider({
+                url: `/api/weather/tile/{z}/{x}/{y}?layer=${weatherOverlay}`,
+            });
+            const layer = new ImageryLayer(provider, { alpha: 0.6 });
+            viewer.imageryLayers.add(layer);
+            weatherLayerRef.current = layer;
+        } catch (err) {
+            console.warn("[useImageryManager] Failed to load weather overlay:", err);
+        }
+
+        return () => {
+            if (weatherLayerRef.current && !viewer.isDestroyed()) {
+                viewer.imageryLayers.remove(weatherLayerRef.current);
+                weatherLayerRef.current = null;
+            }
+        };
+    }, [viewer, viewerReady, weatherOverlay]);
 
     return {
         isGoogle3D

--- a/src/core/globe/useImageryManager.ts
+++ b/src/core/globe/useImageryManager.ts
@@ -179,21 +179,31 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
 
         if (!weatherOverlay) return;
 
+        let cancelled = false;
+        let addedLayer: ImageryLayer | null = null;
+
         try {
             const provider = new UrlTemplateImageryProvider({
                 url: `/api/weather/tile/{z}/{x}/{y}?layer=${weatherOverlay}`,
             });
             const layer = new ImageryLayer(provider, { alpha: 0.6 });
+
+            if (cancelled || viewer.isDestroyed()) return;
+
             viewer.imageryLayers.add(layer);
+            addedLayer = layer;
             weatherLayerRef.current = layer;
         } catch (err) {
             console.warn("[useImageryManager] Failed to load weather overlay:", err);
         }
 
         return () => {
-            if (weatherLayerRef.current && !viewer.isDestroyed()) {
-                viewer.imageryLayers.remove(weatherLayerRef.current);
-                weatherLayerRef.current = null;
+            cancelled = true;
+            if (addedLayer && !viewer.isDestroyed()) {
+                viewer.imageryLayers.remove(addedLayer);
+                if (weatherLayerRef.current === addedLayer) {
+                    weatherLayerRef.current = null;
+                }
             }
         };
     }, [viewer, viewerReady, weatherOverlay]);

--- a/src/core/state/configSlice.ts
+++ b/src/core/state/configSlice.ts
@@ -63,6 +63,8 @@ export interface MapConfig {
     sceneMode: 1 | 2 | 3;
     /** Whether OSM 3D Buildings are shown on non-Google imagery layers. */
     showOsmBuildings: boolean;
+    /** Active weather overlay layer ID, or null if disabled. */
+    weatherOverlay: string | null;
 }
 
 /**
@@ -111,6 +113,7 @@ export const createConfigSlice: StateCreator<AppStore, [], [], ConfigSlice> = (s
         fallbackLayerId: null,
         sceneMode: 3,
         showOsmBuildings: true,
+        weatherOverlay: null,
     },
     updateDataConfig: (config) => set((state) => ({
             dataConfig: { ...state.dataConfig, ...config },

--- a/src/lib/weatherLayers.ts
+++ b/src/lib/weatherLayers.ts
@@ -1,0 +1,13 @@
+export const WEATHER_LAYERS = [
+    "clouds_new",
+    "precipitation_new",
+    "pressure_new",
+    "wind_new",
+    "temp_new",
+] as const;
+
+export type WeatherLayer = (typeof WEATHER_LAYERS)[number];
+
+export function isValidWeatherLayer(layer: string): layer is WeatherLayer {
+    return (WEATHER_LAYERS as readonly string[]).includes(layer);
+}

--- a/src/plugins/weather/weatherLayers.test.ts
+++ b/src/plugins/weather/weatherLayers.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import {
+    beforeEach, describe, expect, it, vi
+} from "vitest";
+import { GET } from "@/app/api/weather/layers/route";
+
+describe("/api/weather/layers", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns available layers with tile URL when configured", async () => {
+        vi.stubEnv("OPENWEATHERMAP_API_KEY", "test-key-123");
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.configured).toBe(true);
+        expect(json.tileUrlTemplate).toBe("/api/weather/tile/{z}/{x}/{y}?layer={layer}");
+        expect(json.layers).toHaveLength(5);
+    });
+
+    it("returns all expected layer IDs", async () => {
+        vi.stubEnv("OPENWEATHERMAP_API_KEY", "test-key-123");
+
+        const response = await GET();
+        const json = await response.json();
+
+        const ids = json.layers.map((l: any) => l.id);
+        expect(ids).toEqual([
+            "clouds_new",
+            "precipitation_new",
+            "pressure_new",
+            "wind_new",
+            "temp_new",
+        ]);
+    });
+
+    it("each layer has id, name, and description", async () => {
+        vi.stubEnv("OPENWEATHERMAP_API_KEY", "test-key-123");
+
+        const response = await GET();
+        const json = await response.json();
+
+        for (const layer of json.layers) {
+            expect(typeof layer.id).toBe("string");
+            expect(typeof layer.name).toBe("string");
+            expect(typeof layer.description).toBe("string");
+        }
+    });
+
+    it("returns configured=false and null tile URL when key is missing", async () => {
+        vi.stubEnv("OPENWEATHERMAP_API_KEY", "");
+
+        const response = await GET();
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.configured).toBe(false);
+        expect(json.tileUrlTemplate).toBeNull();
+        expect(json.layers).toHaveLength(5);
+    });
+});

--- a/src/plugins/weather/weatherTile.test.ts
+++ b/src/plugins/weather/weatherTile.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import {
+    beforeEach, describe, expect, it, vi
+} from "vitest";
+import { GET } from "@/app/api/weather/tile/[z]/[x]/[y]/route";
+import { NextRequest } from "next/server";
+
+function makeRequest(layer: string | null, z = "3", x = "4", y = "2") {
+    const url = new URL(`http://localhost/api/weather/tile/${z}/${x}/${y}`);
+    if (layer !== null) url.searchParams.set("layer", layer);
+    const req = new NextRequest(url);
+    const params = Promise.resolve({ z, x, y });
+    return { req, params };
+}
+
+const fakePng = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+describe("/api/weather/tile/[z]/[x]/[y]", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.stubEnv("OPENWEATHERMAP_API_KEY", "test-key-123");
+    });
+
+    it("proxies a valid tile request and returns PNG", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => fakePng.buffer,
+        }));
+
+        const { req, params } = makeRequest("precipitation_new");
+        const response = await GET(req, { params });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Type")).toBe("image/png");
+
+        const body = new Uint8Array(await response.arrayBuffer());
+        expect(body[0]).toBe(0x89);
+        expect(body[1]).toBe(0x50);
+    });
+
+    it("passes correct URL to upstream", async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => fakePng.buffer,
+        });
+        vi.stubGlobal("fetch", mockFetch);
+
+        const { req, params } = makeRequest("wind_new", "5", "10", "12");
+        await GET(req, { params });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://tile.openweathermap.org/map/wind_new/5/10/12.png?appid=test-key-123",
+            expect.objectContaining({
+                headers: { "User-Agent": "WorldWideView/1.0" },
+            }),
+        );
+    });
+
+    it("returns 400 when layer param is missing", async () => {
+        const { req, params } = makeRequest(null);
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toContain("Invalid layer");
+    });
+
+    it("returns 400 for an invalid layer name", async () => {
+        const { req, params } = makeRequest("invalid_layer");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toContain("Invalid layer");
+    });
+
+    it("returns 400 for negative tile coordinates", async () => {
+        const { req, params } = makeRequest("clouds_new", "-1", "0", "0");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toBe("Invalid tile coordinates");
+    });
+
+    it("returns 400 for non-integer tile coordinates", async () => {
+        const { req, params } = makeRequest("clouds_new", "1.5", "0", "0");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toBe("Invalid tile coordinates");
+    });
+
+    it("returns 400 for non-numeric tile coordinates", async () => {
+        const { req, params } = makeRequest("clouds_new", "abc", "0", "0");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toBe("Invalid tile coordinates");
+    });
+
+    it("returns 503 when API key is not configured", async () => {
+        vi.stubEnv("OPENWEATHERMAP_API_KEY", "");
+
+        const { req, params } = makeRequest("clouds_new");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(json.error).toBe("Weather API not configured");
+    });
+
+    it("returns 502 when upstream returns non-ok status", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+        }));
+
+        const { req, params } = makeRequest("temp_new");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json.error).toBe("Failed to fetch weather tile");
+    });
+
+    it("returns 502 when fetch throws a network error", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(
+            new Error("Network error"),
+        ));
+
+        const { req, params } = makeRequest("pressure_new");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(502);
+        expect(json.error).toBe("Failed to fetch weather tile");
+    });
+
+    it("sets correct cache headers on success", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => fakePng.buffer,
+        }));
+
+        const { req, params } = makeRequest("clouds_new");
+        const response = await GET(req, { params });
+
+        expect(response.headers.get("Cache-Control")).toBe(
+            "public, max-age=600, stale-while-revalidate=300",
+        );
+    });
+
+    it("accepts all valid layer names", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => fakePng.buffer,
+        }));
+
+        const layers = ["clouds_new", "precipitation_new", "pressure_new", "wind_new", "temp_new"];
+        for (const layer of layers) {
+            const { req, params } = makeRequest(layer);
+            const response = await GET(req, { params });
+            expect(response.status).toBe(200);
+        }
+    });
+});

--- a/src/plugins/weather/weatherTile.test.ts
+++ b/src/plugins/weather/weatherTile.test.ts
@@ -101,6 +101,38 @@ describe("/api/weather/tile/[z]/[x]/[y]", () => {
         expect(json.error).toBe("Invalid tile coordinates");
     });
 
+    it("returns 400 when x/y exceed max for zoom level", async () => {
+        // At zoom 0, only tile (0,0) is valid (2^0 = 1)
+        const { req, params } = makeRequest("clouds_new", "0", "1", "0");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toBe("Invalid tile coordinates");
+    });
+
+    it("returns 400 when zoom exceeds max supported level", async () => {
+        const { req, params } = makeRequest("clouds_new", "19", "0", "0");
+        const response = await GET(req, { params });
+        const json = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(json.error).toBe("Invalid tile coordinates");
+    });
+
+    it("accepts max valid tile coordinates for zoom level", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => fakePng.buffer,
+        }));
+
+        // At zoom 2, valid range is 0..3 (2^2 = 4)
+        const { req, params } = makeRequest("clouds_new", "2", "3", "3");
+        const response = await GET(req, { params });
+
+        expect(response.status).toBe(200);
+    });
+
     it("returns 503 when API key is not configured", async () => {
         vi.stubEnv("OPENWEATHERMAP_API_KEY", "");
 


### PR DESCRIPTION
## Summary
- Adds weather radar tile overlays (clouds, precipitation, temperature, wind, pressure) via OpenWeatherMap
- Server-side tile proxy at `/api/weather/tile/[z]/[x]/[y]` keeps the API key hidden
- Metadata endpoint at `/api/weather/layers` returns available layers and config status
- Cesium `UrlTemplateImageryProvider` renders tiles as a semi-transparent overlay (60% opacity)
- Dropdown in Graphics settings to toggle weather layers, persisted to cookies
- `OPENWEATHERMAP_API_KEY` added to `.env.example`

Closes #10.

## Design
Weather tiles are imagery overlays, not entity data. They don't go through the plugin/data engine pipeline. Instead they follow the same integration pattern as OSM 3D Buildings (#135): state in `configSlice`, rendering in `useImageryManager`, toggle in `GraphicsSettings`.

The tile proxy validates layer names against a strict allowlist and tile coordinates as non-negative integers. Returns 503 if the API key is not configured, 502 for upstream failures. Tiles are cached for 10 minutes via Next.js ISR and browser cache headers.

In Google 3D mode the globe surface is hidden, so weather overlays naturally disappear without errors. They reappear when switching to any standard imagery layer.

## Changed files
- `.env.example` (+4)
- `src/core/state/configSlice.ts` (+3) -- `weatherOverlay` field
- `src/core/globe/useImageryManager.ts` (+34) -- weather tile imagery layer
- `src/components/panels/GraphicsSettings.tsx` (+31) -- weather dropdown
- `src/app/api/weather/tile/[z]/[x]/[y]/route.ts` (new) -- tile proxy
- `src/app/api/weather/layers/route.ts` (new) -- layers metadata
- `src/plugins/weather/weatherTile.test.ts` (new) -- 12 tests
- `src/plugins/weather/weatherLayers.test.ts` (new) -- 4 tests

## Test plan
- 16 unit tests covering proxy happy path, all error branches, validation, and cache headers
- Full suite: 345/345 pass, 0 type errors, 0 lint errors
- Verified OWM tile URL format returns expected responses against live API
- Verified cookie serialization round-trips with `weatherOverlay: null`
- Weather overlay invisible in Google 3D mode (globe hidden), no errors