### PR TITLE
fix(security): remove allow-popups from iframe sandbox and drop iframe proxy CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.18.6",
+  "version": "2.18.7",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/src/app/api/camera/proxy/iframe/route.ts
+++ b/src/app/api/camera/proxy/iframe/route.ts
@@ -55,7 +55,6 @@ export async function GET(req: NextRequest) {
                 headers: {
                     "Content-Type": contentType,
                     "Cache-Control": "no-store",
-                    "Access-Control-Allow-Origin": "*",
                 },
             });
         }
@@ -78,8 +77,6 @@ export async function GET(req: NextRequest) {
                 "Content-Type": contentType,
                 "Cache-Control": "no-store",
                 "X-Content-Type-Options": "nosniff",
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Methods": "GET, OPTIONS",
             },
         });
     } catch (error: unknown) {
@@ -90,16 +87,4 @@ export async function GET(req: NextRequest) {
             { status: 502 },
         );
     }
-}
-
-export async function OPTIONS() {
-    return new Response(null, {
-        status: 204,
-        headers: {
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type",
-            "Access-Control-Max-Age": "86400",
-        },
-    });
 }

--- a/src/components/video/CameraStream.tsx
+++ b/src/components/video/CameraStream.tsx
@@ -173,7 +173,7 @@ label: label || "Camera Stream",
             return (
               <iframe
                 src={embedUrl}
-                sandbox={isProxiedIframe ? "allow-scripts allow-popups allow-presentation" : undefined}
+                sandbox={isProxiedIframe ? "allow-scripts allow-presentation" : undefined}
                 style={{
  position: "absolute", inset: 0, width: "100%", height: "100%", border: "none"
 }}


### PR DESCRIPTION
## Summary

Two medium-severity security fixes identified by pre-mortem analysis before the camera proxy feature went to production.

- **Remove `allow-popups` from proxied iframe sandbox** (`CameraStream.tsx`): Third-party camera pages served through `/api/camera/proxy/iframe` had `allow-popups` in their sandbox, allowing them to call `window.open()`. A compromised or malicious camera provider could open phishing tabs. No camera use case requires popup capability.
- **Remove CORS wildcard from iframe proxy** (`iframe/route.ts`): The iframe proxy responded with `Access-Control-Allow-Origin: *` and had an `OPTIONS` handler. The iframe proxy is only consumed same-origin (the browser loads it as an `<iframe src="/api/camera/proxy/iframe?url=...">` — never via cross-origin XHR), so these headers served no purpose and only advertised unnecessary cross-origin access. The `OPTIONS` handler is deleted entirely.

The stream proxy (`/api/camera/proxy/stream`) is unchanged — it legitimately uses CORS wildcard for `<img>` tag fetching.

## What was NOT changed

- `default-src * 'unsafe-inline' 'unsafe-eval'` on proxy CSP routes: intentional, documented, scoped to `/api/camera/proxy/*` only
- `http://` allowed in `validateOrigin()`: intentional server-side HTTP-to-HTTPS bridge, private IPs blocked and DNS pinned

## Test plan

- [ ] All 363 unit tests pass (`pnpm test`)
- [ ] Open a proxied (non-major-platform) camera iframe in the app — confirm it loads and the browser devtools Network tab shows no `Access-Control-Allow-Origin` header on the iframe proxy response
- [ ] Confirm YouTube/Twitch cameras still load directly (no proxy path, no sandbox attribute)
- [ ] Verify a proxied iframe cannot open a popup (`window.open` should be silently blocked by the sandbox)