### PR TITLE
fix(camera): camera proxy display + iframe sandbox hardening

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // Global security headers for all routes
         source: "/(.*)",
         headers: [
           {
@@ -49,6 +50,39 @@ const nextConfig: NextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=(self)",
           },
+        ],
+      },
+      {
+        // Camera proxy routes serve content that must be embeddable in an <iframe>
+        // within the same origin. Override the global frame-ancestors 'none' and
+        // X-Frame-Options: DENY so the browser allows the proxy response to be
+        // framed by our own app (localhost:3000 / production domain).
+        // The upstream camera HTML already had its own X-Frame-Options stripped by
+        // the iframe proxy route; this override ensures our response headers don't
+        // re-block it.
+        source: "/api/camera/proxy/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://unpkg.com https://cdn.jsdelivr.net https://analytics.worldwideview.dev https://va.vercel-scripts.com https://pagead2.googlesyndication.com https://adservice.google.com https://www.googletagservices.com https://ep2.adtrafficquality.google https://static.cloudflareinsights.com",
+              "style-src 'self' 'unsafe-inline' fonts.googleapis.com",
+              "font-src 'self' fonts.gstatic.com",
+              "img-src 'self' data: blob: http: https:",
+              "connect-src 'self' http: https: ws: wss:",
+              "media-src 'self' blob: http: https:",
+              "frame-src 'self' http: https: blob:",
+              "worker-src 'self' blob:",
+              // Allow same-origin framing only — the app embeds these proxy responses
+              // inside <iframe> elements on localhost:3000 / the production domain.
+              "frame-ancestors 'self'",
+            ].join("; "),
+          },
+          // Remove the DENY override — SAMEORIGIN allows our app to frame this response
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
         ],
       },
     ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -64,20 +64,11 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "Content-Security-Policy",
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://unpkg.com https://cdn.jsdelivr.net https://analytics.worldwideview.dev https://va.vercel-scripts.com https://pagead2.googlesyndication.com https://adservice.google.com https://www.googletagservices.com https://ep2.adtrafficquality.google https://static.cloudflareinsights.com",
-              "style-src 'self' 'unsafe-inline' fonts.googleapis.com",
-              "font-src 'self' fonts.gstatic.com",
-              "img-src 'self' data: blob: http: https:",
-              "connect-src 'self' http: https: ws: wss:",
-              "media-src 'self' blob: http: https:",
-              "frame-src 'self' http: https: blob:",
-              "worker-src 'self' blob:",
-              // Allow same-origin framing only — the app embeds these proxy responses
-              // inside <iframe> elements on localhost:3000 / the production domain.
-              "frame-ancestors 'self'",
-            ].join("; "),
+            // Proxy routes serve arbitrary external HTML (YouTube embeds, camera feeds, etc.).
+            // Restricting style-src/script-src here would break the proxied content since we
+            // cannot predict which CDN domains it loads from. The meaningful security boundary
+            // is frame-ancestors 'self' — only our own origin can embed these proxy responses.
+            value: "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:; frame-ancestors 'self'",
           },
           // Remove the DENY override — SAMEORIGIN allows our app to frame this response
           { key: "X-Frame-Options", value: "SAMEORIGIN" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.18.4",
+  "version": "2.18.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/scripts/boot-db.mjs
+++ b/scripts/boot-db.mjs
@@ -63,7 +63,22 @@ console.log(`🔌 Assigned deterministic database port: ${port}`);
 
 // Robust rewrite of DATABASE_URL in .env
 const envPath = path.resolve(cwd, '.env');
-if (fs.existsSync(envPath)) {
+
+// Ensure .env exists — worktrees only have .env.local, not .env.
+// Without this, the DATABASE_URL injection block below is silently skipped
+// and safe-db-push.mjs fails with "DATABASE_URL is missing".
+if (!fs.existsSync(envPath)) {
+  const examplePath = path.resolve(cwd, '.env.example');
+  if (fs.existsSync(examplePath)) {
+    fs.copyFileSync(examplePath, envPath);
+    console.log('📄 Created .env from .env.example (worktree first-run).');
+  } else {
+    fs.writeFileSync(envPath, '');
+    console.log('📄 Created empty .env (worktree first-run).');
+  }
+}
+
+{
   const envContent = fs.readFileSync(envPath, 'utf8');
   const lines = envContent.split(/\r?\n/);
   
@@ -96,7 +111,7 @@ if (fs.existsSync(envPath)) {
   
   if (linesModified) {
     const newContent = newLines.join('\n');
-    
+
     // File write with retries and telemetry
     const maxRetries = 3;
     let attempt = 0;
@@ -121,7 +136,7 @@ if (fs.existsSync(envPath)) {
       }
     }
   }
-}
+} // end DATABASE_URL injection block
 
 
 console.log('🚀 Checking local PostgreSQL database...');

--- a/src/components/video/CameraStream.tsx
+++ b/src/components/video/CameraStream.tsx
@@ -163,9 +163,17 @@ label: label || "Camera Stream",
                 embedUrl = getProxiedIframeUrl(embedUrl);
             }
 
