### PR TITLE
fix(incidents): add mapWebsocketPayload default to BaseIncidentPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/packages/wwv-lib-incidents/package.json
+++ b/packages/wwv-lib-incidents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldwideview/wwv-lib-incidents",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared abstract base classes for WorldWideView incident plugins (earthquakes, wildfires, conflicts)",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/wwv-lib-incidents/src/index.test.ts
+++ b/packages/wwv-lib-incidents/src/index.test.ts
@@ -1,21 +1,15 @@
 /**
  * Guard tests for the BaseIncidentPlugin WebSocket payload contract.
  *
- * CONTEXT — The bug being guarded against:
+ * CONTEXT — The bug this suite guards against (now fixed):
  *   WsClient.handleDataMessage (src/core/data/WsClient.ts, lines 166-190) has three branches:
  *     1. Plugin has `mapWebsocketPayload` → called with raw payload → must return GeoEntity[]
  *     2. No handler AND payload IS a flat array → used directly (timestamps normalised)
  *     3. No handler AND payload is ANY OTHER object → silently dropped (console.warn + return)
  *
- *   BaseIncidentPlugin currently has NO `mapWebsocketPayload`. The canonical data-engine
- *   scheduler wraps snapshots as `{ source, fetchedAt, items, totalCount }` (an object, not
- *   an array), so branch 3 fires for every BaseIncidentPlugin subclass whose seeder uses the
- *   standard scheduler wrapper — including the earthquakes plugin.
- *
- * TEST STRATEGY:
- *   - it.fails(...)  → asserts the DESIRED post-fix behavior; currently fails → proves the bug.
- *                      CI will flip these to green once BaseIncidentPlugin gains mapWebsocketPayload.
- *   - it(...)        → asserts current working behaviour that must NOT regress.
+ *   BaseIncidentPlugin now provides a default `mapWebsocketPayload` that unwraps the three
+ *   common payload shapes (scheduler envelope, GeoJSON FeatureCollection, flat array).
+ *   Subclasses may override for domain-specific shapes.
  */
 
 import { describe, it, expect } from "vitest";
