### PR TITLE
fix: add id-token write permission and fix invalid inputs in GC workflow

### DIFF
--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -28,6 +28,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   collect:
@@ -81,7 +82,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-haiku-4-5-20251001
           prompt: |
             You are the WorldWideView Garbage Collector agent running headless in GitHub Actions.
 
@@ -91,4 +91,4 @@ jobs:
             Execute the full sweep procedure described in `.agents/agents/garbage-collector.md`.
 
             Do not scan the codebase yourself. Work only from gc-findings.json.
-          allowed_tools: 'Bash,Read,Edit,Write,Grep,Glob'
+          claude_args: '--model claude-haiku-4-5-20251001 --allowedTools Bash,Read,Edit,Write,Grep,Glob'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",


### PR DESCRIPTION
## Summary

- Add `id-token: write` to the `garbage-collector.yml` workflow permissions block — required by `claude-code-action@v1` to obtain an OIDC token for OAuth authentication
- Remove unsupported `model` and `allowed_tools` top-level inputs; move them into `claude_args` as CLI flags (`--model` and `--allowedTools`), which is the correct way to pass these options to `claude-code-action@v1`

## Root cause

`claude-code-action@v1` authenticates via OIDC and requires the `ACTIONS_ID_TOKEN_REQUEST_URL` environment variable to be populated, which only happens when the job has `id-token: write` permission. Without it the action retried 3 times then failed with:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

The `model` and `allowed_tools` inputs were additionally generating `Unexpected input(s)` warnings on every run because they are not declared inputs of `claude-code-action@v1`.

## Test plan

- [ ] After merge, trigger the Garbage Collector workflow manually via `workflow_dispatch` (dry_run=true) and confirm the "Run Garbage Collector agent" step completes successfully