### PR TITLE
feat(marketplace): pass from_instance origin when opening marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.18.3",
+  "version": "2.19.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const MARKETPLACE_DIR = path.resolve(__dir, '../worldwideview-marketplace');
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -61,12 +66,25 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'pnpm dev',
-    env: { PORT: '3001' },
-    url: 'http://localhost:3001',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  /* Run dev servers before starting the tests */
+  webServer: [
+    {
+      command: 'pnpm dev',
+      env: {
+        PORT: '3001',
+        NEXT_PUBLIC_MARKETPLACE_URL: 'http://localhost:3002',
+      },
+      url: 'http://localhost:3001',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+    },
+    {
+      command: 'pnpm dev',
+      cwd: MARKETPLACE_DIR,
+      env: { PORT: '3002' },
+      url: 'http://localhost:3002',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+    },
+  ],
 });

--- a/playwright.marketplace.config.ts
+++ b/playwright.marketplace.config.ts
@@ -1,0 +1,46 @@
+/**
+ * Marketplace-only E2E config.
+ * Runs against the marketplace dev server on port 3002 only.
+ * No worldwideview auth or Docker/Postgres required.
+ *
+ * Usage:
+ *   pnpm exec playwright test --config=playwright.marketplace.config.ts
+ */
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+const MARKETPLACE_DIR = path.resolve(__dir, '../worldwideview-marketplace');
+
+export default defineConfig({
+    timeout: 30000,
+    expect: { timeout: 10000 },
+    testDir: './tests',
+    testMatch: '**/marketplace-from-instance.spec.ts',
+    fullyParallel: false,
+    retries: 0,
+    workers: 1,
+    reporter: 'list',
+
+    use: {
+        baseURL: 'http://localhost:3002',
+        trace: 'on-first-retry',
+    },
+
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+
+    webServer: {
+        command: 'pnpm dev',
+        cwd: MARKETPLACE_DIR,
+        env: { PORT: '3002' },
+        url: 'http://localhost:3002',
+        reuseExistingServer: true,
+        timeout: 90 * 1000,
+    },
+});

--- a/src/components/panels/PluginsTab.tsx
+++ b/src/components/panels/PluginsTab.tsx
@@ -62,16 +62,23 @@ function TrustBadge({ trust }: { trust: string }) {
 // ─── Browse Link ────────────────────────────────────────────
 
 function BrowseLink() {
+    function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
+        e.preventDefault();
+        trackEvent("marketplace-browse-click");
+        const base = "https://marketplace.worldwideview.dev";
+        const url = `${base}?from_instance=${encodeURIComponent(window.location.origin)}`;
+        window.open(url, "_blank", "noopener,noreferrer");
+    }
     return (
       <a
         href="https://marketplace.worldwideview.dev"
         target="_blank"
         rel="noopener noreferrer"
         className="plugins-tab__browse"
-        onClick={() => trackEvent("marketplace-browse-click")}
+        onClick={handleClick}
       >
         <ExternalLink size={14} />
-        Marketplace
+        Browse Plugins
       </a>
     );
 }

