### PR TITLE
feat(auth): ADR-001 Workstream C — ticket auth, SSRF protection, and pre-flight audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/worldwideview
 # at the project root so docker-compose can inject it.
 AUTH_SECRET=
 
+# Encryption Master Key (REQUIRED — generate with: openssl rand -hex 16)
+# Must be exactly 32 characters. Used to derive the AES-256-GCM key for credentials at rest.
+# PRE-DEPLOY GATE: verify this is set in Coolify for every environment before merging C1 changes.
+# If unset the server will refuse to start (enforced in src/instrumentation.ts).
+ENCRYPTION_MASTER_KEY=
+
 # Cesium Ion Access Token (optional — get one free at https://ion.cesium.com/)
 NEXT_PUBLIC_CESIUM_ION_TOKEN=
 
@@ -47,6 +53,25 @@ ACLED_PASSWORD=
 # Marketplace Bridge Token — shared secret for marketplace → WWV install requests
 # Generate any random string, then set the same value in the marketplace instance config.
 WWV_BRIDGE_TOKEN=
+
+# Marketplace URL — used by ticketClient.ts for token exchange (server-side only)
+# Falls back to NEXT_PUBLIC_WWV_MARKETPLACE_URL then https://app.worldwideview.dev
+MARKETPLACE_URL=
+
+# Marketplace URL — used for PKCE connect/callback and client-side links
+NEXT_PUBLIC_WWV_MARKETPLACE_URL=
+
+# Plugin Ticket Auth — comma-separated plugin IDs that require WS first-message auth (ADR-001).
+# Empty (default) = ticket auth dormant for all plugins. Set AFTER Marketplace + Data Engine deploy.
+# Example: NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS=aviation,maritime
+NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS=
+
+# SSRF Proxy Host Allowlist (REQUIRED in production)
+# "*" = permissive (logs WARN per request — use to observe traffic for one week, then tighten).
+# ""  = deny all (safe default when not set).
+# Comma-separated list = only those hostnames allowed (e.g. "192.168.1.100,camera.example.com").
+# Ship with "*" in Coolify; replace with concrete list after one week of log observation.
+PROXY_HOST_ALLOWLIST=*
 
 # Default plugins enabled on boot for demo edition
 # Comma-separated list of plugin IDs

--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       NEXT_PUBLIC_WWV_EDITION: local
       AUTH_SECRET: ci-placeholder-secret-not-used-in-tests
+      ENCRYPTION_MASTER_KEY: ci-placeholder-key-not-used-in-tests
     steps:
       - uses: actions/checkout@v6
       

--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -32,7 +32,9 @@ jobs:
         run: pnpm install --frozen-lockfile
         
       - name: Setup environment
-        run: cp .env.example .env
+        run: |
+          cp .env.example .env
+          sed -i 's/^ENCRYPTION_MASTER_KEY=.*/ENCRYPTION_MASTER_KEY=ci-placeholder-key-not-used-in-tests/' .env
         
       - name: Test predev setup
         # Tests that Docker DB boots, port mappings work, Prisma pushes schema, and plugins sync

--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           cp .env.example .env
           sed -i 's/^ENCRYPTION_MASTER_KEY=.*/ENCRYPTION_MASTER_KEY=ci-placeholder-key-not-used-in-tests/' .env
+          sed -i 's/^AUTH_SECRET=.*/AUTH_SECRET=ci-placeholder-secret-not-used-in-tests/' .env
         
       - name: Test predev setup
         # Tests that Docker DB boots, port mappings work, Prisma pushes schema, and plugins sync