@@ -128,19 +122,8 @@ function simulateWsClientDispatch(
 describe("BaseIncidentPlugin — WebSocket payload contract", () => {
 
     describe("scheduler-wrapped payload { source, fetchedAt, items, totalCount }", () => {
-        /**
-         * DESIRED behavior: BaseIncidentPlugin.mapWebsocketPayload should unwrap the
-         * canonical scheduler envelope and return the items array as GeoEntity[].
-         *
-         * CURRENT state: the method does not exist on BaseIncidentPlugin, so
-         * simulateWsClientDispatch returns null (silent drop) instead of the items.
-         *
-         * This test is marked it.fails so CI proves the bug today and will automatically
-         * turn green once the fix is landed.
-         */
-        it.fails(
-            "unwraps { source, fetchedAt, items, totalCount } and returns items as GeoEntity[] " +
-            "(CURRENTLY FAILS — BaseIncidentPlugin has no mapWebsocketPayload)",
+        it(
+            "unwraps { source, fetchedAt, items, totalCount } and returns items as GeoEntity[]",
             () => {
                 const plugin = new MinimalIncidentPlugin();
                 const entity1 = makeEntity("eq-1");
@@ -164,26 +147,6 @@ describe("BaseIncidentPlugin — WebSocket payload contract", () => {
             }
         );
 
-        /**
-         * Documents the CURRENT broken behaviour explicitly.
-         * When the fix lands, this test should be DELETED (the positive assertion above replaces it).
-         */
-        it(
-            "currently drops the wrapped payload silently (returns null) because mapWebsocketPayload is absent",
-            () => {
-                const plugin = new MinimalIncidentPlugin();
-                const wrappedPayload = {
-                    source: "usgs-earthquake-feed",
-                    fetchedAt: "2025-01-01T00:00:00Z",
-                    items: [makeEntity("eq-1")],
-                    totalCount: 1,
-                };
-
-                // simulateWsClientDispatch returns null to represent the silent drop
-                const result = simulateWsClientDispatch(plugin, wrappedPayload);
-                expect(result).toBeNull();
-            }
-        );
     });
 
     describe("flat GeoEntity[] payload", () => {
@@ -219,17 +182,8 @@ describe("BaseIncidentPlugin — WebSocket payload contract", () => {
     });
 
     describe("GeoJSON { features: [...] } payload", () => {
-        /**
-         * DESIRED behavior: BaseIncidentPlugin.mapWebsocketPayload should normalise a
-         * GeoJSON FeatureCollection envelope into a GeoEntity[].
-         *
-         * CURRENT state: no mapWebsocketPayload → silent drop (null).
-         *
-         * Marked it.fails for the same reason as the scheduler-wrapped test.
-         */
-        it.fails(
-            "normalises a GeoJSON FeatureCollection into GeoEntity[] " +
-            "(CURRENTLY FAILS — BaseIncidentPlugin has no mapWebsocketPayload)",
+        it(
+            "normalises a GeoJSON FeatureCollection into GeoEntity[]",
             () => {
                 const plugin = new MinimalIncidentPlugin();
 
@@ -260,26 +214,6 @@ describe("BaseIncidentPlugin — WebSocket payload contract", () => {
             }
         );
 
-        it(
-            "currently drops a GeoJSON FeatureCollection silently because mapWebsocketPayload is absent",
-            () => {
-                const plugin = new MinimalIncidentPlugin();
-
-                const geojsonPayload = {
-                    type: "FeatureCollection",
-                    features: [
-                        {
-                            type: "Feature",
-                            geometry: { type: "Point", coordinates: [139.65, 35.68] },
-                            properties: {},
-                        },
-                    ],
-                };
-
-                const result = simulateWsClientDispatch(plugin, geojsonPayload);
-                expect(result).toBeNull();
-            }
-        );
     });
 
     describe("subclass override of mapWebsocketPayload", () => {
@@ -318,14 +252,9 @@ describe("BaseIncidentPlugin — WebSocket payload contract", () => {
     });
 
     describe("BaseIncidentPlugin structural contract", () => {
-        /**
-         * Confirm mapWebsocketPayload is NOT present on BaseIncidentPlugin today.
-         * This is the definitive proof of the bug — once the fix is added, this test
-         * should be updated (or removed) alongside the it.fails tests above.
-         */
-        it("does NOT have mapWebsocketPayload defined (confirms the bug exists)", () => {
+        it("has mapWebsocketPayload defined", () => {
             const plugin = new MinimalIncidentPlugin();
-            expect(typeof (plugin as any).mapWebsocketPayload).toBe("undefined");
+            expect(typeof (plugin as any).mapWebsocketPayload).toBe("function");
         });
 
         it("implements the required WorldPlugin lifecycle methods", () => {

--- a/packages/wwv-lib-incidents/src/index.ts
+++ b/packages/wwv-lib-incidents/src/index.ts
@@ -80,4 +80,69 @@ export abstract class BaseIncidentPlugin implements WorldPlugin {
             labelFont: "11px JetBrains Mono, monospace" // Adds optional label standard
         };
     }
+
+    /**
+     * Default WebSocket payload normaliser. WsClient calls this when a data message
+     * arrives; if absent, WsClient silently drops anything that isn't a flat array.
+     *
+     * Handles three shapes:
+     *   - Scheduler envelope: { source, fetchedAt, items: GeoEntity[], totalCount } → items
+     *   - GeoJSON FeatureCollection: { features: [{geometry, properties}, ...] } → normalised
+     *   - Flat array: passes through (with timestamp normalisation)
+     *
+     * Subclasses may override for domain-specific shapes; this default covers
+     * the common scheduler-wrapped and GeoJSON cases so the bug doesn't recur.
+     *
+     * @param payload - Raw payload received from the WebSocket message
+     * @param _existingEntities - Current entities in the layer (unused by default; available for subclass merging logic)
+     * @returns Normalised GeoEntity[] ready for the layer renderer
+     */
+    mapWebsocketPayload(payload: any, _existingEntities?: GeoEntity[]): GeoEntity[] {
+        const items = this.extractIncidentItems(payload);
+        return items.map((e) => ({
+            ...e,
+            timestamp: e.timestamp instanceof Date ? e.timestamp : new Date(e.timestamp ?? Date.now()),
+        }));
+    }
+
+    /**
+     * Extracts a raw GeoEntity array from the three common payload shapes:
+     * scheduler envelope, GeoJSON FeatureCollection, or flat array.
+     *
+     * @param payload - The raw WebSocket payload
+     * @returns Unnormalised array of GeoEntity-like objects (timestamps not yet coerced)
+     */
+    protected extractIncidentItems(payload: any): GeoEntity[] {
+        if (Array.isArray(payload)) {
+            return payload as GeoEntity[];
+        }
+        if (payload && Array.isArray(payload.items)) {
+            return payload.items as GeoEntity[];
+        }
+        if (payload && Array.isArray(payload.features)) {
+            return payload.features.map((f: any, i: number) => this.geoJsonFeatureToEntity(f, i));
+        }
+        return [];
+    }
+
+    /**
+     * Converts a GeoJSON Feature object into a GeoEntity.
+     *
+     * @param feature - GeoJSON Feature with geometry.coordinates and optional properties
+     * @param index - Position in the parent features array, used to generate a fallback id
+     * @returns A GeoEntity with lat/lon extracted from the feature geometry
+     */
+    protected geoJsonFeatureToEntity(feature: any, index: number): GeoEntity {
+        const coords = feature?.geometry?.coordinates ?? [0, 0];
+        const props = feature?.properties ?? {};
+        return {
+            id: props.id ?? `${this.id}-${index}`,
+            pluginId: this.id,
+            latitude: coords[1],
+            longitude: coords[0],
+            timestamp: props.timestamp ? new Date(props.timestamp) : new Date(),
+            properties: props,
+            label: props.label,
+        };
+    }
 }

--- a/src/lib/security/ssrf.spec.ts
+++ b/src/lib/security/ssrf.spec.ts
@@ -1,4 +1,19 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockUndiciF, mockDnsLookup } = vi.hoisted(() => ({
+    mockUndiciF: vi.fn(),
+    mockDnsLookup: vi.fn(),
+}));
+
+vi.mock("dns/promises", () => ({
+    default: { lookup: mockDnsLookup },
+}));
+
+vi.mock("undici", async (importOriginal) => {
+    const original = await importOriginal<typeof import("undici")>();
+    return { ...original, fetch: mockUndiciF };
+});
+
 import { safeFetch, validateOrigin, isPrivateIP } from "./ssrf";
 
 describe("SSRF Protection Utility", () => {
@@ -68,23 +83,55 @@ describe("SSRF Protection Utility", () => {
     });
 
     describe("safeFetch", () => {
+        const PUBLIC_IP = "93.184.216.34";
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+            process.env.PROXY_HOST_ALLOWLIST = "*";
+        });
+
+        afterEach(() => {
+            delete process.env.PROXY_HOST_ALLOWLIST;
+        });
+
         it("should reject private IPs immediately", async () => {
-            process.env.PROXY_HOST_ALLOWLIST = "*"; // bypass allowlist for these tests
             await expect(safeFetch("https://127.0.0.1/data")).rejects.toThrow(/SSRF/);
             await expect(safeFetch("https://169.254.169.254/latest/meta-data")).rejects.toThrow(/SSRF/);
         });
 
-        it("should enforce size limits", async () => {
-            // Because safeFetch will attempt DNS lookup, we'd need to mock it if we wanted to test this in isolation.
-            // But since this is a unit test, we can trust the return is a standard fetch wrapped with size enforcement.
-            // The size limits are enforced on the stream pull.
-            const result = safeFetch;
-            expect(typeof result).toBe("function");
+        it("enforces maxSize — responses exceeding the limit error on body read", async () => {
+            mockDnsLookup.mockResolvedValue({ address: PUBLIC_IP, family: 4 });
+            const oversized = new Uint8Array(11); // 11 bytes > 10-byte limit
+            const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(oversized);
+                    controller.close();
+                },
+            });
+            mockUndiciF.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+
+            const response = await safeFetch("https://example.com/feed", { maxSize: 10 });
+            await expect(response.text()).rejects.toThrow(/size exceeded/);
         });
 
-        it("should use undici dispatcher to pin the DNS resolution", async () => {
-            // Again, a full mock is complex, but we know it now uses undici.
-            expect(true).toBe(true);
+        it("uses undici dispatcher pinned to the resolved IP and does not follow redirects", async () => {
+            mockDnsLookup.mockResolvedValue({ address: PUBLIC_IP, family: 4 });
+            // safeFetch uses redirect:"manual" — this 301 must not be followed
+            mockUndiciF.mockResolvedValueOnce(
+                new Response(null, { status: 301, headers: { Location: "https://evil-rebind.example.com" } })
+            );
+
+            const response = await safeFetch("https://example.com/feed");
+
+            // DNS resolved exactly once; redirect was NOT followed (fetch still once)
+            expect(mockDnsLookup).toHaveBeenCalledOnce();
+            expect(mockUndiciF).toHaveBeenCalledOnce();
+            expect(response.status).toBe(301);
+
+            // fetch was called with a dispatcher (undici Agent) and redirect:"manual"
+            const callOpts = mockUndiciF.mock.calls[0][1] as Record<string, unknown>;
+            expect(callOpts.dispatcher).toBeDefined();
+            expect(callOpts.redirect).toBe("manual");
         });
     });
 });


### PR DESCRIPTION
## Summary
Adds a default `mapWebsocketPayload` implementation to `BaseIncidentPlugin` that unwraps three common payload shapes (scheduler envelope, GeoJSON FeatureCollection, flat array). Fixes the silent-drop bug that left the earthquakes plugin showing an empty layer post-Phase-4-cutover.

## Test plan
- [ ] `pnpm test "packages/wwv-lib-incidents"` shows 10 passed (down from 12, since 2 'currently drops' companions are deleted).
- [ ] Full repo: `Tests  360 passed (360)` — no expected-fail (was 360 passed | 2 expected fail before this fix).
- [ ] `pnpm typecheck && pnpm build` clean.
- [ ] After merge, restart the local data engine + frontend and confirm the earthquakes plugin shows markers (was empty before).

## Follow-ups (not in this PR)
- Coolify cutover for Phase 4 enforcement (separate plan).
- `conflict-events` and `iranwarlive` plugin behaviour is unchanged — `conflict-events` ships flat arrays (covered by the passthrough branch), `iranwarlive` has its own override (precedence verified by tests).
