### PR TITLE
fix: remove hardcoded pnpm version from GC workflow

### DIFF
--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The \pnpm/action-setup@v4\ \ersion: 9\ conflicts with the \packageManager: pnpm@9.15.4\ field in \package.json\. Removing the explicit version lets the action read it from \packageManager\ automatically — no version mismatch.