### PR TITLE
fix(globe): enable Cesium World Terrain for non-Google 3D mode

### DIFF
--- a/src/core/globe/useImageryManager.ts
+++ b/src/core/globe/useImageryManager.ts
@@ -6,6 +6,7 @@ import {
     SceneMode,
     Cesium3DTileset,
     Cesium3DTileStyle,
+    Terrain,
     createOsmBuildingsAsync
 } from "cesium";
 import { useStore } from "@/core/state/store";
@@ -22,8 +23,8 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
     const activeLayerId = fallbackLayerId || baseLayerId;
 
     const currentImageryLayerRef = useRef<ImageryLayer | null>(null);
-    // const googleTilesetRef = useRef<Cesium3DTileset | null>(null);
     const osmBuildingsRef = useRef<Cesium3DTileset | null>(null);
+    const terrainActiveRef = useRef(false);
 
     // 1. Manage Scene Mode (2D / 3D / Columbus)
     useEffect(() => {
@@ -112,9 +113,24 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
         updateImagery();
     }, [viewer, viewerReady, baseLayerId, fallbackLayerId]);
 
-    // 3. Manage OSM 3D Buildings (only in 3D mode, not with Google Photorealistic tiles)
+    // 3. Enable Cesium World Terrain for non-Google 3D mode.
+    //    depthTestAgainstTerrain is already true (useViewerInitialization) and OSM 3D
+    //    Buildings store absolute WGS84 heights including terrain elevation — both need
+    //    real terrain. Without it the globe is a smooth ellipsoid, buildings float, and
+    //    depth clipping is inaccurate. In Google 3D mode globe.show is false so the
+    //    terrain provider is irrelevant; no need to tear it down on mode switch.
     const isGoogle3D = activeLayerId === "google-3d";
     const is3DMode = sceneMode === 3;
+
+    useEffect(() => {
+        if (!viewer || !viewerReady || viewer.isDestroyed()) return;
+        if (isGoogle3D || !is3DMode || terrainActiveRef.current) return;
+
+        viewer.scene.setTerrain(Terrain.fromWorldTerrain());
+        terrainActiveRef.current = true;
+    }, [viewer, viewerReady, isGoogle3D, is3DMode]);
+
+    // 4. Manage OSM 3D Buildings (only in 3D mode, not with Google Photorealistic tiles)
     useEffect(() => {
         if (!viewer || !viewerReady || viewer.isDestroyed()) return;
 


### PR DESCRIPTION
## Summary

Fixes #167. OSM 3D Buildings float above the globe surface because no terrain
provider was configured. The default `EllipsoidTerrainProvider` renders a smooth
ellipsoid, but OSM buildings store absolute WGS84 heights that include terrain
elevation. The mismatch causes buildings to appear suspended by exactly the
terrain height at their location.

This also fixes an existing issue where `depthTestAgainstTerrain = true`
(set in `useViewerInitialization`) had no real terrain to test against,
causing inaccurate entity depth clipping in non-Google 3D mode.

## Changes

- Add a dedicated `useEffect` in `useImageryManager` that calls
  `scene.setTerrain(Terrain.fromWorldTerrain())` when entering non-Google
  3D mode
- Terrain is enabled once via a ref guard and never torn down. In Google
  3D mode `globe.show` is already false, so the terrain provider is
  irrelevant and does not need cleanup
- The buildings effect (section 4) is unchanged. Terrain and buildings
  are now independent concerns

## Why not tie terrain to the buildings toggle?

Buildings are one consumer of terrain, but `depthTestAgainstTerrain` is
another. Coupling terrain lifecycle to the buildings checkbox would leave
depth clipping broken when buildings are disabled. Terrain belongs at the
rendering layer level, not gated behind a feature toggle.

## Test plan

- [x] `pnpm test` (350/350 pass)
- [x] `pnpm build` compiles successfully
- [ ] Visual verification: toggle 3D Buildings on a non-Google imagery
      layer (e.g. Bing Aerial) and confirm buildings sit on the ground
- [ ] Switch between Google 3D and non-Google layers, confirm no
      terrain-related console errors
- [ ] Toggle buildings off, confirm terrain remains active and depth
      testing still works