### PR TITLE
fix(test): cast null mock to any in ticket route spec

### DIFF
--- a/src/app/api/auth/ticket/route.spec.ts
+++ b/src/app/api/auth/ticket/route.spec.ts
@@ -14,7 +14,8 @@ describe("GET /api/auth/ticket", () => {
     });
 
     it("returns 401 when no session exists", async () => {
-        vi.mocked(auth).mockResolvedValue(null);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        vi.mocked(auth).mockResolvedValue(null as any);
         const req = new NextRequest("http://localhost/api/auth/ticket?pluginId=aviation");
         const res = await GET(req);
         expect(res.status).toBe(401);


### PR DESCRIPTION
## Summary

- Fixes the TypeScript error from #172: `Argument of type 'null' is not assignable to parameter of type 'NextMiddleware'`
- `auth` is typed as `NextMiddleware` in NextAuth v5; `mockResolvedValue(null)` requires `as any` cast consistent with all other `vi.mocked(auth)` calls in the file

One-line fix, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)