+            // Proxied iframes are served from our own origin, so without sandboxing the
+            // upstream HTML could reach window.parent and exfiltrate localStorage / DOM.
+            // Omit allow-same-origin so the iframe gets a unique opaque origin; scripts
+            // still run (video players keep working) but cannot touch the host app.
+            // Major platforms (YouTube/Twitch/Vimeo) bypass the proxy and load from their
+            // own cross-origin host, where the browser's same-origin policy already isolates them.
+            const isProxiedIframe = !isMajorPlatformHost;
             return (
               <iframe
                 src={embedUrl}
+                sandbox={isProxiedIframe ? "allow-scripts allow-popups allow-presentation" : undefined}
                 style={{
  position: "absolute", inset: 0, width: "100%", height: "100%", border: "none"
 }}

--- a/src/lib/security/ssrf.spec.ts
+++ b/src/lib/security/ssrf.spec.ts
@@ -38,14 +38,19 @@ describe("SSRF Protection Utility", () => {
     });
 
     describe("validateOrigin", () => {
-        it("should allow valid https origins", () => {
+        it("should allow https origins", () => {
             expect(validateOrigin("https://api.github.com/v1")).toBe(true);
         });
 
-        it("should reject non-https protocols", () => {
-            expect(validateOrigin("http://api.github.com")).toBe(false);
+        it("should allow http origins (StreamProxy fetches HTTP camera feeds server-side)", () => {
+            expect(validateOrigin("http://camera.example.com/stream")).toBe(true);
+        });
+
+        it("should reject dangerous non-web protocols", () => {
             expect(validateOrigin("ftp://api.github.com")).toBe(false);
             expect(validateOrigin("file:///etc/passwd")).toBe(false);
+            expect(validateOrigin("data:text/html,<h1>xss</h1>")).toBe(false);
+            expect(validateOrigin("javascript:alert(1)")).toBe(false);
         });
     });
 
@@ -97,6 +102,19 @@ describe("SSRF Protection Utility", () => {
         it("should reject private IPs immediately", async () => {
             await expect(safeFetch("https://127.0.0.1/data")).rejects.toThrow(/SSRF/);
             await expect(safeFetch("https://169.254.169.254/latest/meta-data")).rejects.toThrow(/SSRF/);
+        });
+
+        it("should reject dangerous protocols (ftp, file, etc.)", async () => {
+            await expect(safeFetch("ftp://camera.example.com/stream")).rejects.toThrow(/SSRF.*protocol/i);
+            await expect(safeFetch("file:///etc/passwd")).rejects.toThrow(/SSRF.*protocol/i);
+        });
+
+        it("should accept HTTP URLs (StreamProxy use case — camera feeds)", async () => {
+            mockDnsLookup.mockResolvedValue({ address: PUBLIC_IP, family: 4 });
+            mockUndiciF.mockResolvedValueOnce(new Response("stream-data", { status: 200 }));
+
+            const response = await safeFetch("http://camera.example.com/stream");
+            expect(response.status).toBe(200);
         });
 
         it("enforces maxSize — responses exceeding the limit error on body read", async () => {

--- a/src/lib/security/ssrf.ts
+++ b/src/lib/security/ssrf.ts
@@ -8,10 +8,19 @@ export function isPrivateIP(ip: string): boolean {
     return false;
 }
 
+/**
+ * Validates that a URL uses a safe web protocol for server-side proxying.
+ * Both http: and https: are allowed -- the StreamProxy is a server-side bridge
+ * that fetches HTTP camera feeds and serves them over HTTPS to the browser,
+ * converting them to avoid browser mixed-content blocks. Blocking HTTP here
+ * would defeat the proxy's purpose. Real SSRF protection is provided by the
+ * private-IP check, DNS pinning, and the PROXY_HOST_ALLOWLIST below.
+ * Dangerous protocols (file://, ftp://, data://, javascript://, etc.) are rejected.
+ */
 export function validateOrigin(urlStr: string): boolean {
     try {
         const url = new URL(urlStr);
-        return url.protocol === "https:";
+        return url.protocol === "https:" || url.protocol === "http:";
     } catch {
         return false;
     }
@@ -48,7 +57,7 @@ export async function safeFetch(urlStr: string, options: FetchOptions = {}): Pro
     checkHostAllowlist(hostForCheck);
 
     if (!validateOrigin(urlStr)) {
-        throw new Error("SSRF Error: Invalid protocol. Only HTTPS is allowed.");
+        throw new Error("SSRF Error: Invalid protocol. Only HTTP and HTTPS are allowed.");
     }
 
     const url = new URL(urlStr);


### PR DESCRIPTION
## Summary
- Camera streams (MJPEG/iframe/YouTube/HLS) now display correctly through the server-side proxy at `/api/camera/proxy/{stream,iframe}`
- Fixes three independent root causes: CSP `frame-ancestors 'none'` blocking iframe embeds, SSRF rejecting `http://` URLs, and the proxy CSP inheriting `style-src`/`script-src` restrictions that broke external stylesheets/scripts inside proxied content
- Adds an `iframe` sandbox so the now-permissive proxy CSP cannot be turned into a same-origin XSS pivot

## Changes

| File | Change |
|---|---|
| `next.config.ts` | Path-scoped header override for `/api/camera/proxy/:path*`: `frame-ancestors 'self'`, `X-Frame-Options: SAMEORIGIN`, `default-src *` so proxied HTML can load its own CDNs |
| `src/lib/security/ssrf.ts` | `validateOrigin()` now accepts both `http://` and `https://`. The proxy is a server-side bridge that fetches plain-HTTP camera feeds and re-serves them over HTTPS |
| `src/lib/security/ssrf.spec.ts` | Updated tests to cover HTTP acceptance and dangerous-protocol rejection (`file://`, `data:`, `javascript:`, `ftp://`) |
| `src/components/video/CameraStream.tsx` | Proxied iframes get `sandbox="allow-scripts allow-popups allow-presentation"` (no `allow-same-origin`) so upstream HTML runs in an opaque origin and cannot reach `window.parent`. Major platforms (YouTube/Twitch/Vimeo) bypass the proxy and remain unsandboxed since the browser already cross-origin-isolates them |
| `scripts/boot-db.mjs` | Creates `.env` from `.env.example` if missing in worktrees, so `DATABASE_URL` is never silently skipped |

## Security model

After this branch, the proxy CSP is intentionally wide-open (`default-src *`) because we're serving arbitrary external HTML. The meaningful security boundaries are:

1. **`frame-ancestors 'self'`** — only our own origin can embed the proxy response
2. **iframe `sandbox` without `allow-same-origin`** — proxied scripts run in an opaque origin and cannot touch the host app (`window.parent`, `localStorage`, DOM)
3. **SSRF allowlist + private-IP block + DNS pinning** — still enforced on all upstream fetches
4. **Auth check** — both `/stream` and `/iframe` require a session when `isAuthEnabled`

## Verified

- `pnpm test` — 363/363 passing
- `pnpm exec tsc --noEmit` — clean
- Local dev server: proxy routes return 401 (auth) instead of 404 (route dispatch working); proxied YouTube/tvkur/webcamera embeds load their stylesheets; HTTP MJPEG cameras stream through the HTTPS bridge

## Test plan

- [ ] Enable the camera plugin in local dev and confirm at least one HTTP MJPEG stream and one YouTube/iframe embed display
- [ ] Verify proxy responses include `frame-ancestors 'self'` and `X-Frame-Options: SAMEORIGIN`; non-proxy routes still serve `frame-ancestors 'none'` / `DENY`
- [ ] Inspect proxied iframe in devtools and confirm the `sandbox` attribute is present (no `allow-same-origin`)
- [ ] Confirm `pnpm test` passes in CI

## Known limitations (not addressed in this PR)

- Some proxied players (player.tvkur.com, play.player.im, webcamera.pl) emit CORS errors from inside the iframe when their JS calls their own RUM/analytics backend — this is third-party code we cannot intercept
- A dead/flaky upstream camera can still return HTTP 500 if it errors mid-stream (after headers have been sent). Converting these to 502 would require buffering the first chunk, which trades latency for cleaner errors

Closes #160
Closes #168