--- a/src/components/panels/PluginsTab.tsx
+++ b/src/components/panels/PluginsTab.tsx
@@ -61,20 +61,22 @@ function TrustBadge({ trust }: { trust: string }) {
 
 // ─── Browse Link ────────────────────────────────────────────
 
+const MARKETPLACE_BASE = process.env.NEXT_PUBLIC_MARKETPLACE_URL ?? "https://marketplace.worldwideview.dev";
+
 function BrowseLink() {
     function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
         e.preventDefault();
         trackEvent("marketplace-browse-click");
-        const base = "https://marketplace.worldwideview.dev";
-        const url = `${base}?from_instance=${encodeURIComponent(window.location.origin)}`;
+        const url = `${MARKETPLACE_BASE}?from_instance=${encodeURIComponent(window.location.origin)}`;
         window.open(url, "_blank", "noopener,noreferrer");
     }
     return (
       <a
-        href="https://marketplace.worldwideview.dev"
+        href={MARKETPLACE_BASE}
         target="_blank"
         rel="noopener noreferrer"
         className="plugins-tab__browse"
+        data-testid="browse-plugins-btn"
         onClick={handleClick}
       >
         <ExternalLink size={14} />

--- a/tests/marketplace-from-instance.spec.ts
+++ b/tests/marketplace-from-instance.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Marketplace instance auto-discovery E2E tests.
+ *
+ * Two test groups:
+ *
+ * 1. "capture side" — navigates directly to the marketplace with
+ *    ?from_instance=... and verifies InstanceCapture stores it.
+ *    Runs with playwright.marketplace.config.ts (no worldwideview / Docker needed).
+ *
+ * 2. "full flow" — opens worldwideview, clicks Browse Plugins, and verifies
+ *    the marketplace receives the param. Needs the main playwright.config.ts
+ *    (Docker + Postgres required for auth).
+ */
+
+const MARKETPLACE_URL = 'http://localhost:3002';
+const WWV_ORIGIN = 'http://localhost:3001';
+const FROM_INSTANCE_PARAM = `from_instance=${encodeURIComponent(WWV_ORIGIN)}`;
+
+// ─── Marketplace capture side (no worldwideview auth needed) ────────────────
+
+test.describe('InstanceCapture — marketplace receives from_instance', () => {
+    test('captures valid origin, writes localStorage, cleans URL', async ({ page }) => {
+        // Navigate as the marketplace would be opened by worldwideview.
+        // InstanceCapture runs during React hydration (useEffect), so by the time
+        // page.goto() resolves the URL may already be clean — that is correct behavior.
+        await page.goto(`${MARKETPLACE_URL}/?${FROM_INSTANCE_PARAM}`);
+
+        // Wait for InstanceCapture to write to localStorage (may already be set)
+        await page.waitForFunction(
+            () => localStorage.getItem('wwv_instance_url') !== null,
+            { timeout: 15000 }
+        );
+
+        // localStorage has the correct origin-only value
+        const stored = await page.evaluate(() => localStorage.getItem('wwv_instance_url'));
+        expect(stored).toBe(WWV_ORIGIN);
+
+        // from_instance param was stripped by history.replaceState
+        expect(page.url()).not.toContain('from_instance');
+    });
+
+    test('rejects javascript: protocol and leaves localStorage empty', async ({ page }) => {
+        // Clear any prior localStorage from the same origin
+        await page.goto(MARKETPLACE_URL);
+        await page.evaluate(() => localStorage.removeItem('wwv_instance_url'));
+
+        await page.goto(`${MARKETPLACE_URL}/?from_instance=${encodeURIComponent('javascript:alert(1)')}`);
+
+        // Give InstanceCapture time to run
+        await page.waitForTimeout(1500);
+
+        const stored = await page.evaluate(() => localStorage.getItem('wwv_instance_url'));
+        expect(stored).toBeNull();
+    });
+
+    test('rejects self-referential origin and leaves localStorage empty', async ({ page }) => {
+        await page.goto(MARKETPLACE_URL);
+        await page.evaluate(() => localStorage.removeItem('wwv_instance_url'));
+
+        // from_instance points at the marketplace itself — should be rejected
+        await page.goto(`${MARKETPLACE_URL}/?from_instance=${encodeURIComponent(MARKETPLACE_URL)}`);
+        await page.waitForTimeout(1500);
+
+        const stored = await page.evaluate(() => localStorage.getItem('wwv_instance_url'));
+        expect(stored).toBeNull();
+    });
+
+    test('direct navigation without param leaves localStorage unchanged', async ({ page }) => {
+        await page.goto(MARKETPLACE_URL);
+        await page.evaluate(() => localStorage.removeItem('wwv_instance_url'));
+
+        await page.reload();
+        await page.waitForLoadState('load');
+        await page.waitForTimeout(1000);
+
+        const stored = await page.evaluate(() => localStorage.getItem('wwv_instance_url'));
+        expect(stored).toBeNull();
+    });
+});
+
+// ─── Full flow (worldwideview → marketplace, requires Docker + auth) ─────────
+
+test.describe('Full flow — Browse Plugins in worldwideview opens marketplace', () => {
+    test.beforeEach(async ({ page, baseURL }) => {
+        // Skip when running with the marketplace-only config (baseURL = 3002)
+        test.skip(baseURL !== WWV_ORIGIN, 'Requires worldwideview running (main config + Docker)');
+
+        await page.goto('/');
+        await page.waitForSelector('[data-testid="app-ready"]', { state: 'attached', timeout: 45000 });
+
+        // Dismiss unverified plugin dialog if it appears
+        try {
+            const installBtn = page.getByRole('button', { name: /Install Selected/ });
+            await installBtn.waitFor({ state: 'visible', timeout: 2000 });
+            await installBtn.click();
+        } catch { /* not present */ }
+
+        // Ensure left panel is open
+        const leftToggle = page.locator('[data-testid="panel-toggle-left"]');
+        const isOpen = await leftToggle.evaluate((el) => el.classList.contains('panel-toggle-btn--open'));
+        if (!isOpen) await leftToggle.click();
+    });
+
+    test('Browse Plugins appends from_instance and marketplace captures it', async ({ page }) => {
+        // Navigate to Plugins tab
+        const pluginsTab = page.locator('button.panel-tab[title="Plugins"]');
+        await expect(pluginsTab).toBeVisible({ timeout: 10000 });
+        await pluginsTab.click();
+
+        const browseBtn = page.locator('[data-testid="browse-plugins-btn"]');
+        await expect(browseBtn).toBeVisible({ timeout: 5000 });
+
+        // Click and capture the popup
+        const popupPromise = page.waitForEvent('popup');
+        await browseBtn.click();
+        const popup = await popupPromise;
+
+        // Initial URL has from_instance
+        expect(popup.url()).toContain(FROM_INSTANCE_PARAM);
+
+        // InstanceCapture writes to localStorage
+        await popup.waitForFunction(
+            () => localStorage.getItem('wwv_instance_url') !== null,
+            { timeout: 15000 }
+        );
+
+        const stored = await popup.evaluate(() => localStorage.getItem('wwv_instance_url'));
+        expect(stored).toBe(WWV_ORIGIN);
+
+        // URL cleaned up
+        expect(popup.url()).not.toContain('from_instance');
+
+        await popup.close();
+    });
+});


### PR DESCRIPTION
## Summary

- `BrowseLink` in `PluginsTab.tsx` now builds the marketplace URL dynamically on click, appending `?from_instance=<encoded-origin>` so the marketplace knows which instance opened it
- Fallback `href` stays as the bare marketplace URL (SSR-safe, works without JS)
- Button label updated to "Browse Plugins" to match user vocabulary
- Version bumped 2.18.3 -> 2.19.0 (feat: minor bump)

## How it works

When the user clicks "Browse Plugins", the `onClick` handler fires before the navigation, reads `window.location.origin`, and opens the marketplace in a new tab with the origin appended as `?from_instance=...`. The marketplace (see companion PR) picks this up on load and writes it to localStorage, so the `InstanceConfig` modal never appears for users arriving from worldwideview.

## Test Plan

- [ ] Run worldwideview locally (`pnpm dev`)
- [ ] Open Plugins panel, click "Browse Plugins"
- [ ] Verify new tab opens with `?from_instance=http://localhost:3000` (or your origin) in the URL
- [ ] Verify `localStorage["wwv_instance_url"]` is set in the marketplace tab after landing
- [ ] Verify clicking "Install" on any plugin does NOT trigger the InstanceConfig modal
- [ ] `pnpm test` - all 360 tests pass