--- a/docs/deploys/2026-05-21-adr-001-preflight.md
+++ b/docs/deploys/2026-05-21-adr-001-preflight.md
@@ -1,0 +1,167 @@
+# ADR-001 Pre-flight Audit — 2026-05-21
+
+**Auditor:** Claude (ADR-001 Local App workstream) &nbsp; **Branch:** `feat/adr-001-local-app`  
+**Status:** Complete — see gate summary in §6
+
+This document records the six step-0 checklist items from the master deploy plan
+(`i-want-you-to-delightful-candle.md`, §"Deploy Order") before any ADR-001 code
+lands on production.
+
+---
+
+## 1. Coolify Env-Var Audit
+
+Swept every `JWT_*`, `TICKET_*`, `JWKS_*`, and `AUTH_*` variable across the three
+live services. Values are masked; only presence is recorded.
+
+### Debris check
+
+| Service | Coolify resource | `JWT_*` | `TICKET_*` | `JWKS_*` | `AUTH_SECRET` | Decision |
+|---|---|---|---|---|---|---|
+| Local App | `worldwideview-demo` | — | — | — | ✓ set | nothing to remove |
+| Data Engine | `wwv-engine-stack` | — | — | — | — | nothing to remove |
+| Marketplace | `worldwideview-marketplace` | — | — | — | — | nothing to remove |
+
+**Result: No debris from the previous failed deploy.** All three services are clean.
+No removals required.
+
+### ADR-001 vars — gaps to fill in deploy steps 1–2
+
+| Service | Missing var | Required by | When to set | Notes |
+|---|---|---|---|---|
+| `worldwideview-demo` | `ENCRYPTION_MASTER_KEY` | **C1 hard gate** | **Step 1 — first action** | Without it the app boots but step-1 code will refuse to start |
+| `worldwideview-demo` | `MARKETPLACE_URL` | C3 ticketClient | Step 1 | Server-side token exchange endpoint |
+| `worldwideview-demo` | `NEXT_PUBLIC_WWV_MARKETPLACE_URL` | C3/C5 client | Step 1 | Client-side Marketplace link |
+| `worldwideview-demo` | `PROXY_HOST_ALLOWLIST` | C2 SSRF | Step 1 | Set to `"*"` (observation mode); tighten in step 7c |
+| `worldwideview-demo` | `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS` | C5 flag | Step 6 | Leave empty (dormant) until step 6 cutover |
+| `worldwideview-marketplace` | `DATABASE_URL`, `AUTH_SECRET` | A basics | Step 2 | Marketplace cannot function without these |
+| `worldwideview-marketplace` | EdDSA signing key + JWKS endpoint | A1–A2 | Step 2 | Required for `/api/auth/exchange` to sign tickets |
+| `wwv-engine-stack` | JWKS / JWT public-key config | B JWKS wiring | Step 4 | See §5 — not blocking until cutover |
+
+---
+
+## 2. Data Engine `main` Branch State
+
+**Repo:** `silvertakana/wwv-data-engine`  
+**Branch audited:** `main` (HEAD matches `feat/adr-001-data-engine`)
+
+The `main` branch is **not** in a rolled-back clean state. The decentralised auth
+work from the prior attempt was **retained and fully merged** (PR #5
+`feature/decentralised-plugin-auth-data-engine`, PR #6 `chore/standardise-ci`), with
+four additional fix commits on top.
+
+**Auth code present in `main`:**
+
+- Dependencies: `@fastify/jwt ^10`, `get-jwks ^11`, `jose ^6`
+- `websocket.ts` verifies EdDSA JWTs:
+  ```
+  allowedIss: 'https://marketplace.worldwideview.dev'
+  algorithms: ['EdDSA']
+  clockTolerance: 60
+  expectedAud: process.env.ENGINE_ID || 'wwv-data-engine'
+  ```
+
+**Env-gated bypass (commit `e3e2940`):**  
+`WWV_SKIP_WS_AUTH=true` is set on `wwv-engine-stack`. When true, every WS connection
+is pre-authenticated with no JWT required. **This bypass is currently load-bearing:**
+the JWKS endpoint is not yet wired (`websocket.ts:23` comment confirms), so the
+engine cannot verify real tokens. `WWV_SKIP_WS_AUTH=true` must stay until Workstream
+B wires JWKS (deploy step 4).
+
+**Uncommitted working-tree WIP (not blocking steps 1–3):**  
+`src/server.ts`, `src/websocket.ts`, `src/websocket.spec.ts` modified; untracked
+`HANDOFF.md`, `src/startup-checks.ts`, `vitest.config.ts`. The Data Engine
+workstream has unfinished work not yet committed. Must be resolved before step 4.
+
+---
+
+## 3. Dormant Routes / Flags Already in Production
+
+| Flag / Route | Service | Current value | Introduced | Notes |
+|---|---|---|---|---|
+| `WWV_SKIP_WS_AUTH` | `wwv-engine-stack` | `true` (load-bearing) | 2026-05-20 | Engine bypass — must stay `true` until JWKS wired (step 4) |
+
+No other ADR-001 feature flags are active in production. The old no-auth data path
+is still the only path through the Data Engine.
+
+---
+
+## 4. `ENCRYPTION_MASTER_KEY` Gate (C1)
+
+**Status: FAIL — not set on `worldwideview-demo`**
+
+The `ENCRYPTION_MASTER_KEY` env var is absent from the live Local App. Once
+`src/instrumentation.ts` boot validation ships (deploy step 1), the app will
+**refuse to start** if this var is missing.
+
+**Action required before deploy step 1:**  
+Generate a 32-character key (`openssl rand -hex 16`) and set `ENCRYPTION_MASTER_KEY`
+on `worldwideview-demo` in Coolify. This is the **first action of deploy step 1** and
+blocks all subsequent steps.
+
+---
+
+## 5. SDK Delivery Decision (Gate for Workstream B)
+
+**Status: OPEN — operator to confirm**
+
+No evidence of a published `@worldwideview/wwv-plugin-sdk` package in the deployed
+services. The `auth-contracts.ts` types (`TokenExchangeRequest`,
+`TokenExchangeResponse`, `PluginTicket`, `MarketplaceSessionToken`) currently live in
+the Local App's bundled SDK package.
+
+Workstream B JWKS wiring requires a decision on how the engine receives the
+Marketplace public key:
+- **Option A:** Ed25519 public key as a Coolify env var (simplest)
+- **Option B:** Remote JWKS URL env var — engine fetches key from
+  `https://marketplace.worldwideview.dev/.well-known/jwks.json` at startup
+
+**Cross-repo issuer alignment note:** The engine hard-codes
+`allowedIss: 'https://marketplace.worldwideview.dev'`. The Local App's `MARKETPLACE_URL`
+config defaults to `https://app.worldwideview.dev`. Confirm that the live Marketplace
+issues JWTs with `iss: https://marketplace.worldwideview.dev` before step 5 smoke test.
+
+This decision must be made and documented before deploy step 4.
+
+---
+
+## 6. Gate Summary
+
+| Gate | Status | Blocks deploy step | Action |
+|---|---|---|---|
+| No legacy JWT/TICKET debris | ✅ PASS | — | None |
+| `ENCRYPTION_MASTER_KEY` set on Local App | ❌ FAIL | **Step 1** | Set as first action of step 1 |
+| Marketplace configured (DB, auth, signing key) | ❌ FAIL | **Step 2** | Configure `worldwideview-marketplace` in Coolify |
+| SDK delivery decision confirmed | ⚠️ OPEN | Step 4 | Operator decision needed |
+| Data Engine JWKS wired | ❌ FAIL | Step 4 / cutover | `WWV_SKIP_WS_AUTH` bypass active until then |
+| Data Engine WIP committed | ⚠️ OPEN | Step 4 | Not blocking steps 1–3 |
+| Issuer alignment confirmed | ⚠️ OPEN | Step 5 smoke test | Verify `iss` claim matches engine `allowedIss` |
+
+**Top pre-cutover risks:**
+
+1. **JWKS not wired on the engine** — `WWV_SKIP_WS_AUTH=true` is the only thing
+   keeping streams alive. If this flag is ever accidentally unset, all WebSocket
+   streams break immediately.
+2. **Marketplace under-configured** — token exchange will error until step 2 env vars
+   are set. `worldwideview-marketplace` currently has only infra vars (NIXPACKS,
+   REDIS, REGISTRY_PRIVATE_KEY).
+3. **`ENCRYPTION_MASTER_KEY` missing** — deploy step 1 will trigger a boot refusal
+   if not set first. This is the riskiest item in the pre-cutover phase per the
+   master plan.
+
+---
+
+## 7. Cleanup Log
+
+**Removed this step (2026-05-21):**
+
+| Resource | Type | UUID | Reason |
+|---|---|---|---|
+| `wwv-app-stack` | Coolify service | `h3gtnyotl6b7007hudlfqyf9` | Operator-confirmed deprecated |
+
+**Remaining cleanup decisions (operator to confirm before step 4):**
+
+| Resource | Type | UUID | Notes |
+|---|---|---|---|
+| `worldwideview web` | Application | `cisr3bruyyvvoeym41dexxa3` | Repo `silvertakana/worldwideview-web`; only REDIS+AISSTREAM vars — appears stale. Verify before removing. |
+| `wwv-data-engine-legacy` | Application | `sj8519kr561va8ktcdq166hn` | Repo `wwv-data-engine-internal`, branch `master`; appears superseded by `wwv-engine-stack`. Verify before removing. |

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,79 @@
+# ADR-001 Feature Flags
+
+Single source of truth for all feature flags introduced by
+[ADR-0001](architecture/decisions/adr-0001-decentralized-plugin-auth-and-ssrf-mitigation.md)
+(Decentralized Plugin Auth + SSRF Mitigation).
+
+**Keep the per-environment table current** whenever a flag is set, changed, or
+removed in Coolify. Drift between staging and production is the primary paper-cut
+this doc exists to prevent.
+
+---
+
+## Flag Inventory
+
+### 5 Master-Plan Flags
+
+| Flag | Repo | Default | Meaning |
+|---|---|---|---|
+| `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS` | **Local App** | `""` (empty = dormant) | Comma-separated plugin IDs that require WS first-message auth (e.g. `aviation,maritime`). Empty or unset → ticket auth disabled for all plugins. Set *after* Marketplace + Data Engine are deployed (step 6). |
+| `REQUIRE_TICKET_AUTH` | **Data Engine** | `false` | When `true`, the engine rejects any WS connection that does not present a valid ticket. Global — applies to all plugins. Replaces `WWV_SKIP_WS_AUTH=false` once JWKS is wired (step 7a). |
+| `REQUIRE_TICKET_AUTH_PLUGINS` | **Data Engine** | `""` | Comma-separated plugin IDs for per-plugin enforcement before enabling the global flag. Not yet implemented (see Divergence Note below). |
+| `ENFORCE_ORIGIN_ALLOWLIST` | **Data Engine** | `false` | When `true`, the engine rejects connections from Origins not in its configured allowlist. Enable after populating the allowlist from observed traffic (step 7b). |
+| `PROXY_HOST_ALLOWLIST` | **Local App** | `""` (deny all) | SSRF allowlist for the camera / iframe proxy route. `""` or unset = deny all (safe default). `"*"` = permissive + logs WARN per host (observation mode). Comma-separated list = explicit allowlist. Ship `"*"` initially; tighten to an explicit list after one week of log observation (step 7c). |
+
+### Deployed Reality: `WWV_SKIP_WS_AUTH`
+
+> **Divergence note:** The Data Engine workstream implemented a single global bypass
+> flag (`WWV_SKIP_WS_AUTH`) instead of the three granular master-plan flags
+> (`REQUIRE_TICKET_AUTH`, `REQUIRE_TICKET_AUTH_PLUGINS`, `ENFORCE_ORIGIN_ALLOWLIST`).
+> The master-plan flags remain the target architecture and must be implemented before
+> step 7. `WWV_SKIP_WS_AUTH` is the current interim control.
+
+| Flag | Repo | Default | Meaning |
+|---|---|---|---|
+| `WWV_SKIP_WS_AUTH` | **Data Engine** | `false` | When `true`, every WS connection is pre-authenticated — no JWT is checked. **Currently `true` in production and load-bearing** (JWKS not yet wired; the engine cannot verify real tokens). Must stay `true` until deploy step 4 wires JWKS. Flip to `false` as part of step 5 smoke test, replacing it with `REQUIRE_TICKET_AUTH=true`. |
+
+---
+
+## Per-Environment Table
+
+Update this table whenever a flag changes in Coolify.
+
+| Flag | Local dev | Staging | Production | Last updated |
+|---|---|---|---|---|
+| `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS` | `""` (.env.example) | `""` (not set) | `""` (not set) | 2026-05-21 |
+| `REQUIRE_TICKET_AUTH` | N/A | N/A | N/A (not yet implemented) | — |
+| `REQUIRE_TICKET_AUTH_PLUGINS` | N/A | N/A | N/A (not yet implemented) | — |
+| `ENFORCE_ORIGIN_ALLOWLIST` | N/A | N/A | N/A (not yet implemented) | — |
+| `PROXY_HOST_ALLOWLIST` | `"*"` (.env.example) | TBD — set before step 5 | not set (= deny all) | 2026-05-21 |
+| `WWV_SKIP_WS_AUTH` | `false` | TBD — set before step 4 | `true` (**load-bearing**) | 2026-05-20 |
+
+---
+
+## Rollout Sequence
+
+The sequence in which flags are set during the ADR-001 deploy order:
+
+| Deploy step | Service | Flag change | Notes |
+|---|---|---|---|
+| Step 1 | Local App | Set `PROXY_HOST_ALLOWLIST="*"` | Observation mode — watch WARN logs for one week |
+| Step 3 | Local App | `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS=""` confirmed empty | Dormant — no change needed, just confirm |
+| Step 4 | Data Engine | JWKS wired; `WWV_SKIP_WS_AUTH` remains `true` | Both paths exist, neither enforced |
+| Step 5 (staging) | Local App | `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS=test-synthetic` | Smoke test only — revert after |
+| Step 5 (staging) | Data Engine | `WWV_SKIP_WS_AUTH=false` | Prove real JWT verification end-to-end |
+| Step 6 | Local App | `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS=<first-real-plugin>` | One plugin at a time, 24 h soak |
+| Step 6 | Data Engine | `REQUIRE_TICKET_AUTH_PLUGINS=<same-plugin>` | Mirror Local App change |
+| Step 7a | Data Engine | `REQUIRE_TICKET_AUTH=true` | Global default-deny; 24 h soak |
+| Step 7b | Data Engine | `ENFORCE_ORIGIN_ALLOWLIST=true` | After populating allowlist from observed connections |
+| Step 7c | Local App | `PROXY_HOST_ALLOWLIST=<observed-list>` | Replace `"*"` with explicit host list |
+
+---
+
+## Rollback
+
+Every step is independently revertable by flipping its single flag back. The old
+no-auth data path remains wired throughout steps 1–6 and is only superseded at
+step 7a. If anything breaks, removing the plugin from
+`NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS` immediately restores the old path for that
+plugin.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldwideview",
-  "version": "2.17.0",
-  "private": true,  
+  "version": "2.17.1",
+  "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "private": true,  
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/packages/wwv-plugin-sdk/src/auth-contracts.spec.ts
+++ b/packages/wwv-plugin-sdk/src/auth-contracts.spec.ts
@@ -1,10 +1,11 @@
  
 import { describe, it, expectTypeOf } from "vitest";
-import type { 
-    TokenExchangeRequest, 
-    TokenExchangeResponse, 
+import type {
+    TokenExchangeRequest,
+    TokenExchangeResponse,
     WebSocketAuthMessage,
     SensitiveString,
+    PluginTicket,
     Tier,
     PKCEConnectRequest,
     PKCETokenExchange,
@@ -40,7 +41,7 @@ describe("Auth Contracts", () => {
     it("WebSocketAuthMessage has exact required properties including protocol version", () => {
         expectTypeOf<WebSocketAuthMessage>().toHaveProperty("type").toEqualTypeOf<"auth">();
         expectTypeOf<WebSocketAuthMessage>().toHaveProperty("v").toEqualTypeOf<1>();
-        expectTypeOf<WebSocketAuthMessage>().toHaveProperty("token").toEqualTypeOf<SensitiveString>();
+        expectTypeOf<WebSocketAuthMessage>().toHaveProperty("token").toEqualTypeOf<PluginTicket>();
 
         // @ts-expect-error - missing version
         const _badMsg: WebSocketAuthMessage = { type: "auth", token: "jwt-token-here" as SensitiveString };

--- a/packages/wwv-plugin-sdk/src/auth-contracts.ts
+++ b/packages/wwv-plugin-sdk/src/auth-contracts.ts
@@ -8,6 +8,12 @@
  */
 export type SensitiveString = string & { readonly __brand: "SensitiveString" };
 
+/** Marketplace session JWT issued after PKCE; scoped to this Local App only. */
+export type MarketplaceSessionToken = string & { readonly __brand: "marketplace-session" };
+
+/** Short-lived, audience-bound JWT obtained from token exchange; used for WebSocket auth. */
+export type PluginTicket = string & { readonly __brand: "plugin-ticket" };
+
 /**
  * Factory function to safely cast a string to a SensitiveString.
  * This provides a single grep target for every place a secret enters the system.
@@ -66,7 +72,7 @@ export interface WebSocketAuthMessage {
     /** Protocol version to allow future wire shape evolution */
     v: 1;
     /** The short-lived JWT obtained from the Token Exchange */
-    token: SensitiveString;
+    token: PluginTicket;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,385 +221,6 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.13(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
 
-  local-plugins/wwv-plugin-air-defense:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.19
-      '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.14
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  local-plugins/wwv-plugin-airports:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-
-  local-plugins/wwv-plugin-aviation:
-    dependencies:
-      '@worldwideview/wwv-lib-aviation':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-aviation
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.16.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-borders:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-
-  local-plugins/wwv-plugin-camera:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.16.0(react@19.2.6)
-      react:
-        specifier: '>=18'
-        version: 19.2.6
-
-  local-plugins/wwv-plugin-civil-unrest:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      cesium:
-        specifier: ^1.139.0
-        version: 1.141.0
-      lucide-react:
-        specifier: ^0.477.0
-        version: 0.477.0(react@19.2.6)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.6
-      resium:
-        specifier: 1.19.4
-        version: 1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-conflict-events:
-    dependencies:
-      '@worldwideview/wwv-lib-incidents':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-incidents
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      cesium:
-        specifier: ^1.139.0
-        version: 1.141.0
-      lucide-react:
-        specifier: ^0.477.0
-        version: 0.477.0(react@19.2.6)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.6
-      resium:
-        specifier: 1.19.4
-        version: 1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-conflict-zones:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.19
-      '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.14
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  local-plugins/wwv-plugin-cyber-attacks:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.16.0(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-daynight:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-      lucide-react:
-        specifier: ^0.468.0
-        version: 0.468.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-earthquakes:
-    dependencies:
-      '@worldwideview/wwv-lib-incidents':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-incidents
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.16.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-embassies:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-fortiguard:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  local-plugins/wwv-plugin-gps-jamming:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      cesium:
-        specifier: ^1.139.0
-        version: 1.141.0
-      h3-js:
-        specifier: ^4.4.0
-        version: 4.4.0
-      lucide-react:
-        specifier: ^0.477.0
-        version: 0.477.0(react@19.2.6)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.6
-      resium:
-        specifier: 1.19.4
-        version: 1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-international-sanctions:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: ^1.14.0
-        version: 1.16.0(react@19.2.6)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-iranwarlive:
-    dependencies:
-      '@worldwideview/wwv-lib-incidents':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-incidents
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-lighthouses:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-maritime:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.16.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-military-aviation:
-    dependencies:
-      '@worldwideview/wwv-lib-aviation':
-        specifier: workspace:*
-        version: link:../../packages/wwv-lib-aviation
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.16.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-military-bases:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-mineral-mines:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.19
-      '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.14
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  local-plugins/wwv-plugin-nuclear:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-nz-traffic-cameras:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@types/node':
-        specifier: ^20.0.0
-        version: 20.19.41
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-      vitest:
-        specifier: ^1.0.0
-        version: 1.6.1(@types/node@20.19.41)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.47.1)
-
-  local-plugins/wwv-plugin-osm-search:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@types/react':
-        specifier: ^19.0.2
-        version: 19.2.14
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      typescript:
-        specifier: ^5.4.5
-        version: 5.9.3
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-satellite:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-seaports:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-spaceports:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-surveillance-satellites:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-undersea-cables:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-      typescript:
-        specifier: ^5.4.3
-        version: 5.9.3
-      vite:
-        specifier: ^8.0.8
-        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
-  local-plugins/wwv-plugin-volcanoes:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: ^1.4.10
-        version: 1.5.0(react@19.2.6)
-
-  local-plugins/wwv-plugin-wildfire:
-    dependencies:
-      '@worldwideview/wwv-plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/wwv-plugin-sdk
-      lucide-react:
-        specifier: '>=0.576.0'
-        version: 1.16.0(react@19.2.6)
-
   packages/wwv-cli:
     dependencies:
       commander:
@@ -937,34 +558,16 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -973,34 +576,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.0':
     resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -1009,22 +594,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -1033,22 +606,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -1057,22 +618,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -1081,22 +630,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -1105,34 +642,16 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.28.0':
     resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.0':
@@ -1147,12 +666,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.28.0':
     resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
     engines: {node: '>=18'}
@@ -1163,12 +676,6 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -1183,23 +690,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
@@ -1207,22 +702,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.0':
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.0':
@@ -1592,10 +1075,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@jest/schemas@29.6.3':
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2436,9 +1915,6 @@ packages:
     peerDependencies:
       webpack: '>=5.0.0'
 
-  '@sinclair/typebox@0.27.10':
-    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
-
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -2630,12 +2106,6 @@ packages:
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
-
-  '@types/node@20.19.41':
-    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
-
-  '@types/node@22.19.19':
-    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/node@25.7.0':
     resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
@@ -2936,9 +2406,6 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@1.6.1':
-    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
-
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
@@ -2956,26 +2423,14 @@ packages:
   '@vitest/pretty-format@4.1.6':
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@1.6.1':
-    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
-
   '@vitest/runner@4.1.6':
     resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
-
-  '@vitest/snapshot@1.6.1':
-    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@4.1.6':
     resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@1.6.1':
-    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
-
   '@vitest/spy@4.1.6':
     resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
-
-  '@vitest/utils@1.6.1':
-    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
@@ -3055,10 +2510,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -3159,9 +2610,6 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
-
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -3299,10 +2747,6 @@ packages:
       magicast:
         optional: true
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3340,10 +2784,6 @@ packages:
     resolution: {integrity: sha512-bRwgABDjsXRqNLjeJAxSlCrWCTvAt/yWJD30fY5CbqtoEKR6g/YCOcJW37vk4w/Gq3uMW7sF1uP74ajRrktjEw==}
     engines: {node: '>=22.0.0'}
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -3362,9 +2802,6 @@ packages:
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -3432,9 +2869,6 @@ packages:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
     engines: {node: '>=18'}
     hasBin: true
-
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
@@ -3532,10 +2966,6 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3582,10 +3012,6 @@ packages:
 
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
-
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3713,11 +3139,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
@@ -3894,10 +3315,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -4047,9 +3464,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -4060,10 +3474,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
@@ -4128,10 +3538,6 @@ packages:
 
   graphmatch@1.1.1:
     resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
-
-  h3-js@4.4.0:
-    resolution: {integrity: sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==}
-    engines: {node: '>=4', npm: '>=3', yarn: '>=1.3.0'}
 
   har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -4216,10 +3622,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -4390,10 +3792,6 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -4473,9 +3871,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -4647,10 +4042,6 @@ packages:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
-  local-pkg@0.5.1:
-    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
-    engines: {node: '>=14'}
-
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
@@ -4671,9 +4062,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -4688,16 +4076,6 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
-
-  lucide-react@0.468.0:
-    resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
-
-  lucide-react@0.477.0:
-    resolution: {integrity: sha512-yCf7aYxerFZAbd8jHJxjwe1j7jEMPptjnaOqdYeirFnEy85cNR3/L+o0I875CYFYya+eEVzZSbNuRk8BZPDpVw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lucide-react@1.16.0:
     resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
@@ -4762,10 +4140,6 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -4789,9 +4163,6 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
-  mlly@1.8.2:
-    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -4916,10 +4287,6 @@ packages:
   nosleep.js@0.12.0:
     resolution: {integrity: sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
@@ -4974,10 +4341,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-
   openid-client@6.8.4:
     resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
@@ -4992,10 +4355,6 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
-
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -5046,14 +4405,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -5108,9 +4461,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
@@ -5185,10 +4535,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -5279,9 +4625,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-
   react-player@3.4.0:
     resolution: {integrity: sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ==}
     peerDependencies:
@@ -5332,14 +4675,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  resium@1.19.4:
-    resolution: {integrity: sha512-RW0ffHlQUbgqbc0jDaF2Dnor/GKbiz5s5AKdamEKxMJfxiwQNgtgfaKK7UvafFpX25Y2J4DZP1MclTlEQ/5YUw==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      cesium: 1.x
-      react: '>=18.2.0'
-      react-dom: '>=18.2.0'
 
   resium@1.21.1:
     resolution: {integrity: sha512-Gst/KJlC0zDisja+lVWvTYsEs133+VmaUOcT6ka1fhoZGEdxbtAnP0USMyb1zoyghdBBp9g17VW8yib/NvEnug==}
@@ -5598,10 +4933,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
@@ -5613,9 +4944,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@2.1.1:
-    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   stripe@22.1.1:
     resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
@@ -5734,16 +5062,8 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.27:
@@ -5814,10 +5134,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
-
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
@@ -5862,18 +5178,12 @@ packages:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
-  ufo@1.6.4:
-    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
-
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.21.0:
     resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
@@ -5936,42 +5246,6 @@ packages:
   vimeo-video-element@1.7.0:
     resolution: {integrity: sha512-UydSgi8svX7Iwd7yInAJVzcGKPv3E705sjCjnevQSNlJBmLcitx4aq0IBczopK6zw0OFJPWd8Qqby0Yflkz42w==}
 
-  vite-node@1.6.1:
-    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@8.0.13:
     resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6013,31 +5287,6 @@ packages:
       tsx:
         optional: true
       yaml:
-        optional: true
-
-  vitest@1.6.1:
-    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.1
-      '@vitest/ui': 1.6.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@4.1.6:
@@ -6218,10 +5467,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -6625,103 +5870,52 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
   '@esbuild/android-arm@0.28.0':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
   '@esbuild/linux-s390x@0.28.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
@@ -6730,16 +5924,10 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -6748,25 +5936,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
@@ -7075,10 +6251,6 @@ snapshots:
   '@inquirer/type@4.0.5(@types/node@25.7.0)':
     optionalDependencies:
       '@types/node': 25.7.0
-
-  '@jest/schemas@29.6.3':
-    dependencies:
-      '@sinclair/typebox': 0.27.10
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7934,8 +7106,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sinclair/typebox@0.27.10': {}
-
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@spz-loader/core@0.3.0': {}
@@ -8157,14 +7327,6 @@ snapshots:
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 25.9.1
-
-  '@types/node@20.19.41':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.19.19':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@25.7.0':
     dependencies:
@@ -8470,11 +7632,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.13(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)
-
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -8488,12 +7645,6 @@ snapshots:
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.13(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2))
-
-  '@vitest/expect@1.6.1':
-    dependencies:
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      chai: 4.5.0
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -8516,22 +7667,10 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@1.6.1':
-    dependencies:
-      '@vitest/utils': 1.6.1
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
   '@vitest/runner@4.1.6':
     dependencies:
       '@vitest/utils': 4.1.6
       pathe: 2.0.3
-
-  '@vitest/snapshot@1.6.1':
-    dependencies:
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      pretty-format: 29.7.0
 
   '@vitest/snapshot@4.1.6':
     dependencies:
@@ -8540,18 +7679,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@1.6.1':
-    dependencies:
-      tinyspy: 2.2.1
-
   '@vitest/spy@4.1.6': {}
-
-  '@vitest/utils@1.6.1':
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -8654,10 +7782,6 @@ snapshots:
       acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
-  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -8791,8 +7915,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   assert-plus@1.0.0: {}
-
-  assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -8938,8 +8060,6 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.2
 
-  cac@6.7.14: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -8978,16 +8098,6 @@ snapshots:
       '@cesium/engine': 25.0.0
       '@cesium/widgets': 15.0.0
 
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -9002,10 +8112,6 @@ snapshots:
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
 
   cheerio-select@2.1.0:
     dependencies:
@@ -9081,8 +8187,6 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
-
-  confbox@0.1.8: {}
 
   confbox@0.2.4: {}
 
@@ -9212,10 +8316,6 @@ snapshots:
       mimic-response: 3.1.0
     optional: true
 
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
-
   deep-extend@0.6.0:
     optional: true
 
@@ -9253,8 +8353,6 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff-match-patch@1.0.5: {}
-
-  diff-sequences@29.6.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -9445,32 +8543,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -9754,18 +8826,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -9915,8 +8975,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-func-name@2.0.2: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9936,8 +8994,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stream@8.0.1: {}
 
   get-stream@9.0.1:
     dependencies:
@@ -9997,8 +9053,6 @@ snapshots:
   grapheme-splitter@1.0.4: {}
 
   graphmatch@1.1.1: {}
-
-  h3-js@4.4.0: {}
 
   har-schema@2.0.0: {}
 
@@ -10090,8 +9144,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
 
@@ -10266,8 +9318,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-stream@3.0.0: {}
-
   is-stream@4.0.1: {}
 
   is-string@1.1.1:
@@ -10343,8 +9393,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -10497,11 +9545,6 @@ snapshots:
 
   loader-runner@4.3.2: {}
 
-  local-pkg@0.5.1:
-    dependencies:
-      mlly: 1.8.2
-      pkg-types: 1.3.1
-
   localforage@1.10.0:
     dependencies:
       lie: 3.1.1
@@ -10520,10 +9563,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
-
   lru-cache@11.2.7: {}
 
   lru-cache@11.4.0: {}
@@ -10533,14 +9572,6 @@ snapshots:
       yallist: 3.1.1
 
   lru.min@1.1.4: {}
-
-  lucide-react@0.468.0(react@19.2.6):
-    dependencies:
-      react: 19.2.6
-
-  lucide-react@0.477.0(react@19.2.6):
-    dependencies:
-      react: 19.2.6
 
   lucide-react@1.16.0(react@19.2.6):
     dependencies:
@@ -10601,8 +9632,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mimic-fn@4.0.0: {}
-
   mimic-response@3.1.0:
     optional: true
 
@@ -10622,13 +9651,6 @@ snapshots:
 
   mkdirp-classic@0.5.3:
     optional: true
-
-  mlly@1.8.2:
-    dependencies:
-      acorn: 8.16.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.4
 
   module-details-from-path@1.0.4: {}
 
@@ -10735,10 +9757,6 @@ snapshots:
 
   nosleep.js@0.12.0: {}
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
   npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
@@ -10803,10 +9821,6 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-
   openid-client@6.8.4:
     dependencies:
       jose: 6.2.3
@@ -10830,10 +9844,6 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.2.2
 
   p-locate@5.0.0:
     dependencies:
@@ -10879,11 +9889,7 @@ snapshots:
       lru-cache: 11.4.0
       minipass: 7.1.3
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
-
-  pathval@1.1.1: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -10931,12 +9937,6 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.8.2
-      pathe: 2.0.3
 
   pkg-types@2.3.1:
     dependencies:
@@ -11015,12 +10015,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty-format@29.7.0:
-    dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
 
   pretty-ms@9.3.0:
     dependencies:
@@ -11122,8 +10116,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-is@18.3.1: {}
-
   react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@mux/mux-player-react': 3.11.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11213,12 +10205,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  resium@1.19.4(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      cesium: 1.141.0
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   resium@1.21.1(cesium@1.141.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -11582,18 +10568,12 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-final-newline@3.0.0: {}
-
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1:
     optional: true
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@2.1.1:
-    dependencies:
-      js-tokens: 9.0.1
 
   stripe@22.1.1(@types/node@25.7.0):
     optionalDependencies:
@@ -11672,11 +10652,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@0.8.4: {}
-
   tinyrainbow@3.1.0: {}
-
-  tinyspy@2.2.1: {}
 
   tldts-core@7.0.27: {}
 
@@ -11742,8 +10718,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-detect@4.1.0: {}
-
   type-fest@0.7.1: {}
 
   typed-array-buffer@1.0.3:
@@ -11804,8 +10778,6 @@ snapshots:
 
   ua-parser-js@1.0.41: {}
 
-  ufo@1.6.4: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -11814,8 +10786,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   underscore@1.13.8: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.21.0: {}
 
@@ -11894,35 +10864,6 @@ snapshots:
       '@vimeo/player': 2.29.0
       media-played-ranges-mixin: 0.1.0
 
-  vite-node@1.6.1(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.14
-      rollup: 4.60.4
-    optionalDependencies:
-      '@types/node': 20.19.41
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-      terser: 5.47.1
-
   vite@8.0.13(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2):
     dependencies:
       lightningcss: 1.32.0
@@ -11937,56 +10878,6 @@ snapshots:
       jiti: 2.7.0
       terser: 5.47.1
       tsx: 4.22.2
-
-  vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rolldown: 1.0.1
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.9.1
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.47.1
-      tsx: 4.22.2
-
-  vitest@1.6.1(@types/node@20.19.41)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.47.1):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.5
-      chai: 4.5.0
-      debug: 4.4.3
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1)
-      vite-node: 1.6.1(@types/node@20.19.41)(lightningcss@1.32.0)(terser@5.47.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.41
-      jsdom: 28.1.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.13(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)):
     dependencies:
@@ -12189,8 +11080,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -27,6 +27,7 @@ if (!existsSync(EXAMPLE)) {
 }
 
 const secret = randomBytes(32).toString("hex");
+const encryptionKey = randomBytes(32).toString("hex");
 let content = readFileSync(EXAMPLE, "utf8");
 
 // Fill in the AUTH_SECRET line
@@ -34,6 +35,13 @@ if (content.includes("AUTH_SECRET=")) {
     content = content.replace(/^AUTH_SECRET=.*$/m, `AUTH_SECRET=${secret}`);
 } else {
     content += `\nAUTH_SECRET=${secret}\n`;
+}
+
+// Fill in the ENCRYPTION_MASTER_KEY line
+if (content.includes("ENCRYPTION_MASTER_KEY=")) {
+    content = content.replace(/^ENCRYPTION_MASTER_KEY=.*$/m, `ENCRYPTION_MASTER_KEY=${encryptionKey}`);
+} else {
+    content += `\nENCRYPTION_MASTER_KEY=${encryptionKey}\n`;
 }
 
 // Strip comment-only sections (keep values)
@@ -48,6 +56,6 @@ content = content
 
 writeFileSync(TARGET, content, "utf8");
 
-console.log("✅ .env created with a generated AUTH_SECRET.");
+console.log("✅ .env created with generated AUTH_SECRET and ENCRYPTION_MASTER_KEY.");
 console.log("   Fill in any optional API keys (Cesium, Bing, OpenSky, etc.)");
 console.log("   then run: npm run dev");

--- a/src/app/api/auth/ticket/route.ts
+++ b/src/app/api/auth/ticket/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { isAuthEnabled } from "@/core/edition";
+import { getTicket } from "@/lib/auth/ticketClient";
+
+/**
+ * GET /api/auth/ticket?pluginId=<id>
+ * Returns a short-lived PluginTicket for the given plugin.
+ * Used by WsClient (browser) to obtain auth tokens without DB access.
+ */
+export async function GET(req: NextRequest) {
+    if (isAuthEnabled) {
+        const session = await auth();
+        if (!session?.user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+    }
+
+    const pluginId = req.nextUrl.searchParams.get("pluginId");
+    if (!pluginId) {
+        return NextResponse.json({ error: "Missing pluginId" }, { status: 400 });
+    }
+
+    try {
+        const token = await getTicket(pluginId);
+        return NextResponse.json({ token });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error("[ticket-route]", message);
+        return NextResponse.json({ error: "Failed to obtain plugin ticket" }, { status: 500 });
+    }
+}

--- a/src/app/api/camera/proxy/iframe/route.ts
+++ b/src/app/api/camera/proxy/iframe/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { isAuthEnabled } from "@/core/edition";
 import { cameraProxyLimiter } from "@/lib/rateLimiters";
 import { getClientIp } from "@/lib/rateLimit";
+import { safeFetch } from "@/lib/security/ssrf";
 
 const MAX_IFRAME_DURATION_MS = 10 * 1000; // 10 seconds timeout for HTML
 
@@ -28,13 +29,14 @@ export async function GET(req: NextRequest) {
     }
 
     try {
-        const upstream = await fetch(targetUrl, {
+        const upstream = await safeFetch(targetUrl, {
             headers: {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                 Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
                 "Accept-Language": "en-US,en;q=0.5",
             },
-            signal: AbortSignal.timeout(MAX_IFRAME_DURATION_MS),
+            maxSize: 5 * 1024 * 1024,
+            timeout: MAX_IFRAME_DURATION_MS,
         });
 
         if (!upstream.ok) {

--- a/src/app/api/marketplace/callback/route.ts
+++ b/src/app/api/marketplace/callback/route.ts
@@ -21,16 +21,18 @@ export async function GET(req: NextRequest) {
 
     const marketplaceUrl = process.env.NEXT_PUBLIC_WWV_MARKETPLACE_URL || "https://app.worldwideview.dev";
     const issuer = new URL(marketplaceUrl);
-    const server = {
-        issuer: issuer.toString(),
-        authorization_endpoint: new URL("/oauth/authorize", issuer).toString(),
-        token_endpoint: new URL("/api/tickets/exchange", issuer).toString(),
-    };
-    const config = { server, clientId: "local-app" };
-    
+    const config = new client.Configuration(
+        {
+            issuer: issuer.toString(),
+            authorization_endpoint: new URL("/oauth/authorize", issuer).toString(),
+            token_endpoint: new URL("/api/oauth/token", issuer).toString(),
+        },
+        "local-app",
+    );
+
     try {
         const tokens = await client.authorizationCodeGrant(
-            config as any,
+            config,
             new URL(req.url),
             { expectedState: stateCookie, pkceCodeVerifier: verifierCookie }
         );
@@ -54,8 +56,8 @@ export async function GET(req: NextRequest) {
                 }
             });
         }
-    } catch (err: any) {
-        console.error("[PKCE] Exchange failed:", err.message);
+    } catch (err) {
+        console.error("[PKCE] Exchange failed:", err instanceof Error ? err.message : String(err));
         return NextResponse.json({ error: "Failed to exchange authorization code" }, { status: 500 });
     }
 

--- a/src/app/api/marketplace/grant-token/route.ts
+++ b/src/app/api/marketplace/grant-token/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import { issueMarketplaceToken } from "@/lib/marketplace/marketplaceToken";
+import type { MarketplaceSessionToken } from "@worldwideview/wwv-plugin-sdk";
 import { grantTokenLimiter } from "@/lib/rateLimiters";
 import { getClientIp } from "@/lib/rateLimit";
 import { isPluginInstallEnabled, isDemo, isDemoAdmin } from "@/core/edition";
@@ -68,7 +69,7 @@ export async function GET(request: NextRequest) {
             return NextResponse.json({ error: "Invalid or missing redirectTo" }, { status: 400 });
         }
 
-        const token = await issueMarketplaceToken(session.user.id ?? "");
+        const token: MarketplaceSessionToken = await issueMarketplaceToken(session.user.id ?? "");
         const dest = new URL(redirectTo);
         // Token in fragment — never sent to server in logs/referer
         return NextResponse.redirect(`${dest.toString()}#token=${token}`);

--- a/src/app/api/marketplace/install-redirect/route.ts
+++ b/src/app/api/marketplace/install-redirect/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import { upsertPlugin } from "@/lib/marketplace/repository";
 import { issueMarketplaceToken } from "@/lib/marketplace/marketplaceToken";
+import type { MarketplaceSessionToken } from "@worldwideview/wwv-plugin-sdk";
 import type { PluginManifest } from "@/core/plugins/PluginManifest";
 import { validateManifest } from "@/core/plugins/validateManifest";
 import { installLimiter } from "@/lib/rateLimiters";
@@ -113,7 +114,7 @@ export async function GET(request: NextRequest) {
             return NextResponse.json({ error: "Install failed" }, { status: 500 });
         }
 
-        const token = await issueMarketplaceToken(session.user.id ?? "");
+        const token: MarketplaceSessionToken = await issueMarketplaceToken(session.user.id ?? "");
         const successUrl = new URL(redirectTo);
 
         // Unverified plugins need user confirmation on the WWV client side

--- a/src/app/api/marketplace/pkce.spec.ts
+++ b/src/app/api/marketplace/pkce.spec.ts
@@ -6,7 +6,7 @@ import { GET as connectRoute } from "./connect/route";
 import { GET as callbackRoute } from "./callback/route";
 
 vi.mock("openid-client", () => ({
-    Configuration: vi.fn().mockImplementation(function() { return this; }),
+    Configuration: vi.fn().mockImplementation(() => ({})),
     randomState: vi.fn(() => "mock-state"),
     randomPKCECodeVerifier: vi.fn(() => "mock-verifier"),
     calculatePKCECodeChallenge: vi.fn(() => "mock-challenge"),

--- a/src/app/api/marketplace/pkce.spec.ts
+++ b/src/app/api/marketplace/pkce.spec.ts
@@ -6,7 +6,7 @@ import { GET as connectRoute } from "./connect/route";
 import { GET as callbackRoute } from "./callback/route";
 
 vi.mock("openid-client", () => ({
-    Configuration: vi.fn().mockImplementation(() => ({})),
+    Configuration: vi.fn().mockImplementation(function(this: object) { return this; }),
     randomState: vi.fn(() => "mock-state"),
     randomPKCECodeVerifier: vi.fn(() => "mock-verifier"),
     calculatePKCECodeChallenge: vi.fn(() => "mock-challenge"),

--- a/src/app/api/marketplace/pkce.spec.ts
+++ b/src/app/api/marketplace/pkce.spec.ts
@@ -6,6 +6,7 @@ import { GET as connectRoute } from "./connect/route";
 import { GET as callbackRoute } from "./callback/route";
 
 vi.mock("openid-client", () => ({
+    Configuration: vi.fn().mockImplementation(function() { return this; }),
     randomState: vi.fn(() => "mock-state"),
     randomPKCECodeVerifier: vi.fn(() => "mock-verifier"),
     calculatePKCECodeChallenge: vi.fn(() => "mock-challenge"),

--- a/src/core/data/WsClient.spec.ts
+++ b/src/core/data/WsClient.spec.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../edition", () => ({
+    ticketAuthEnabledForPlugin: vi.fn(),
+}));
+vi.mock("./DataBus", () => ({
+    dataBus: { emit: vi.fn() },
+}));
+vi.mock("../plugins/PluginManager", () => ({
+    pluginManager: { getPlugin: vi.fn(() => null) },
+}));
+vi.mock("../state/store", () => ({
+    useStore: { getState: vi.fn(() => ({ entitiesByPlugin: {} })) },
+}));
+
+// Fake WebSocket that stays CONNECTING until explicitly opened by tests
+class FakeWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static instances: FakeWebSocket[] = [];
+
+    readyState = FakeWebSocket.CONNECTING;
+    onopen: ((e: Event) => void) | null = null;
+    onmessage: ((e: MessageEvent) => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    readonly sentMessages: string[] = [];
+
+    constructor(public url: string) {
+        FakeWebSocket.instances.push(this);
+    }
+
+    send(data: string) {
+        this.sentMessages.push(data);
+    }
+
+    close() {
+        this.readyState = FakeWebSocket.CLOSED;
+        this.onclose?.();
+    }
+
+    triggerOpen() {
+        this.readyState = FakeWebSocket.OPEN;
+        this.onopen?.(new Event("open"));
+    }
+
+    triggerMessage(data: object) {
+        this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+    }
+}
+
+// Flush all pending Promise microtasks (handles multiple nested awaits in fetchPluginTicket)
+const flushPromises = async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+
+let savedWebSocket: typeof WebSocket;
+let engineIndex = 0;
+const nextEngineUrl = () => `wss://engine-${++engineIndex}.test`;
+
+describe("WsClient — first-message auth", () => {
+    beforeEach(() => {
+        FakeWebSocket.instances.length = 0;
+        savedWebSocket = global.WebSocket;
+        global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        global.WebSocket = savedWebSocket;
+    });
+
+    it("sends subscribe immediately on open when ticket auth is not required", async () => {
+        const { ticketAuthEnabledForPlugin } = await import("../edition");
+        vi.mocked(ticketAuthEnabledForPlugin).mockReturnValue(false);
+
+        const { wsClient } = await import("./WsClient");
+        const url = nextEngineUrl();
+
+        wsClient.subscribe("aviation", url);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        const msgs = ws.sentMessages.map((m) => JSON.parse(m));
+        expect(msgs).toContainEqual({ action: "subscribe", pluginId: "aviation" });
+        expect(msgs.some((m: { type?: string }) => m.type === "auth")).toBe(false);
+    });
+
+    it("sends auth message before any subscribe when ticket auth is required", async () => {
+        const { ticketAuthEnabledForPlugin } = await import("../edition");
+        vi.mocked(ticketAuthEnabledForPlugin).mockReturnValue(true);
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response(JSON.stringify({ token: "ticket-abc" }), { status: 200 })
+        );
+
+        const { wsClient } = await import("./WsClient");
+        const url = nextEngineUrl();
+
+        wsClient.subscribe("aviation", url);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        await flushPromises();
+
+        const msgs = ws.sentMessages.map((m) => JSON.parse(m));
+        expect(msgs).toContainEqual({ type: "auth", v: 1, token: "ticket-abc" });
+        expect(msgs.some((m: { action?: string }) => m.action === "subscribe")).toBe(false);
+        expect(fetchSpy).toHaveBeenCalledWith(
+            expect.stringContaining("/api/auth/ticket?pluginId=aviation")
+        );
+
+        fetchSpy.mockRestore();
+    });
+
+    it("flushes all queued subscribes after receiving a welcome message", async () => {
+        const { ticketAuthEnabledForPlugin } = await import("../edition");
+        vi.mocked(ticketAuthEnabledForPlugin).mockReturnValue(true);
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response(JSON.stringify({ token: "ticket-abc" }), { status: 200 })
+        );
+
+        const { wsClient } = await import("./WsClient");
+        const url = nextEngineUrl();
+
+        wsClient.subscribe("aviation", url);
+        wsClient.subscribe("maritime", url);
+
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        await flushPromises();
+
+        // Before welcome: no subscribes yet
+        const beforeWelcome = ws.sentMessages.map((m) => JSON.parse(m));
+        expect(beforeWelcome.some((m: { action?: string }) => m.action === "subscribe")).toBe(false);
+
+        // Simulate engine welcome
+        ws.triggerMessage({ type: "welcome", plugins: [] });
+
+        // After welcome: both subscribes flushed
+        const afterWelcome = ws.sentMessages.map((m) => JSON.parse(m));
+        const subscribePids = afterWelcome
+            .filter((m: { action?: string }) => m.action === "subscribe")
+            .map((m: { pluginId?: string }) => m.pluginId);
+        expect(subscribePids).toContain("aviation");
+        expect(subscribePids).toContain("maritime");
+
+        fetchSpy.mockRestore();
+    });
+});

--- a/src/core/data/WsClient.ts
+++ b/src/core/data/WsClient.ts
@@ -2,6 +2,16 @@ import type { WsStreamPayload, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
 import { dataBus } from "./DataBus";
 import { pluginManager } from "../plugins/PluginManager";
 import { useStore } from "../state/store";
+import { ticketAuthEnabledForPlugin } from "../edition";
+import type { PluginTicket } from "@worldwideview/wwv-plugin-sdk";
+
+async function fetchPluginTicket(pluginId: string): Promise<PluginTicket> {
+  const res = await fetch(`/api/auth/ticket?pluginId=${encodeURIComponent(pluginId)}`);
+  if (!res.ok) throw new Error(`[WSClient] Ticket fetch failed (${res.status}) for ${pluginId}`);
+  const data = await res.json() as { token?: string };
+  if (!data.token) throw new Error(`[WSClient] Ticket response missing token for ${pluginId}`);
+  return data.token as PluginTicket;
+}
 
 interface EngineConnection {
   ws: WebSocket | null;
@@ -13,6 +23,10 @@ interface EngineConnection {
   reconnectAttempts: number;
   /** Timer that resets the backoff counter once a connection has been stable */
   stableConnectionTimer: NodeJS.Timeout | null;
+  /** True while waiting for the server's welcome after sending an auth message */
+  awaitingWelcome: boolean;
+  /** Closes the connection if the server doesn't send welcome within 3s */
+  authTimeoutTimer: NodeJS.Timeout | null;
 }
 
 const RECONNECT_BASE_MS = 5000;
@@ -39,6 +53,8 @@ class WebSocketClient {
         cleanupTimer: null,
         reconnectAttempts: 0,
         stableConnectionTimer: null,
+        awaitingWelcome: false,
+        authTimeoutTimer: null,
       };
       this.engines.set(engineUrl, engine);
     }
@@ -63,9 +79,31 @@ class WebSocketClient {
       engine.stableConnectionTimer = setTimeout(() => {
         engine.reconnectAttempts = 0;
       }, STABLE_CONNECTION_MS);
-      // Resubscribe to all active plugins on this engine
-      for (const pluginId of engine.subscriptions) {
-        this.send(engine, { action: "subscribe", pluginId });
+
+      // Check whether any subscription on this engine requires ticket auth.
+      const ticketPlugin = [...engine.subscriptions].find((id) => ticketAuthEnabledForPlugin(id));
+      if (ticketPlugin) {
+        engine.awaitingWelcome = true;
+        fetchPluginTicket(ticketPlugin)
+          .then((ticket) => {
+            this.send(engine, { type: "auth", v: 1, token: ticket });
+            // 3s timeout — if the server doesn't send welcome, close and trigger reconnect.
+            engine.authTimeoutTimer = setTimeout(() => {
+              if (engine.awaitingWelcome) {
+                console.warn(`[WSClient] Auth timeout waiting for welcome from ${engineUrl}. Closing to reconnect.`);
+                engine.ws?.close();
+              }
+            }, 3000);
+          })
+          .catch((err: unknown) => {
+            console.error(`[WSClient] Failed to get ticket for ${ticketPlugin}:`, err instanceof Error ? err.message : err);
+            engine.ws?.close();
+          });
+      } else {
+        // No ticket auth required — subscribe immediately.
+        for (const pluginId of engine.subscriptions) {
+          this.send(engine, { action: "subscribe", pluginId });
+        }
       }
     };
 
@@ -75,9 +113,15 @@ class WebSocketClient {
         console.debug(`[WSClient] 📥 Received raw message at +${(msgTime - wsStart).toFixed(2)}ms from start:`, event.data.substring(0, 150) + (event.data.length > 150 ? '...' : ''));
         const data = JSON.parse(event.data);
 
-        // Handle welcome message (informational, no action needed)
         if (data.type === "welcome") {
           console.debug(`[WSClient] 👋 Engine ${engineUrl} serves: ${data.plugins?.join(", ")}`);
+          if (engine.awaitingWelcome) {
+            engine.awaitingWelcome = false;
+            if (engine.authTimeoutTimer) { clearTimeout(engine.authTimeoutTimer); engine.authTimeoutTimer = null; }
+            for (const pluginId of engine.subscriptions) {
+              this.send(engine, { action: "subscribe", pluginId });
+            }
+          }
           return;
         }
 
@@ -95,6 +139,8 @@ class WebSocketClient {
 
     engine.ws.onclose = () => {
       engine.ws = null;
+      engine.awaitingWelcome = false;
+      if (engine.authTimeoutTimer) { clearTimeout(engine.authTimeoutTimer); engine.authTimeoutTimer = null; }
       if (engine.stableConnectionTimer) {
         clearTimeout(engine.stableConnectionTimer);
         engine.stableConnectionTimer = null;
@@ -178,6 +224,7 @@ class WebSocketClient {
           console.log(`[WSClient] No subscriptions remain for ${engineUrl}. Closing connection.`);
           if (engine.reconnectTimer) clearTimeout(engine.reconnectTimer);
           if (engine.stableConnectionTimer) clearTimeout(engine.stableConnectionTimer);
+          if (engine.authTimeoutTimer) { clearTimeout(engine.authTimeoutTimer); engine.authTimeoutTimer = null; }
           engine.ws?.close();
           this.engines.delete(engineUrl);
         }

--- a/src/core/edition.ts
+++ b/src/core/edition.ts
@@ -99,6 +99,22 @@ export function getDemoAdminSecret(): string | undefined {
 /** Demo admin session role constant. */
 export const DEMO_ADMIN_ROLE = "demo-admin";
 
+// ---------------------------------------------------------------------------
+// Per-plugin ticket auth flag (ADR-001)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the given plugin requires WebSocket first-message auth
+ * (i.e., must send a PluginTicket before any subscribe message).
+ *
+ * Controlled by NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS (comma-separated plugin IDs).
+ * Empty or unset → ticket auth is disabled for all plugins (dormant / safe default).
+ */
+export function ticketAuthEnabledForPlugin(pluginId: string): boolean {
+    const list = process.env.NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS ?? "";
+    return list.split(",").map((s) => s.trim()).filter(Boolean).includes(pluginId);
+}
+
 /**
  * Returns `true` when the session belongs to the demo admin user.
  * Accepts any session-like object (uses runtime narrowing to avoid

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,6 +2,13 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Fail fast at boot — prevents silent zero-key encryption (ADR-001C / Verification §7).
+    if (!process.env.ENCRYPTION_MASTER_KEY) {
+      throw new Error("[startup] ENCRYPTION_MASTER_KEY is not set. The server cannot start without it.");
+    }
+    if (!process.env.AUTH_SECRET) {
+      throw new Error("[startup] AUTH_SECRET is not set. The server cannot start without it.");
+    }
     await import("./sentry.server.config");
   }
 

--- a/src/lib/auth/encryption.spec.ts
+++ b/src/lib/auth/encryption.spec.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { encryptCredential, decryptCredential } from "./encryption";
 
 describe("AES-256-GCM Encryption with PBKDF2", () => {
+    beforeAll(() => { process.env.ENCRYPTION_MASTER_KEY = "test-master-key-32-chars-padding!!"; });
+    afterAll(() => { delete process.env.ENCRYPTION_MASTER_KEY; });
     it("should correctly encrypt and decrypt a string", async () => {
         const secret = "my-super-secret-api-key";
 

--- a/src/lib/auth/encryption.ts
+++ b/src/lib/auth/encryption.ts
@@ -5,8 +5,11 @@ const ITERATIONS = 100000;
 const KEY_LENGTH = 32;
 const DIGEST = "sha256";
 
-// In production, this should be set in the environment
-const MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY || "00000000000000000000000000000000";
+function getMasterKey(): string {
+    const key = process.env.ENCRYPTION_MASTER_KEY;
+    if (!key) throw new Error('[encryption] ENCRYPTION_MASTER_KEY env var is required');
+    return key;
+}
 
 export interface EncryptedCredential {
     version: string;
@@ -18,7 +21,7 @@ export interface EncryptedCredential {
 export async function encryptCredential(plainText: string): Promise<EncryptedCredential> {
     return new Promise((resolve, reject) => {
         const salt = crypto.randomBytes(16);
-        crypto.pbkdf2(MASTER_KEY, salt, ITERATIONS, KEY_LENGTH, DIGEST, (err, key) => {
+        crypto.pbkdf2(getMasterKey(), salt, ITERATIONS, KEY_LENGTH, DIGEST, (err, key) => {
             if (err) return reject(err);
 
             const nonce = crypto.randomBytes(12);
@@ -54,7 +57,7 @@ export async function decryptCredential(cred: EncryptedCredential): Promise<stri
         const ciphertext = payloadParts[0];
         const authTag = Buffer.from(payloadParts[1], "base64");
 
-        crypto.pbkdf2(MASTER_KEY, salt, ITERATIONS, KEY_LENGTH, DIGEST, (err, key) => {
+        crypto.pbkdf2(getMasterKey(), salt, ITERATIONS, KEY_LENGTH, DIGEST, (err, key) => {
             if (err) return reject(err);
 
             try {

--- a/src/lib/auth/ticketClient.spec.ts
+++ b/src/lib/auth/ticketClient.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        marketplaceCredential: {
+            findUnique: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/auth/encryption", () => ({
+    decryptCredential: vi.fn(),
+}));
+
+// getTicket caches by ENGINE_AUDIENCE across test runs — re-import per test suite
+// by clearing the module registry so the cache starts fresh.
+describe("ticketClient", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.resetAllMocks();
+        process.env.MARKETPLACE_URL = "https://marketplace.test";
+        process.env.ENCRYPTION_MASTER_KEY = "test-key-32-chars-xxxxxxxxxxx!!";
+    });
+
+    afterEach(() => {
+        delete process.env.MARKETPLACE_URL;
+        delete process.env.ENCRYPTION_MASTER_KEY;
+    });
+
+    it("fetches a ticket, caches it, and returns the same token on the second call", async () => {
+        const { prisma } = await import("@/lib/db");
+        const { decryptCredential } = await import("@/lib/auth/encryption");
+        const { getTicket } = await import("./ticketClient");
+
+        const mockCred = { tenantId: "local", version: "v1", salt: "s", nonce: "n", ciphertext: "c" };
+        vi.mocked(prisma.marketplaceCredential.findUnique).mockResolvedValue(mockCred as never);
+        vi.mocked(decryptCredential).mockResolvedValue("my-api-key");
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({ token: "ticket-abc" }), { status: 200 })
+        );
+
+        const t1 = await getTicket("aviation");
+        const t2 = await getTicket("aviation");
+
+        expect(t1).toBe("ticket-abc");
+        expect(t2).toBe("ticket-abc");
+        // fetch should be called only once — second call hits cache
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        fetchSpy.mockRestore();
+    });
+
+    it("sends the correct body to the Marketplace exchange endpoint", async () => {
+        const { prisma } = await import("@/lib/db");
+        const { decryptCredential } = await import("@/lib/auth/encryption");
+        const { getTicket } = await import("./ticketClient");
+
+        const mockCred = { tenantId: "local", version: "v1", salt: "s", nonce: "n", ciphertext: "c" };
+        vi.mocked(prisma.marketplaceCredential.findUnique).mockResolvedValue(mockCred as never);
+        vi.mocked(decryptCredential).mockResolvedValue("my-api-key");
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({ token: "ticket-xyz" }), { status: 200 })
+        );
+
+        await getTicket("maritime");
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        const [url, init] = fetchSpy.mock.calls[0];
+        expect(url).toBe("https://marketplace.test/api/auth/exchange");
+        expect(init?.method).toBe("POST");
+
+        const body = JSON.parse(init?.body as string);
+        expect(body.apiKey).toBe("my-api-key");         // camelCase — matches Marketplace
+        expect(body.audience).toBe("wwv-data-engine"); // engine-scoped per ADR-001B
+        expect(body.plugin_id).toBe("maritime");        // retained for future scoping
+
+        fetchSpy.mockRestore();
+    });
+
+    it("throws when no MarketplaceCredential row exists", async () => {
+        const { prisma } = await import("@/lib/db");
+        const { getTicket } = await import("./ticketClient");
+
+        vi.mocked(prisma.marketplaceCredential.findUnique).mockResolvedValue(null);
+
+        await expect(getTicket("aviation")).rejects.toThrow("No marketplace credential found");
+    });
+
+    it("throws on a non-OK response from the Marketplace", async () => {
+        const { prisma } = await import("@/lib/db");
+        const { decryptCredential } = await import("@/lib/auth/encryption");
+        const { getTicket } = await import("./ticketClient");
+
+        const mockCred = { tenantId: "local", version: "v1", salt: "s", nonce: "n", ciphertext: "c" };
+        vi.mocked(prisma.marketplaceCredential.findUnique).mockResolvedValue(mockCred as never);
+        vi.mocked(decryptCredential).mockResolvedValue("my-api-key");
+
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
+        );
+
+        await expect(getTicket("aviation")).rejects.toThrow("Token exchange failed (401)");
+    });
+
+    it("throws when the Marketplace response is missing the token field", async () => {
+        const { prisma } = await import("@/lib/db");
+        const { decryptCredential } = await import("@/lib/auth/encryption");
+        const { getTicket } = await import("./ticketClient");
+
+        const mockCred = { tenantId: "local", version: "v1", salt: "s", nonce: "n", ciphertext: "c" };
+        vi.mocked(prisma.marketplaceCredential.findUnique).mockResolvedValue(mockCred as never);
+        vi.mocked(decryptCredential).mockResolvedValue("my-api-key");
+
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response(JSON.stringify({}), { status: 200 })
+        );
+
+        await expect(getTicket("aviation")).rejects.toThrow("missing 'token' field");
+    });
+});

--- a/src/lib/auth/ticketClient.ts
+++ b/src/lib/auth/ticketClient.ts
@@ -1,0 +1,75 @@
+import type { PluginTicket } from "@worldwideview/wwv-plugin-sdk";
+import { decryptCredential } from "@/lib/auth/encryption";
+import { prisma as db } from "@/lib/db";
+
+interface CacheEntry {
+    ticket: PluginTicket;
+    /** Unix ms — the ticket is considered stale 30s before the 5-min expiry */
+    expiresAt: number;
+}
+
+const TICKET_LIFETIME_MS = 4.5 * 60 * 1000; // refresh 30s before the 5-min expiry
+
+// Per ADR-001B: audience = the Data Engine's ENGINE_ID (default "wwv-data-engine").
+// Per-engine audiences (true multi-engine decentralisation) are a follow-up.
+const ENGINE_AUDIENCE = "wwv-data-engine";
+
+// Cache is keyed by audience, not pluginId — the ticket is user/engine-scoped.
+// All plugins on the same engine share one ticket, avoiding redundant exchange calls.
+const cache = new Map<string, CacheEntry>();
+
+function getMarketplaceUrl(): string {
+    return (
+        process.env.MARKETPLACE_URL ||
+        process.env.NEXT_PUBLIC_WWV_MARKETPLACE_URL ||
+        "https://app.worldwideview.dev"
+    );
+}
+
+async function fetchTicket(pluginId: string): Promise<PluginTicket> {
+    const cred = await db.marketplaceCredential.findUnique({
+        where: { tenantId: "local" },
+    });
+    if (!cred) {
+        throw new Error(`[ticketClient] No marketplace credential found. Complete the PKCE flow first.`);
+    }
+
+    const apiKey = await decryptCredential(cred);
+    const url = `${getMarketplaceUrl()}/api/auth/exchange`;
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // apiKey camelCase — matches the Marketplace /api/auth/exchange destructure.
+        // audience = engine ID per ADR-001B, not pluginId.
+        // plugin_id retained for future Marketplace entitlement scoping.
+        body: JSON.stringify({ apiKey, audience: ENGINE_AUDIENCE, plugin_id: pluginId }),
+    });
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`[ticketClient] Token exchange failed (${response.status}): ${body}`);
+    }
+
+    const data = await response.json() as { token?: string };
+    if (!data.token) {
+        throw new Error("[ticketClient] Token exchange response missing 'token' field.");
+    }
+
+    return data.token as PluginTicket;
+}
+
+/**
+ * Returns a short-lived PluginTicket for the given plugin ID.
+ * Results are cached by engine audience; the ticket is refreshed 30s before expiry (4.5-min window).
+ */
+export async function getTicket(pluginId: string): Promise<PluginTicket> {
+    const cached = cache.get(ENGINE_AUDIENCE);
+    if (cached && cached.expiresAt > Date.now()) {
+        return cached.ticket;
+    }
+
+    const ticket = await fetchTicket(pluginId);
+    cache.set(ENGINE_AUDIENCE, { ticket, expiresAt: Date.now() + TICKET_LIFETIME_MS });
+    return ticket;
+}

--- a/src/lib/marketplace/marketplaceToken.ts
+++ b/src/lib/marketplace/marketplaceToken.ts
@@ -1,5 +1,6 @@
 import { SignJWT, jwtVerify } from "jose";
 import { randomUUID } from "crypto";
+import type { MarketplaceSessionToken } from "@worldwideview/wwv-plugin-sdk";
 
 const SCOPE = "marketplace";
 const ISSUER = "worldwideview";
@@ -17,10 +18,11 @@ function getSecret(): Uint8Array {
 }
 
 /**
- * Issue a JWT scoped to marketplace API access, bound to a specific user.
+ * Issue a marketplace session JWT scoped to API access, bound to a specific user.
  * Signed with AUTH_SECRET — no database required.
+ * Returns a branded MarketplaceSessionToken to prevent accidental use as a WebSocket credential.
  */
-export async function issueMarketplaceToken(userId: string): Promise<string> {
+export async function issueMarketplaceToken(userId: string): Promise<MarketplaceSessionToken> {
     return new SignJWT({ scope: SCOPE })
         .setProtectedHeader({ alg: "HS256" })
         .setSubject(userId)
@@ -29,7 +31,7 @@ export async function issueMarketplaceToken(userId: string): Promise<string> {
         .setJti(randomUUID())
         .setIssuedAt()
         .setExpirationTime(EXPIRY)
-        .sign(getSecret());
+        .sign(getSecret()) as Promise<MarketplaceSessionToken>;
 }
 
 export interface MarketplaceTokenPayload {

--- a/src/lib/security/ssrf.spec.ts
+++ b/src/lib/security/ssrf.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { safeFetch, validateOrigin, isPrivateIP } from "./ssrf";
 
 describe("SSRF Protection Utility", () => {
@@ -34,8 +34,42 @@ describe("SSRF Protection Utility", () => {
         });
     });
 
+    describe("checkHostAllowlist via safeFetch", () => {
+        const originalAllowlist = process.env.PROXY_HOST_ALLOWLIST;
+
+        afterEach(() => {
+            if (originalAllowlist === undefined) {
+                delete process.env.PROXY_HOST_ALLOWLIST;
+            } else {
+                process.env.PROXY_HOST_ALLOWLIST = originalAllowlist;
+            }
+        });
+
+        it("denies all when PROXY_HOST_ALLOWLIST is unset", async () => {
+            delete process.env.PROXY_HOST_ALLOWLIST;
+            await expect(safeFetch("https://camera.example.com/feed")).rejects.toThrow(/SSRF.*PROXY_HOST_ALLOWLIST/);
+        });
+
+        it("denies all when PROXY_HOST_ALLOWLIST is empty string", async () => {
+            process.env.PROXY_HOST_ALLOWLIST = "";
+            await expect(safeFetch("https://camera.example.com/feed")).rejects.toThrow(/SSRF.*PROXY_HOST_ALLOWLIST/);
+        });
+
+        it("rejects a host not in the concrete allowlist", async () => {
+            process.env.PROXY_HOST_ALLOWLIST = "allowed.example.com";
+            await expect(safeFetch("https://blocked.example.com/feed")).rejects.toThrow(/not in PROXY_HOST_ALLOWLIST/);
+        });
+
+        it("passes the allowlist check for '*' but still rejects private IPs", async () => {
+            process.env.PROXY_HOST_ALLOWLIST = "*";
+            // Private IP clears the allowlist but the post-DNS private-IP check still fires
+            await expect(safeFetch("https://127.0.0.1/data")).rejects.toThrow(/SSRF/);
+        });
+    });
+
     describe("safeFetch", () => {
         it("should reject private IPs immediately", async () => {
+            process.env.PROXY_HOST_ALLOWLIST = "*"; // bypass allowlist for these tests
             await expect(safeFetch("https://127.0.0.1/data")).rejects.toThrow(/SSRF/);
             await expect(safeFetch("https://169.254.169.254/latest/meta-data")).rejects.toThrow(/SSRF/);
         });

--- a/src/lib/security/ssrf.ts
+++ b/src/lib/security/ssrf.ts
@@ -22,7 +22,31 @@ interface FetchOptions extends RequestInit {
     timeout?: number;
 }
 
+function checkHostAllowlist(hostname: string): void {
+    const raw = process.env.PROXY_HOST_ALLOWLIST ?? "";
+    const allowlist = raw.trim();
+
+    if (allowlist === "*") {
+        console.warn(`[SSRF] PROXY_HOST_ALLOWLIST="*" — permissive mode, host: ${hostname}. Populate the list from WARN logs then tighten.`);
+        return;
+    }
+
+    if (!allowlist) {
+        throw new Error(`SSRF Error: PROXY_HOST_ALLOWLIST is not configured. Set to "*" to allow all (permissive) or a comma-separated host list.`);
+    }
+
+    const allowed = allowlist.split(",").map((h) => h.trim()).filter(Boolean);
+    if (!allowed.includes(hostname)) {
+        throw new Error(`SSRF Error: Host "${hostname}" is not in PROXY_HOST_ALLOWLIST.`);
+    }
+}
+
 export async function safeFetch(urlStr: string, options: FetchOptions = {}): Promise<Response> {
+    const hostForCheck = (() => {
+        try { return new URL(urlStr).hostname; } catch { return ""; }
+    })();
+    checkHostAllowlist(hostForCheck);
+
     if (!validateOrigin(urlStr)) {
         throw new Error("SSRF Error: Invalid protocol. Only HTTPS is allowed.");
     }


### PR DESCRIPTION
## Summary

- **C1** Boot-time validation: `instrumentation.ts` throws on missing `ENCRYPTION_MASTER_KEY` / `AUTH_SECRET`; `encryption.ts` silent fallback removed; marketplace token guarded against data-plane misuse
- **C2** SSRF protection: `PROXY_HOST_ALLOWLIST` env flag in `ssrf.ts`; camera/iframe proxy routed through `safeFetch` with private-IP rejection and size limits
- **C3** `ticketClient.ts` (new): exchanges long-lived API key for 5-min EdDSA ticket from Marketplace; audience fixed to `ENGINE_AUDIENCE = 'wwv-data-engine'`; cache keyed by engine (not plugin) to avoid N exchange calls
- **C4** `WsClient.ts` first-message auth: sends `{type:'auth',v:1,token}` on open; queues all subscribes until engine sends `{type:'welcome'}`; gated by `ticketAuthEnabledForPlugin`
- **C5** `edition.ts`: `ticketAuthEnabledForPlugin` reads `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS` comma list
- **Step 0** `docs/deploys/2026-05-21-adr-001-preflight.md` + `docs/feature-flags.md` — pre-flight audit artifacts recording all env-var gaps, cross-repo discrepancies, and gate status before deploy

## Wire contract fixes (vs. prior implementation)
- `ticketClient.ts` now sends `apiKey` (camelCase) — matches Marketplace `/api/auth/exchange` destructure
- `audience` now sends `"wwv-data-engine"` constant — matches Data Engine `aud` check; not `pluginId`

## Test plan
- [x] `pnpm test` — 342 tests passing across 48 files
- [x] `pnpm build` — no TS errors (verified locally)
- [ ] Set `ENCRYPTION_MASTER_KEY` on `worldwideview-demo` Coolify env before deploying (C1 gate — see preflight doc)
- [ ] Set `MARKETPLACE_URL` + `NEXT_PUBLIC_WWV_MARKETPLACE_URL` + `PROXY_HOST_ALLOWLIST="*"` on `worldwideview-demo` (deploy step 1)
- [ ] Staging smoke test with `NEXT_PUBLIC_WWV_TICKET_AUTH_PLUGINS=test-synthetic` after steps 2–4 land (deploy step 5)

## Related
- Marketplace PR: `feat/adr-001-marketplace` (A1–A3)
- Data Engine PR: `feat/adr-001-data-engine` (B)
- ADR: `docs/architecture/decisions/adr-0001-decentralized-plugin-auth-and-ssrf-mitigation.md` (status → Accepted pending step 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)