### PR TITLE
fix(docker): guard community seeder cd and add ENCRYPTION_MASTER_KEY default

### DIFF
--- a/.agents/rules/cloud-auth-architecture.md
+++ b/.agents/rules/cloud-auth-architecture.md
@@ -8,6 +8,9 @@ paths:
   - "src/core/tenant.ts"
 ---
 
+> **SUPERSEDED by ADR-003** (`docs/architecture/decisions/adr-0003-shared-identity-and-ecosystem-auth-host.md`).
+> The auth host is `worldwideview.dev` (worldwideview-web repo), not `app.worldwideview.dev`. Read ADR-003 first.
+
 # WorldWideView — Cloud & Auth Architecture
 
 

--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -82,13 +82,35 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           prompt: |
             You are the WorldWideView Garbage Collector agent running headless in GitHub Actions.
 
             Read `.agents/rules/garbage-collection.md` for your charter and all guard rails.
             Read `gc-findings.json` for the pre-scanned findings produced by `scripts/gc-scan.mjs`.
-            Check the DRY_RUN environment variable — if "true", post a dry-run summary only (no PRs or Issues).
-            Execute the full sweep procedure described in `.agents/agents/garbage-collector.md`.
+
+            The DRY_RUN environment variable is: ${{ env.DRY_RUN }}
+
+            ## If DRY_RUN is "true":
+            Do NOT create any PRs or Issues.
+            Instead, find or create the tracking Issue titled "[gc-bot] Daily Scan Reports" (label: gc-bot) in
+            the silvertakana/worldwideview repository using the gh CLI:
+
+              # Find existing tracking issue
+              gh issue list --repo silvertakana/worldwideview --label gc-bot --search "[gc-bot] Daily Scan Reports" --json number,title
+
+              # If it exists, add a comment:
+              gh issue comment <number> --repo silvertakana/worldwideview --body "..."
+
+              # If it doesn't exist, create it:
+              gh issue create --repo silvertakana/worldwideview --title "[gc-bot] Daily Scan Reports" --label gc-bot --body "..."
+
+            The comment body must list every finding with: tier, file, line, description.
+            Include the run ID (${{ github.run_id }}) and timestamp at the top.
+
+            ## If DRY_RUN is "false":
+            Execute the full sweep procedure described in `.claude/agents/garbage-collector.md`.
+            Create Tier A draft PRs and Tier B Issues per the guard rails in `.agents/rules/garbage-collection.md`.
 
             Do not scan the codebase yourself. Work only from gc-findings.json.
           claude_args: '--model claude-haiku-4-5-20251001 --allowedTools Bash,Read,Edit,Write,Grep,Glob'

--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -28,6 +28,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   collect:
@@ -81,7 +82,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-haiku-4-5-20251001
           prompt: |
             You are the WorldWideView Garbage Collector agent running headless in GitHub Actions.
 
@@ -91,4 +91,4 @@ jobs:
             Execute the full sweep procedure described in `.agents/agents/garbage-collector.md`.
 
             Do not scan the codebase yourself. Work only from gc-findings.json.
-          allowed_tools: 'Bash,Read,Edit,Write,Grep,Glob'
+          claude_args: '--model claude-haiku-4-5-20251001 --allowedTools Bash,Read,Edit,Write,Grep,Glob'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
         required: false
     environment:
       - "AUTH_SECRET=${AUTH_SECRET:-default_secret_for_local_dev}"
+      - "ENCRYPTION_MASTER_KEY=${ENCRYPTION_MASTER_KEY:-local_dev_encryption_key_change_in_prod}"
       - "WWV_DEMO_ADMIN_SECRET=${WWV_DEMO_ADMIN_SECRET:-}"
       - "WWV_BRIDGE_TOKEN=${WWV_BRIDGE_TOKEN:-}"
       - "DATABASE_URL=postgresql://postgres:postgres@db:5432/worldwideview?schema=public"
@@ -58,7 +59,7 @@ services:
     command: >
       sh -c "
       echo 'Syncing workspace dependencies...' &&
-      cd $$SEEDERS_DIR/community && CI=true pnpm install --ignore-scripts && pnpm -r rebuild better-sqlite3 esbuild &&
+      if [ -d \"$$SEEDERS_DIR/community\" ]; then cd $$SEEDERS_DIR/community && CI=true pnpm install --ignore-scripts && pnpm -r rebuild better-sqlite3 esbuild; fi &&
       if [ -d \"$$SEEDERS_DIR/private\" ]; then cd $$SEEDERS_DIR/private && CI=true pnpm install --ignore-scripts && pnpm -r rebuild better-sqlite3 esbuild; fi &&
       cd /app && node dist/server.js"
     ports:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",


### PR DESCRIPTION
## Summary

- **data-engine restart loop** — `cd $SEEDERS_DIR/community` in the container `command:` was unconditional. If `local-seeders/community/` is an empty or uncloned nested git repo, `cd` fails, the entire `sh -c` exits non-zero, and Docker's `restart: unless-stopped` triggers the exponential-backoff restart loop (2 s → 4 s → 7 s … 60 s). Fixed by wrapping it in `if [ -d ... ]`, matching the existing guard already present for `private/`.
- **wwv startup crash** — `ENCRYPTION_MASTER_KEY` was absent from the `wwv` service `environment:` block. `src/instrumentation.ts` throws a fatal error at boot if this var is unset. Added with a local-dev fallback (`:-local_dev_encryption_key_change_in_prod`), matching the `AUTH_SECRET` pattern.

## Test Plan

- [ ] `docker compose up` (no `--profile engine`) starts the `wwv` container without the `ENCRYPTION_MASTER_KEY` crash
- [ ] `docker compose --profile engine up` starts `wwv-data-engine` without the restart loop even when `local-seeders/community/` is absent or empty
- [ ] `docker compose --profile engine up` with `local-seeders/community/` present still runs the `pnpm install` step normally