### PR TITLE
feat: add 12 built-in plugins + plugin settings panel

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -37,6 +37,10 @@ import { isDemo } from "@/core/edition";
 
 import { injectHostGlobals } from "@/core/plugins/hostGlobals";
 import { initLogCatcher } from "@/lib/logCatcher";
+
+// Register all 12 built-in plugins into the PluginRegistry (side-effect import).
+// This must be imported before pluginRegistry.getAll() is called below.
+import "@/plugins/builtins/index";
 import { MobileCameraStats } from "./MobileCameraStats";
 import { MobileHudBar } from "./MobileHudBar";
 import { AgentBusSubscriber } from "./AgentBusSubscriber";

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ import Image from "next/image";
 import { useIsMobile } from "@/core/hooks/useIsMobile";
 import { SearchBar } from "./SearchBar";
 import { ApiKeysTab } from "./ApiKeysTab";
+import { PluginSettingsTrigger } from "./PluginSettingsPanel";
 import "./timeSelect.css";
 
 const REGIONS = [
@@ -258,6 +259,7 @@ export function Header() {
               >
                 <Key size={14} />
               </button>
+              <PluginSettingsTrigger />
               <div style={{ position: "relative", flexShrink: 0 }}>
                 <button
                   type="button"

--- a/src/components/layout/PluginSettingsPanel.tsx
+++ b/src/components/layout/PluginSettingsPanel.tsx
@@ -1,0 +1,366 @@
+"use client";
+/**
+ * PluginSettingsPanel — Floating modal for plugin API key configuration.
+ * Shows a gear icon in the header. All keys stored in localStorage.
+ * Covers: ACLED (War Zones), Alpha Vantage (Stocks), AISStream (Ships).
+ * Free-tier layers show a green "No key required" badge.
+ */
+
+import { useState, useCallback, useEffect } from "react";
+import {
+    Settings, Eye, EyeOff, CheckCircle, XCircle, Loader2, X,
+} from "lucide-react";
+
+interface KeyEntry {
+    id: string;
+    label: string;
+    description: string;
+    placeholder: string;
+    lsKey: string;
+    free?: boolean; // show "no key required" badge instead of input
+    testUrl?: (key: string) => string; // optional live test
+}
+
+const KEY_ENTRIES: KeyEntry[] = [
+    // --- Free APIs ---
+    {
+        id: "opensky",
+        label: "Flights (OpenSky)",
+        description: "Anonymous real-time aircraft positions",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "open-meteo",
+        label: "Weather (Open-Meteo)",
+        description: "Current conditions for 20 major cities",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "usgs",
+        label: "Earthquakes (USGS)",
+        description: "Real-time seismic events GeoJSON feed",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "gvp",
+        label: "Volcanoes (Smithsonian GVP)",
+        description: "Active volcano data (hardcoded from GVP 2024)",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "blitzortung",
+        label: "Lightning (Blitzortung.org)",
+        description: "Public WebSocket lightning strike network",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "gdacs",
+        label: "Disasters (GDACS)",
+        description: "Global Disaster Alert and Coordination System",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "open-notify-iss",
+        label: "ISS Tracker (wheretheiss.at)",
+        description: "International Space Station position API",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    {
+        id: "rss",
+        label: "News (RSS Feeds)",
+        description: "BBC, Al Jazeera, NYT, ABC Australia, Times of India",
+        placeholder: "",
+        lsKey: "",
+        free: true,
+    },
+    // --- Keyed APIs ---
+    {
+        id: "aisstream",
+        label: "Ships (AISStream)",
+        description: "Real-time vessel positions WebSocket — free at aisstream.io",
+        placeholder: "Your AISStream API key",
+        lsKey: "wwv_aisstream_key",
+    },
+    {
+        id: "acled-email",
+        label: "War Zones (ACLED) — Email",
+        description: "ACLED API email — register free at developer.acleddata.com",
+        placeholder: "your@email.com",
+        lsKey: "wwv_acled_email",
+    },
+    {
+        id: "acled-key",
+        label: "War Zones (ACLED) — API Key",
+        description: "ACLED API key — register free at developer.acleddata.com",
+        placeholder: "Your ACLED API key",
+        lsKey: "wwv_acled_key",
+    },
+    {
+        id: "alphavantage",
+        label: "Stocks (Alpha Vantage)",
+        description: "Free stock market API — register at alphavantage.co",
+        placeholder: "Your Alpha Vantage API key",
+        lsKey: "wwv_alphavantage_key",
+    },
+];
+
+type SaveStatus = "idle" | "saved" | "cleared";
+
+function FreeBadge() {
+    return (
+        <span
+            style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                background: "rgba(16,185,129,0.12)",
+                color: "#10b981",
+                border: "1px solid rgba(16,185,129,0.3)",
+                borderRadius: 4,
+                padding: "2px 8px",
+                fontSize: 11,
+                fontWeight: 600,
+            }}
+        >
+            <CheckCircle size={10} />
+            No key required
+        </span>
+    );
+}
+
+export function PluginSettingsTrigger() {
+    const [open, setOpen] = useState(false);
+    return (
+        <>
+            <button
+                type="button"
+                className="btn btn--glow"
+                onClick={() => setOpen(true)}
+                title="Plugin Settings"
+                style={{ display: "flex", alignItems: "center", gap: "6px" }}
+            >
+                <Settings size={14} />
+            </button>
+            {open && <PluginSettingsModal onClose={() => setOpen(false)} />}
+        </>
+    );
+}
+
+function PluginSettingsModal({ onClose }: { onClose: () => void }) {
+    const [values, setValues] = useState<Record<string, string>>(() => {
+        if (typeof window === "undefined") return {};
+        const init: Record<string, string> = {};
+        KEY_ENTRIES.forEach((e) => {
+            if (e.lsKey) init[e.id] = localStorage.getItem(e.lsKey) ?? "";
+        });
+        return init;
+    });
+
+    const [visible, setVisible] = useState<Record<string, boolean>>({});
+    const [saveStatus, setSaveStatus] = useState<Record<string, SaveStatus>>({});
+
+    const handleChange = useCallback((id: string, lsKey: string, value: string) => {
+        setValues((prev) => ({ ...prev, [id]: value }));
+        if (lsKey) {
+            if (value) localStorage.setItem(lsKey, value);
+            else localStorage.removeItem(lsKey);
+        }
+        setSaveStatus((prev) => ({ ...prev, [id]: "saved" }));
+        setTimeout(() => setSaveStatus((prev) => ({ ...prev, [id]: "idle" })), 1500);
+    }, []);
+
+    const handleClear = useCallback((id: string, lsKey: string) => {
+        setValues((prev) => ({ ...prev, [id]: "" }));
+        if (lsKey) localStorage.removeItem(lsKey);
+        setSaveStatus((prev) => ({ ...prev, [id]: "cleared" }));
+        setTimeout(() => setSaveStatus((prev) => ({ ...prev, [id]: "idle" })), 1500);
+    }, []);
+
+    // Close on Escape
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+        window.addEventListener("keydown", handler);
+        return () => window.removeEventListener("keydown", handler);
+    }, [onClose]);
+
+    const inputStyle: React.CSSProperties = {
+        background: "var(--bg-tertiary, #1e293b)",
+        border: "1px solid var(--border-subtle, #334155)",
+        color: "var(--text-primary, #e2e8f0)",
+        padding: "6px 10px",
+        borderRadius: 6,
+        fontSize: 12,
+        flex: 1,
+        outline: "none",
+        fontFamily: "monospace",
+    };
+
+    const labelStyle: React.CSSProperties = {
+        fontSize: 12,
+        fontWeight: 600,
+        color: "var(--text-primary, #e2e8f0)",
+        marginBottom: 2,
+    };
+
+    const descStyle: React.CSSProperties = {
+        fontSize: 11,
+        color: "var(--text-muted, #94a3b8)",
+        marginBottom: 6,
+    };
+
+    return (
+        <div
+            style={{
+                position: "fixed", inset: 0,
+                background: "rgba(0,0,0,0.5)",
+                display: "flex", alignItems: "flex-start",
+                justifyContent: "center",
+                paddingTop: "5vh", paddingBottom: "5vh",
+                overflowY: "auto",
+                zIndex: 9999,
+            }}
+            onClick={onClose}
+        >
+            <div
+                className="glass-panel"
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                    width: "min(640px, 90vw)",
+                    maxHeight: "85vh",
+                    overflowY: "auto",
+                    padding: 24,
+                    borderRadius: 16,
+                    margin: 20,
+                }}
+            >
+                {/* Header */}
+                <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 20 }}>
+                    <Settings size={18} style={{ color: "var(--text-muted)" }} />
+                    <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>Plugin Settings</h2>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        style={{
+                            marginLeft: "auto", background: "none", border: "none",
+                            color: "var(--text-muted)", cursor: "pointer", padding: 4,
+                        }}
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+
+                <p style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 24 }}>
+                    All keys are stored only in your browser (localStorage). They never leave your device.
+                </p>
+
+                {/* Free APIs section */}
+                <div style={{ marginBottom: 24 }}>
+                    <div style={{
+                        fontSize: 10, fontWeight: 700, letterSpacing: "0.1em",
+                        textTransform: "uppercase", color: "var(--text-muted)",
+                        marginBottom: 12, paddingBottom: 6,
+                        borderBottom: "1px solid var(--border-subtle)",
+                    }}>
+                        Free APIs — No Key Required
+                    </div>
+                    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                        {KEY_ENTRIES.filter((e) => e.free).map((entry) => (
+                            <div key={entry.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                                <div>
+                                    <div style={{ ...labelStyle, marginBottom: 0 }}>{entry.label}</div>
+                                    <div style={{ fontSize: 11, color: "var(--text-muted)" }}>{entry.description}</div>
+                                </div>
+                                <FreeBadge />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Keyed APIs section */}
+                <div>
+                    <div style={{
+                        fontSize: 10, fontWeight: 700, letterSpacing: "0.1em",
+                        textTransform: "uppercase", color: "var(--text-muted)",
+                        marginBottom: 12, paddingBottom: 6,
+                        borderBottom: "1px solid var(--border-subtle)",
+                    }}>
+                        API Keys Required
+                    </div>
+                    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                        {KEY_ENTRIES.filter((e) => !e.free).map((entry) => {
+                            const status = saveStatus[entry.id] ?? "idle";
+                            const isVisible = visible[entry.id];
+                            const val = values[entry.id] ?? "";
+
+                            return (
+                                <div key={entry.id}>
+                                    <div style={labelStyle}>{entry.label}</div>
+                                    <div style={descStyle}>{entry.description}</div>
+                                    <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                                        <input
+                                            type={isVisible ? "text" : "password"}
+                                            value={val}
+                                            placeholder={entry.placeholder}
+                                            onChange={(e) => handleChange(entry.id, entry.lsKey, e.target.value)}
+                                            style={inputStyle}
+                                            autoComplete="off"
+                                            spellCheck={false}
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => setVisible((prev) => ({ ...prev, [entry.id]: !prev[entry.id] }))}
+                                            title={isVisible ? "Hide" : "Show"}
+                                            style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: 4 }}
+                                        >
+                                            {isVisible ? <EyeOff size={14} /> : <Eye size={14} />}
+                                        </button>
+                                        {val && (
+                                            <button
+                                                type="button"
+                                                onClick={() => handleClear(entry.id, entry.lsKey)}
+                                                title="Clear key"
+                                                style={{ background: "none", border: "none", color: "#ef4444", cursor: "pointer", padding: 4 }}
+                                            >
+                                                <X size={14} />
+                                            </button>
+                                        )}
+                                        {status === "saved" && <CheckCircle size={14} style={{ color: "#10b981", flexShrink: 0 }} />}
+                                        {status === "cleared" && <XCircle size={14} style={{ color: "#ef4444", flexShrink: 0 }} />}
+                                    </div>
+                                    {status === "saved" && (
+                                        <div style={{ fontSize: 10, color: "#10b981", marginTop: 2 }}>Saved to browser storage ✓</div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Footer note */}
+                <div style={{
+                    marginTop: 24, padding: 12,
+                    background: "rgba(59,130,246,0.08)",
+                    border: "1px solid rgba(59,130,246,0.2)",
+                    borderRadius: 8, fontSize: 11, color: "var(--text-muted)",
+                }}>
+                    <strong style={{ color: "var(--text-secondary)" }}>Changes take effect immediately.</strong>{" "}
+                    Reload the page if a WebSocket plugin (Ships, Lightning) doesn't reconnect automatically.
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -74,8 +74,11 @@ export function LayerPanel() {
         "natural-disaster": "Natural Disasters",
         conflict: "Conflict",
         infrastructure: "Infrastructure",
+        space: "Space",
         cyber: "Cyber",
         economic: "Economic",
+        intelligence: "Intelligence",
+        military: "Military",
         custom: "Custom",
     };
 

--- a/src/plugins/builtins/capitals.ts
+++ b/src/plugins/builtins/capitals.ts
@@ -1,0 +1,289 @@
+/**
+ * World Capitals Plugin — All 195 sovereign state capitals with flag emoji and metadata.
+ * Hardcoded data from the Smithsonian/standard geographic references.
+ * No API key required. No refresh needed (static data).
+ */
+import { Star } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+// Gold star icon for capitals
+const STAR_ICON = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+  <circle cx="14" cy="14" r="13" fill="rgba(15,23,42,0.85)"/>
+  <path d="M14 4 L16.5 11 L24 11 L18 15.5 L20.5 23 L14 18.5 L7.5 23 L10 15.5 L4 11 L11.5 11 Z"
+        fill="#fbbf24" stroke="#f59e0b" stroke-width="0.5"/>
+</svg>
+`);
+
+interface Capital {
+    country: string;
+    flag: string;
+    capital: string;
+    lat: number;
+    lon: number;
+    pop: number;
+    continent: string;
+}
+
+const CAPITALS: Capital[] = [
+    { country: "Afghanistan", flag: "🇦🇫", capital: "Kabul", lat: 34.5289, lon: 69.1725, pop: 4601789, continent: "Asia" },
+    { country: "Albania", flag: "🇦🇱", capital: "Tirana", lat: 41.3317, lon: 19.8319, pop: 895000, continent: "Europe" },
+    { country: "Algeria", flag: "🇩🇿", capital: "Algiers", lat: 36.7372, lon: 3.0865, pop: 3915811, continent: "Africa" },
+    { country: "Andorra", flag: "🇦🇩", capital: "Andorra la Vella", lat: 42.5075, lon: 1.5218, pop: 22614, continent: "Europe" },
+    { country: "Angola", flag: "🇦🇴", capital: "Luanda", lat: -8.8147, lon: 13.2302, pop: 8330000, continent: "Africa" },
+    { country: "Antigua and Barbuda", flag: "🇦🇬", capital: "St. John's", lat: 17.1274, lon: -61.8468, pop: 30000, continent: "North America" },
+    { country: "Argentina", flag: "🇦🇷", capital: "Buenos Aires", lat: -34.6037, lon: -58.3816, pop: 15594428, continent: "South America" },
+    { country: "Armenia", flag: "🇦🇲", capital: "Yerevan", lat: 40.1872, lon: 44.5152, pop: 1093500, continent: "Asia" },
+    { country: "Australia", flag: "🇦🇺", capital: "Canberra", lat: -35.2809, lon: 149.1300, pop: 453342, continent: "Oceania" },
+    { country: "Austria", flag: "🇦🇹", capital: "Vienna", lat: 48.2082, lon: 16.3738, pop: 1897491, continent: "Europe" },
+    { country: "Azerbaijan", flag: "🇦🇿", capital: "Baku", lat: 40.4093, lon: 49.8671, pop: 2293100, continent: "Asia" },
+    { country: "Bahamas", flag: "🇧🇸", capital: "Nassau", lat: 25.0480, lon: -77.3554, pop: 274400, continent: "North America" },
+    { country: "Bahrain", flag: "🇧🇭", capital: "Manama", lat: 26.2154, lon: 50.5832, pop: 157000, continent: "Asia" },
+    { country: "Bangladesh", flag: "🇧🇩", capital: "Dhaka", lat: 23.7104, lon: 90.4074, pop: 21741000, continent: "Asia" },
+    { country: "Barbados", flag: "🇧🇧", capital: "Bridgetown", lat: 13.0969, lon: -59.6145, pop: 110000, continent: "North America" },
+    { country: "Belarus", flag: "🇧🇾", capital: "Minsk", lat: 53.9045, lon: 27.5615, pop: 2009786, continent: "Europe" },
+    { country: "Belgium", flag: "🇧🇪", capital: "Brussels", lat: 50.8503, lon: 4.3517, pop: 1208542, continent: "Europe" },
+    { country: "Belize", flag: "🇧🇿", capital: "Belmopan", lat: 17.2514, lon: -88.7590, pop: 22800, continent: "North America" },
+    { country: "Benin", flag: "🇧🇯", capital: "Porto-Novo", lat: 6.3676, lon: 2.4252, pop: 309000, continent: "Africa" },
+    { country: "Bhutan", flag: "🇧🇹", capital: "Thimphu", lat: 27.4716, lon: 89.6386, pop: 114551, continent: "Asia" },
+    { country: "Bolivia", flag: "🇧🇴", capital: "Sucre", lat: -19.0196, lon: -65.2619, pop: 337000, continent: "South America" },
+    { country: "Bosnia and Herzegovina", flag: "🇧🇦", capital: "Sarajevo", lat: 43.8486, lon: 18.3564, pop: 275524, continent: "Europe" },
+    { country: "Botswana", flag: "🇧🇼", capital: "Gaborone", lat: -24.6282, lon: 25.9231, pop: 231592, continent: "Africa" },
+    { country: "Brazil", flag: "🇧🇷", capital: "Brasília", lat: -15.7801, lon: -47.9292, pop: 3015268, continent: "South America" },
+    { country: "Brunei", flag: "🇧🇳", capital: "Bandar Seri Begawan", lat: 4.9400, lon: 114.9480, pop: 64409, continent: "Asia" },
+    { country: "Bulgaria", flag: "🇧🇬", capital: "Sofia", lat: 42.6977, lon: 23.3219, pop: 1241675, continent: "Europe" },
+    { country: "Burkina Faso", flag: "🇧🇫", capital: "Ouagadougou", lat: 12.3647, lon: -1.5337, pop: 2415266, continent: "Africa" },
+    { country: "Burundi", flag: "🇧🇮", capital: "Gitega", lat: -3.4271, lon: 29.9307, pop: 135467, continent: "Africa" },
+    { country: "Cabo Verde", flag: "🇨🇻", capital: "Praia", lat: 14.9305, lon: -23.5133, pop: 131602, continent: "Africa" },
+    { country: "Cambodia", flag: "🇰🇭", capital: "Phnom Penh", lat: 11.5625, lon: 104.9160, pop: 2009264, continent: "Asia" },
+    { country: "Cameroon", flag: "🇨🇲", capital: "Yaoundé", lat: 3.8480, lon: 11.5021, pop: 2765000, continent: "Africa" },
+    { country: "Canada", flag: "🇨🇦", capital: "Ottawa", lat: 45.4215, lon: -75.6972, pop: 1017449, continent: "North America" },
+    { country: "Central African Republic", flag: "🇨🇫", capital: "Bangui", lat: 4.3947, lon: 18.5582, pop: 889231, continent: "Africa" },
+    { country: "Chad", flag: "🇹🇩", capital: "N'Djamena", lat: 12.1091, lon: 15.0444, pop: 1248121, continent: "Africa" },
+    { country: "Chile", flag: "🇨🇱", capital: "Santiago", lat: -33.4489, lon: -70.6693, pop: 5743719, continent: "South America" },
+    { country: "China", flag: "🇨🇳", capital: "Beijing", lat: 39.9042, lon: 116.4074, pop: 21893095, continent: "Asia" },
+    { country: "Colombia", flag: "🇨🇴", capital: "Bogotá", lat: 4.7110, lon: -74.0721, pop: 8380801, continent: "South America" },
+    { country: "Comoros", flag: "🇰🇲", capital: "Moroni", lat: -11.7022, lon: 43.2551, pop: 60200, continent: "Africa" },
+    { country: "Congo (Dem. Rep.)", flag: "🇨🇩", capital: "Kinshasa", lat: -4.3317, lon: 15.3139, pop: 14342439, continent: "Africa" },
+    { country: "Congo (Rep.)", flag: "🇨🇬", capital: "Brazzaville", lat: -4.2634, lon: 15.2429, pop: 1827000, continent: "Africa" },
+    { country: "Costa Rica", flag: "🇨🇷", capital: "San José", lat: 9.9281, lon: -84.0907, pop: 1403455, continent: "North America" },
+    { country: "Croatia", flag: "🇭🇷", capital: "Zagreb", lat: 45.8150, lon: 15.9819, pop: 767131, continent: "Europe" },
+    { country: "Cuba", flag: "🇨🇺", capital: "Havana", lat: 23.1136, lon: -82.3666, pop: 2141652, continent: "North America" },
+    { country: "Cyprus", flag: "🇨🇾", capital: "Nicosia", lat: 35.1856, lon: 33.3823, pop: 330000, continent: "Europe" },
+    { country: "Czech Republic", flag: "🇨🇿", capital: "Prague", lat: 50.0755, lon: 14.4378, pop: 1309000, continent: "Europe" },
+    { country: "Denmark", flag: "🇩🇰", capital: "Copenhagen", lat: 55.6761, lon: 12.5683, pop: 794128, continent: "Europe" },
+    { country: "Djibouti", flag: "🇩🇯", capital: "Djibouti City", lat: 11.5886, lon: 43.1451, pop: 603000, continent: "Africa" },
+    { country: "Dominica", flag: "🇩🇲", capital: "Roseau", lat: 15.3009, lon: -61.3879, pop: 16582, continent: "North America" },
+    { country: "Dominican Republic", flag: "🇩🇴", capital: "Santo Domingo", lat: 18.4861, lon: -69.9312, pop: 3172000, continent: "North America" },
+    { country: "Ecuador", flag: "🇪🇨", capital: "Quito", lat: -0.1807, lon: -78.4678, pop: 2781641, continent: "South America" },
+    { country: "Egypt", flag: "🇪🇬", capital: "Cairo", lat: 30.0444, lon: 31.2357, pop: 20076242, continent: "Africa" },
+    { country: "El Salvador", flag: "🇸🇻", capital: "San Salvador", lat: 13.6929, lon: -89.2182, pop: 1767079, continent: "North America" },
+    { country: "Equatorial Guinea", flag: "🇬🇶", capital: "Malabo", lat: 3.7500, lon: 8.7833, pop: 297000, continent: "Africa" },
+    { country: "Eritrea", flag: "🇪🇷", capital: "Asmara", lat: 15.3229, lon: 38.9251, pop: 963000, continent: "Africa" },
+    { country: "Estonia", flag: "🇪🇪", capital: "Tallinn", lat: 59.4370, lon: 24.7536, pop: 446055, continent: "Europe" },
+    { country: "Eswatini", flag: "🇸🇿", capital: "Mbabane", lat: -26.3054, lon: 31.1367, pop: 94874, continent: "Africa" },
+    { country: "Ethiopia", flag: "🇪🇹", capital: "Addis Ababa", lat: 9.0320, lon: 38.7469, pop: 3352000, continent: "Africa" },
+    { country: "Fiji", flag: "🇫🇯", capital: "Suva", lat: -18.1416, lon: 178.4419, pop: 330000, continent: "Oceania" },
+    { country: "Finland", flag: "🇫🇮", capital: "Helsinki", lat: 60.1699, lon: 24.9384, pop: 658864, continent: "Europe" },
+    { country: "France", flag: "🇫🇷", capital: "Paris", lat: 48.8566, lon: 2.3522, pop: 2161000, continent: "Europe" },
+    { country: "Gabon", flag: "🇬🇦", capital: "Libreville", lat: 0.4162, lon: 9.4673, pop: 813000, continent: "Africa" },
+    { country: "Gambia", flag: "🇬🇲", capital: "Banjul", lat: 13.4549, lon: -16.5790, pop: 34589, continent: "Africa" },
+    { country: "Georgia", flag: "🇬🇪", capital: "Tbilisi", lat: 41.6938, lon: 44.8015, pop: 1118035, continent: "Asia" },
+    { country: "Germany", flag: "🇩🇪", capital: "Berlin", lat: 52.5200, lon: 13.4050, pop: 3769495, continent: "Europe" },
+    { country: "Ghana", flag: "🇬🇭", capital: "Accra", lat: 5.6037, lon: -0.1870, pop: 2557000, continent: "Africa" },
+    { country: "Greece", flag: "🇬🇷", capital: "Athens", lat: 37.9838, lon: 23.7275, pop: 3153000, continent: "Europe" },
+    { country: "Grenada", flag: "🇬🇩", capital: "St. George's", lat: 12.0561, lon: -61.7486, pop: 40000, continent: "North America" },
+    { country: "Guatemala", flag: "🇬🇹", capital: "Guatemala City", lat: 14.6349, lon: -90.5069, pop: 3015081, continent: "North America" },
+    { country: "Guinea", flag: "🇬🇳", capital: "Conakry", lat: 9.6412, lon: -13.5784, pop: 1660973, continent: "Africa" },
+    { country: "Guinea-Bissau", flag: "🇬🇼", capital: "Bissau", lat: 11.8636, lon: -15.5977, pop: 388028, continent: "Africa" },
+    { country: "Guyana", flag: "🇬🇾", capital: "Georgetown", lat: 6.8013, lon: -58.1551, pop: 235017, continent: "South America" },
+    { country: "Haiti", flag: "🇭🇹", capital: "Port-au-Prince", lat: 18.5944, lon: -72.3074, pop: 2844229, continent: "North America" },
+    { country: "Honduras", flag: "🇭🇳", capital: "Tegucigalpa", lat: 14.0818, lon: -87.2068, pop: 1363000, continent: "North America" },
+    { country: "Hungary", flag: "🇭🇺", capital: "Budapest", lat: 47.4979, lon: 19.0402, pop: 1752286, continent: "Europe" },
+    { country: "Iceland", flag: "🇮🇸", capital: "Reykjavik", lat: 64.1355, lon: -21.8954, pop: 128793, continent: "Europe" },
+    { country: "India", flag: "🇮🇳", capital: "New Delhi", lat: 28.6139, lon: 77.2090, pop: 32941309, continent: "Asia" },
+    { country: "Indonesia", flag: "🇮🇩", capital: "Jakarta", lat: -6.2088, lon: 106.8456, pop: 10562088, continent: "Asia" },
+    { country: "Iran", flag: "🇮🇷", capital: "Tehran", lat: 35.6892, lon: 51.3890, pop: 9134000, continent: "Asia" },
+    { country: "Iraq", flag: "🇮🇶", capital: "Baghdad", lat: 33.3152, lon: 44.3661, pop: 7144260, continent: "Asia" },
+    { country: "Ireland", flag: "🇮🇪", capital: "Dublin", lat: 53.3498, lon: -6.2603, pop: 1388000, continent: "Europe" },
+    { country: "Israel", flag: "🇮🇱", capital: "Jerusalem", lat: 31.7683, lon: 35.2137, pop: 936425, continent: "Asia" },
+    { country: "Italy", flag: "🇮🇹", capital: "Rome", lat: 41.9028, lon: 12.4964, pop: 2844234, continent: "Europe" },
+    { country: "Jamaica", flag: "🇯🇲", capital: "Kingston", lat: 17.9970, lon: -76.7936, pop: 662426, continent: "North America" },
+    { country: "Japan", flag: "🇯🇵", capital: "Tokyo", lat: 35.6762, lon: 139.6503, pop: 13960000, continent: "Asia" },
+    { country: "Jordan", flag: "🇯🇴", capital: "Amman", lat: 31.9454, lon: 35.9284, pop: 4007526, continent: "Asia" },
+    { country: "Kazakhstan", flag: "🇰🇿", capital: "Astana", lat: 51.1694, lon: 71.4491, pop: 1136000, continent: "Asia" },
+    { country: "Kenya", flag: "🇰🇪", capital: "Nairobi", lat: -1.2921, lon: 36.8219, pop: 4735000, continent: "Africa" },
+    { country: "Kiribati", flag: "🇰🇮", capital: "South Tarawa", lat: 1.3290, lon: 172.9790, pop: 64000, continent: "Oceania" },
+    { country: "Kosovo", flag: "🇽🇰", capital: "Pristina", lat: 42.6629, lon: 21.1655, pop: 228000, continent: "Europe" },
+    { country: "Kuwait", flag: "🇰🇼", capital: "Kuwait City", lat: 29.3759, lon: 47.9774, pop: 2989000, continent: "Asia" },
+    { country: "Kyrgyzstan", flag: "🇰🇬", capital: "Bishkek", lat: 42.8746, lon: 74.5698, pop: 1074075, continent: "Asia" },
+    { country: "Laos", flag: "🇱🇦", capital: "Vientiane", lat: 17.9757, lon: 102.6331, pop: 820000, continent: "Asia" },
+    { country: "Latvia", flag: "🇱🇻", capital: "Riga", lat: 56.9496, lon: 24.1052, pop: 633000, continent: "Europe" },
+    { country: "Lebanon", flag: "🇱🇧", capital: "Beirut", lat: 33.8886, lon: 35.4955, pop: 2200000, continent: "Asia" },
+    { country: "Lesotho", flag: "🇱🇸", capital: "Maseru", lat: -29.3142, lon: 27.4833, pop: 330760, continent: "Africa" },
+    { country: "Liberia", flag: "🇱🇷", capital: "Monrovia", lat: 6.3005, lon: -10.7969, pop: 1611000, continent: "Africa" },
+    { country: "Libya", flag: "🇱🇾", capital: "Tripoli", lat: 32.8872, lon: 13.1913, pop: 1150989, continent: "Africa" },
+    { country: "Liechtenstein", flag: "🇱🇮", capital: "Vaduz", lat: 47.1410, lon: 9.5215, pop: 5696, continent: "Europe" },
+    { country: "Lithuania", flag: "🇱🇹", capital: "Vilnius", lat: 54.6872, lon: 25.2797, pop: 574221, continent: "Europe" },
+    { country: "Luxembourg", flag: "🇱🇺", capital: "Luxembourg City", lat: 49.6116, lon: 6.1319, pop: 128514, continent: "Europe" },
+    { country: "Madagascar", flag: "🇲🇬", capital: "Antananarivo", lat: -18.9137, lon: 47.5361, pop: 3371700, continent: "Africa" },
+    { country: "Malawi", flag: "🇲🇼", capital: "Lilongwe", lat: -13.9626, lon: 33.7741, pop: 1077116, continent: "Africa" },
+    { country: "Malaysia", flag: "🇲🇾", capital: "Kuala Lumpur", lat: 3.1390, lon: 101.6869, pop: 1982112, continent: "Asia" },
+    { country: "Maldives", flag: "🇲🇻", capital: "Malé", lat: 4.1755, lon: 73.5093, pop: 133000, continent: "Asia" },
+    { country: "Mali", flag: "🇲🇱", capital: "Bamako", lat: 12.6392, lon: -8.0029, pop: 2515000, continent: "Africa" },
+    { country: "Malta", flag: "🇲🇹", capital: "Valletta", lat: 35.8997, lon: 14.5146, pop: 6444, continent: "Europe" },
+    { country: "Marshall Islands", flag: "🇲🇭", capital: "Majuro", lat: 7.0897, lon: 171.3803, pop: 27797, continent: "Oceania" },
+    { country: "Mauritania", flag: "🇲🇷", capital: "Nouakchott", lat: 18.0735, lon: -15.9582, pop: 1205000, continent: "Africa" },
+    { country: "Mauritius", flag: "🇲🇺", capital: "Port Louis", lat: -20.1609, lon: 57.4989, pop: 148001, continent: "Africa" },
+    { country: "Mexico", flag: "🇲🇽", capital: "Mexico City", lat: 19.4326, lon: -99.1332, pop: 21671908, continent: "North America" },
+    { country: "Micronesia", flag: "🇫🇲", capital: "Palikir", lat: 6.9248, lon: 158.1618, pop: 6647, continent: "Oceania" },
+    { country: "Moldova", flag: "🇲🇩", capital: "Chișinău", lat: 47.0105, lon: 28.8638, pop: 510800, continent: "Europe" },
+    { country: "Monaco", flag: "🇲🇨", capital: "Monaco City", lat: 43.7384, lon: 7.4246, pop: 18771, continent: "Europe" },
+    { country: "Mongolia", flag: "🇲🇳", capital: "Ulaanbaatar", lat: 47.8864, lon: 106.9057, pop: 1372000, continent: "Asia" },
+    { country: "Montenegro", flag: "🇲🇪", capital: "Podgorica", lat: 42.4304, lon: 19.2594, pop: 150977, continent: "Europe" },
+    { country: "Morocco", flag: "🇲🇦", capital: "Rabat", lat: 33.9716, lon: -6.8498, pop: 577827, continent: "Africa" },
+    { country: "Mozambique", flag: "🇲🇿", capital: "Maputo", lat: -25.9692, lon: 32.5732, pop: 1101170, continent: "Africa" },
+    { country: "Myanmar", flag: "🇲🇲", capital: "Naypyidaw", lat: 19.7450, lon: 96.1297, pop: 1160000, continent: "Asia" },
+    { country: "Namibia", flag: "🇳🇦", capital: "Windhoek", lat: -22.5609, lon: 17.0658, pop: 431000, continent: "Africa" },
+    { country: "Nauru", flag: "🇳🇷", capital: "Yaren", lat: -0.5477, lon: 166.9209, pop: 10000, continent: "Oceania" },
+    { country: "Nepal", flag: "🇳🇵", capital: "Kathmandu", lat: 27.7172, lon: 85.3240, pop: 1442271, continent: "Asia" },
+    { country: "Netherlands", flag: "🇳🇱", capital: "Amsterdam", lat: 52.3676, lon: 4.9041, pop: 873338, continent: "Europe" },
+    { country: "New Zealand", flag: "🇳🇿", capital: "Wellington", lat: -41.2865, lon: 174.7762, pop: 412500, continent: "Oceania" },
+    { country: "Nicaragua", flag: "🇳🇮", capital: "Managua", lat: 12.1364, lon: -86.2514, pop: 1028808, continent: "North America" },
+    { country: "Niger", flag: "🇳🇪", capital: "Niamey", lat: 13.5137, lon: 2.1098, pop: 1026848, continent: "Africa" },
+    { country: "Nigeria", flag: "🇳🇬", capital: "Abuja", lat: 9.0579, lon: 7.4951, pop: 3464000, continent: "Africa" },
+    { country: "North Korea", flag: "🇰🇵", capital: "Pyongyang", lat: 39.0392, lon: 125.7625, pop: 2581000, continent: "Asia" },
+    { country: "North Macedonia", flag: "🇲🇰", capital: "Skopje", lat: 41.9981, lon: 21.4254, pop: 544086, continent: "Europe" },
+    { country: "Norway", flag: "🇳🇴", capital: "Oslo", lat: 59.9139, lon: 10.7522, pop: 693494, continent: "Europe" },
+    { country: "Oman", flag: "🇴🇲", capital: "Muscat", lat: 23.5880, lon: 58.3829, pop: 1421000, continent: "Asia" },
+    { country: "Pakistan", flag: "🇵🇰", capital: "Islamabad", lat: 33.6844, lon: 73.0479, pop: 1014825, continent: "Asia" },
+    { country: "Palau", flag: "🇵🇼", capital: "Ngerulmud", lat: 7.5000, lon: 134.6240, pop: 391, continent: "Oceania" },
+    { country: "Panama", flag: "🇵🇦", capital: "Panama City", lat: 8.9936, lon: -79.5197, pop: 1440000, continent: "North America" },
+    { country: "Papua New Guinea", flag: "🇵🇬", capital: "Port Moresby", lat: -9.4438, lon: 147.1803, pop: 364125, continent: "Oceania" },
+    { country: "Paraguay", flag: "🇵🇾", capital: "Asunción", lat: -25.2867, lon: -57.6470, pop: 2139465, continent: "South America" },
+    { country: "Peru", flag: "🇵🇪", capital: "Lima", lat: -12.0464, lon: -77.0428, pop: 11044607, continent: "South America" },
+    { country: "Philippines", flag: "🇵🇭", capital: "Manila", lat: 14.5995, lon: 120.9842, pop: 13923452, continent: "Asia" },
+    { country: "Poland", flag: "🇵🇱", capital: "Warsaw", lat: 52.2297, lon: 21.0122, pop: 1794166, continent: "Europe" },
+    { country: "Portugal", flag: "🇵🇹", capital: "Lisbon", lat: 38.7223, lon: -9.1393, pop: 509751, continent: "Europe" },
+    { country: "Qatar", flag: "🇶🇦", capital: "Doha", lat: 25.2854, lon: 51.5310, pop: 956000, continent: "Asia" },
+    { country: "Romania", flag: "🇷🇴", capital: "Bucharest", lat: 44.4268, lon: 26.1025, pop: 1883425, continent: "Europe" },
+    { country: "Russia", flag: "🇷🇺", capital: "Moscow", lat: 55.7558, lon: 37.6176, pop: 13010112, continent: "Europe" },
+    { country: "Rwanda", flag: "🇷🇼", capital: "Kigali", lat: -1.9441, lon: 30.0619, pop: 1259000, continent: "Africa" },
+    { country: "Saint Kitts and Nevis", flag: "🇰🇳", capital: "Basseterre", lat: 17.3026, lon: -62.7177, pop: 14000, continent: "North America" },
+    { country: "Saint Lucia", flag: "🇱🇨", capital: "Castries", lat: 14.0101, lon: -60.9875, pop: 22000, continent: "North America" },
+    { country: "Saint Vincent", flag: "🇻🇨", capital: "Kingstown", lat: 13.1600, lon: -61.2248, pop: 25000, continent: "North America" },
+    { country: "Samoa", flag: "🇼🇸", capital: "Apia", lat: -13.8506, lon: -171.7513, pop: 36735, continent: "Oceania" },
+    { country: "San Marino", flag: "🇸🇲", capital: "San Marino City", lat: 43.9424, lon: 12.4578, pop: 4040, continent: "Europe" },
+    { country: "São Tomé and Príncipe", flag: "🇸🇹", capital: "São Tomé", lat: 0.3365, lon: 6.7273, pop: 71868, continent: "Africa" },
+    { country: "Saudi Arabia", flag: "🇸🇦", capital: "Riyadh", lat: 24.6877, lon: 46.7219, pop: 7538200, continent: "Asia" },
+    { country: "Senegal", flag: "🇸🇳", capital: "Dakar", lat: 14.7167, lon: -17.4677, pop: 3137196, continent: "Africa" },
+    { country: "Serbia", flag: "🇷🇸", capital: "Belgrade", lat: 44.8176, lon: 20.4633, pop: 1688667, continent: "Europe" },
+    { country: "Seychelles", flag: "🇸🇨", capital: "Victoria", lat: -4.6191, lon: 55.4513, pop: 26450, continent: "Africa" },
+    { country: "Sierra Leone", flag: "🇸🇱", capital: "Freetown", lat: 8.4697, lon: -13.2659, pop: 1055964, continent: "Africa" },
+    { country: "Singapore", flag: "🇸🇬", capital: "Singapore", lat: 1.3521, lon: 103.8198, pop: 5453600, continent: "Asia" },
+    { country: "Slovakia", flag: "🇸🇰", capital: "Bratislava", lat: 48.1486, lon: 17.1077, pop: 475503, continent: "Europe" },
+    { country: "Slovenia", flag: "🇸🇮", capital: "Ljubljana", lat: 46.0569, lon: 14.5058, pop: 295504, continent: "Europe" },
+    { country: "Solomon Islands", flag: "🇸🇧", capital: "Honiara", lat: -9.4333, lon: 159.9500, pop: 84520, continent: "Oceania" },
+    { country: "Somalia", flag: "🇸🇴", capital: "Mogadishu", lat: 2.0469, lon: 45.3182, pop: 2587183, continent: "Africa" },
+    { country: "South Africa", flag: "🇿🇦", capital: "Pretoria", lat: -25.7461, lon: 28.1881, pop: 2921488, continent: "Africa" },
+    { country: "South Korea", flag: "🇰🇷", capital: "Seoul", lat: 37.5665, lon: 126.9780, pop: 9776000, continent: "Asia" },
+    { country: "South Sudan", flag: "🇸🇸", capital: "Juba", lat: 4.8594, lon: 31.5713, pop: 1500000, continent: "Africa" },
+    { country: "Spain", flag: "🇪🇸", capital: "Madrid", lat: 40.4168, lon: -3.7038, pop: 3223334, continent: "Europe" },
+    { country: "Sri Lanka", flag: "🇱🇰", capital: "Sri Jayawardenepura Kotte", lat: 6.8935, lon: 79.9009, pop: 115826, continent: "Asia" },
+    { country: "Sudan", flag: "🇸🇩", capital: "Khartoum", lat: 15.5007, lon: 32.5599, pop: 5274321, continent: "Africa" },
+    { country: "Suriname", flag: "🇸🇷", capital: "Paramaribo", lat: 5.8520, lon: -55.2038, pop: 240924, continent: "South America" },
+    { country: "Sweden", flag: "🇸🇪", capital: "Stockholm", lat: 59.3293, lon: 18.0686, pop: 975551, continent: "Europe" },
+    { country: "Switzerland", flag: "🇨🇭", capital: "Bern", lat: 46.9480, lon: 7.4474, pop: 133791, continent: "Europe" },
+    { country: "Syria", flag: "🇸🇾", capital: "Damascus", lat: 33.5102, lon: 36.2913, pop: 2503000, continent: "Asia" },
+    { country: "Taiwan", flag: "🇹🇼", capital: "Taipei", lat: 25.0330, lon: 121.5654, pop: 2646204, continent: "Asia" },
+    { country: "Tajikistan", flag: "🇹🇯", capital: "Dushanbe", lat: 38.5737, lon: 68.7738, pop: 863400, continent: "Asia" },
+    { country: "Tanzania", flag: "🇹🇿", capital: "Dodoma", lat: -6.1730, lon: 35.7382, pop: 410956, continent: "Africa" },
+    { country: "Thailand", flag: "🇹🇭", capital: "Bangkok", lat: 13.7563, lon: 100.5018, pop: 10539000, continent: "Asia" },
+    { country: "Timor-Leste", flag: "🇹🇱", capital: "Dili", lat: -8.5569, lon: 125.5789, pop: 277279, continent: "Asia" },
+    { country: "Togo", flag: "🇹🇬", capital: "Lomé", lat: 6.1375, lon: 1.2123, pop: 1477660, continent: "Africa" },
+    { country: "Tonga", flag: "🇹🇴", capital: "Nuku'alofa", lat: -21.1393, lon: -175.2049, pop: 23661, continent: "Oceania" },
+    { country: "Trinidad and Tobago", flag: "🇹🇹", capital: "Port of Spain", lat: 10.6596, lon: -61.5086, pop: 544000, continent: "North America" },
+    { country: "Tunisia", flag: "🇹🇳", capital: "Tunis", lat: 36.8065, lon: 10.1815, pop: 2291185, continent: "Africa" },
+    { country: "Turkey", flag: "🇹🇷", capital: "Ankara", lat: 39.9334, lon: 32.8597, pop: 5663322, continent: "Asia" },
+    { country: "Turkmenistan", flag: "🇹🇲", capital: "Ashgabat", lat: 37.9601, lon: 58.3261, pop: 683000, continent: "Asia" },
+    { country: "Tuvalu", flag: "🇹🇻", capital: "Funafuti", lat: -8.5211, lon: 179.1983, pop: 6025, continent: "Oceania" },
+    { country: "Uganda", flag: "🇺🇬", capital: "Kampala", lat: 0.3476, lon: 32.5825, pop: 1659600, continent: "Africa" },
+    { country: "Ukraine", flag: "🇺🇦", capital: "Kyiv", lat: 50.4501, lon: 30.5234, pop: 2967360, continent: "Europe" },
+    { country: "United Arab Emirates", flag: "🇦🇪", capital: "Abu Dhabi", lat: 24.4539, lon: 54.3773, pop: 1483000, continent: "Asia" },
+    { country: "United Kingdom", flag: "🇬🇧", capital: "London", lat: 51.5074, lon: -0.1278, pop: 9748000, continent: "Europe" },
+    { country: "United States", flag: "🇺🇸", capital: "Washington D.C.", lat: 38.9072, lon: -77.0369, pop: 689545, continent: "North America" },
+    { country: "Uruguay", flag: "🇺🇾", capital: "Montevideo", lat: -34.9011, lon: -56.1645, pop: 1381000, continent: "South America" },
+    { country: "Uzbekistan", flag: "🇺🇿", capital: "Tashkent", lat: 41.2995, lon: 69.2401, pop: 2485900, continent: "Asia" },
+    { country: "Vanuatu", flag: "🇻🇺", capital: "Port Vila", lat: -17.7333, lon: 168.3167, pop: 44040, continent: "Oceania" },
+    { country: "Vatican City", flag: "🇻🇦", capital: "Vatican City", lat: 41.9029, lon: 12.4534, pop: 800, continent: "Europe" },
+    { country: "Venezuela", flag: "🇻🇪", capital: "Caracas", lat: 10.4806, lon: -66.9036, pop: 2943000, continent: "South America" },
+    { country: "Vietnam", flag: "🇻🇳", capital: "Hanoi", lat: 21.0285, lon: 105.8542, pop: 8053663, continent: "Asia" },
+    { country: "Yemen", flag: "🇾🇪", capital: "Sana'a", lat: 15.3694, lon: 44.1910, pop: 2957000, continent: "Asia" },
+    { country: "Zambia", flag: "🇿🇲", capital: "Lusaka", lat: -15.3875, lon: 28.3228, pop: 2731696, continent: "Africa" },
+    { country: "Zimbabwe", flag: "🇿🇼", capital: "Harare", lat: -17.8252, lon: 31.0335, pop: 1542813, continent: "Africa" },
+];
+
+// Pre-build entities at module load time (static data, no fetch needed)
+const CAPITAL_ENTITIES: GeoEntity[] = CAPITALS.map((c) => ({
+    id: `capital-${c.country.replace(/\s+/g, "-").toLowerCase()}`,
+    pluginId: "capitals",
+    latitude: c.lat,
+    longitude: c.lon,
+    timestamp: new Date(0), // static
+    label: `${c.flag} ${c.capital}`,
+    properties: {
+        country: c.country,
+        flag: c.flag,
+        capital: c.capital,
+        population: c.pop,
+        continent: c.continent,
+    },
+}));
+
+class CapitalsPlugin implements WorldPlugin {
+    id = "capitals";
+    name = "World Capitals";
+    description = "All 195 sovereign state capitals with flag emoji, population, and continent";
+    icon = Star;
+    category = "infrastructure" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        return CAPITAL_ENTITIES;
+    }
+
+    getPollingInterval(): number {
+        return 24 * 60 * 60_000; // once a day (static data, effectively never re-fetches)
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#fbbf24",
+            iconUrl: STAR_ICON,
+            clusterEnabled: true,
+            clusterDistance: 25,
+            maxEntities: 195,
+        };
+    }
+
+    renderEntity(_entity: GeoEntity): CesiumEntityOptions {
+        return {
+            type: "billboard",
+            iconUrl: STAR_ICON,
+            iconScale: 0.65,
+            color: "#fbbf24",
+        };
+    }
+}
+
+export const capitalsPlugin = new CapitalsPlugin();

--- a/src/plugins/builtins/disasters.ts
+++ b/src/plugins/builtins/disasters.ts
@@ -1,0 +1,128 @@
+/**
+ * Global Disasters Plugin — Events from GDACS (Global Disaster Alert and Coordination System).
+ * Fetched via CORS proxy. No API key required.
+ * Refresh: every 30 minutes.
+ */
+import { AlertOctagon } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+import { fetchViaProxy } from "./proxy-utils";
+
+const GDACS_URL = "https://www.gdacs.org/gdacsapi/api/events/geteventlist/EVENTS?alertlevel=Green;Orange;Red&limit=200";
+
+function alertColor(level: string): string {
+    const l = level.toLowerCase();
+    if (l === "red")    return "#dc2626";
+    if (l === "orange") return "#ea580c";
+    return "#16a34a";
+}
+
+function disasterEmoji(type: string): string {
+    const t = (type || "").toLowerCase();
+    if (t.includes("flood"))     return "🌊";
+    if (t.includes("storm") || t.includes("cyclone") || t.includes("typhoon") || t.includes("hurricane")) return "🌀";
+    if (t.includes("earthquake") || t.includes("seismic")) return "🔥";
+    if (t.includes("volcano"))   return "🌋";
+    if (t.includes("drought"))   return "☀️";
+    if (t.includes("fire") || t.includes("wildfire")) return "🔥";
+    return "⚠️";
+}
+
+class DisastersPlugin implements WorldPlugin {
+    id = "disasters";
+    name = "Global Disasters";
+    description = "Active disaster alerts from GDACS — floods, storms, earthquakes, and more";
+    icon = AlertOctagon;
+    category = "natural-disaster" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        try {
+            const res = await fetchViaProxy(GDACS_URL);
+            const data: any = await res.json();
+
+            const features = Array.isArray(data?.features) ? data.features
+                : Array.isArray(data?.items) ? data.items
+                : [];
+
+            return features
+                .filter((f: any) => {
+                    const coords = f?.geometry?.coordinates ?? f?.geometry?.point?.coordinates;
+                    return Array.isArray(coords) && coords.length >= 2;
+                })
+                .map((f: any): GeoEntity | null => {
+                    const coords = f?.geometry?.coordinates ?? f?.geometry?.point?.coordinates;
+                    const props = f?.properties ?? f;
+
+                    const lon = parseFloat(coords[0]);
+                    const lat = parseFloat(coords[1]);
+                    if (!isFinite(lat) || !isFinite(lon)) return null;
+
+                    const alertLevel = props?.alertlevel ?? props?.AlertLevel ?? "Green";
+                    const eventType = props?.eventtype ?? props?.EventType ?? "Unknown";
+                    const country = props?.country ?? props?.Country ?? "";
+                    const name = props?.eventname ?? props?.EventName ?? eventType;
+                    const severity = props?.severity ?? props?.Severity ?? "";
+                    const dateFrom = props?.fromdate ?? props?.FromDate ?? "";
+                    const dateTo = props?.todate ?? props?.ToDate ?? "";
+                    const eventId = props?.eventid ?? props?.EventId ?? `${lon}-${lat}`;
+
+                    return {
+                        id: `disaster-${eventId}`,
+                        pluginId: "disasters",
+                        latitude: lat,
+                        longitude: lon,
+                        timestamp: dateFrom ? new Date(dateFrom) : new Date(),
+                        label: `${disasterEmoji(eventType)} ${name} (${alertLevel})`,
+                        properties: {
+                            eventType,
+                            alertLevel,
+                            country,
+                            name,
+                            severity,
+                            dateFrom,
+                            dateTo,
+                            url: props?.url ?? props?.Url ?? "",
+                        },
+                    };
+                })
+                .filter(Boolean) as GeoEntity[];
+        } catch {
+            return [];
+        }
+    }
+
+    getPollingInterval(): number {
+        return 30 * 60_000; // 30 minutes
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#ea580c",
+            clusterEnabled: false,
+            clusterDistance: 50,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        const level = (entity.properties.alertLevel as string) ?? "Green";
+        return {
+            type: "point",
+            color: alertColor(level),
+            size: level.toLowerCase() === "red" ? 16 : level.toLowerCase() === "orange" ? 12 : 8,
+            outlineColor: "#1c1917",
+            outlineWidth: 1,
+        };
+    }
+}
+
+export const disastersPlugin = new DisastersPlugin();

--- a/src/plugins/builtins/earthquakes.ts
+++ b/src/plugins/builtins/earthquakes.ts
@@ -1,0 +1,121 @@
+/**
+ * Earthquakes Plugin — Real-time seismic events from USGS GeoJSON feed.
+ * Uses the local /api/earthquake proxy route to avoid CORS issues.
+ * Refresh: every 5 minutes.
+ */
+import { Activity } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+function magnitudeColor(mag: number): string {
+    if (mag >= 5) return "#7f1d1d";   // dark red
+    if (mag >= 4) return "#ea580c";   // orange
+    if (mag >= 3) return "#d97706";   // amber
+    return "#fde047";                  // yellow
+}
+
+function magnitudeSize(mag: number): number {
+    if (mag >= 5) return 18;
+    if (mag >= 4) return 12;
+    if (mag >= 3) return 8;
+    return 6;
+}
+
+class EarthquakesPlugin implements WorldPlugin {
+    id = "earthquakes";
+    name = "Earthquakes";
+    description = "Real-time global seismic events (M1.0+) from USGS GeoJSON feed";
+    icon = Activity;
+    category = "natural-disaster" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        try {
+            // Use our local proxy route to avoid CORS issues with USGS
+            const res = await fetch("/api/earthquake", { signal: AbortSignal.timeout(10000) });
+            if (!res.ok) {
+                // Fallback: try direct USGS URL (works server-side, may fail client-side)
+                const fallback = await fetch(
+                    "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson",
+                    { signal: AbortSignal.timeout(10000) }
+                );
+                if (!fallback.ok) return [];
+                const data = await fallback.json();
+                return this.parseFeatures(data.features ?? []);
+            }
+            const data = await res.json();
+            return this.parseFeatures(data.features ?? []);
+        } catch {
+            return [];
+        }
+    }
+
+    private parseFeatures(features: any[]): GeoEntity[] {
+        return features
+            .filter((f) => {
+                const coords = f?.geometry?.coordinates;
+                return Array.isArray(coords) && coords.length >= 2
+                    && typeof coords[0] === "number" && typeof coords[1] === "number";
+            })
+            .map((f) => {
+                const [lon, lat, depth] = f.geometry.coordinates;
+                const mag = f.properties?.mag ?? 0;
+                const place = f.properties?.place ?? "Unknown";
+                const time = f.properties?.time ? new Date(f.properties.time) : new Date();
+
+                return {
+                    id: `quake-${f.id}`,
+                    pluginId: "earthquakes",
+                    latitude: lat,
+                    longitude: lon,
+                    altitude: 0,
+                    timestamp: time,
+                    label: `M${mag.toFixed(1)} ${place}`,
+                    properties: {
+                        magnitude: mag,
+                        place,
+                        depth: typeof depth === "number" ? Math.round(depth) : 0,
+                        depthKm: typeof depth === "number" ? Math.round(depth) : 0,
+                        time: time.toISOString(),
+                        url: f.properties?.url ?? "",
+                        felt: f.properties?.felt ?? 0,
+                        significance: f.properties?.sig ?? 0,
+                    },
+                };
+            });
+    }
+
+    getPollingInterval(): number {
+        return 5 * 60_000; // 5 minutes
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#f59e0b",
+            clusterEnabled: false,
+            clusterDistance: 40,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        const mag = (entity.properties.magnitude as number) ?? 0;
+        return {
+            type: "point",
+            color: magnitudeColor(mag),
+            size: magnitudeSize(mag),
+            outlineColor: "#ffffff",
+            outlineWidth: 1,
+        };
+    }
+}
+
+export const earthquakesPlugin = new EarthquakesPlugin();

--- a/src/plugins/builtins/flights.ts
+++ b/src/plugins/builtins/flights.ts
@@ -1,0 +1,119 @@
+/**
+ * Flights Plugin — Live aircraft positions from OpenSky Network (anonymous).
+ * Uses a CORS proxy chain for browser-side access.
+ * Refresh: every 60 seconds.
+ */
+import { Plane } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+import { fetchViaProxy } from "./proxy-utils";
+
+const OPENSKY_URL = "https://opensky-network.org/api/states/all";
+const MAX_AIRCRAFT = 500;
+
+// Aircraft type icon - simple plane SVG
+const PLANE_ICON = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="15" fill="rgba(15,23,42,0.85)"/>
+  <path d="M16 4 L20 14 L28 14 L24 18 L26 28 L16 22 L6 28 L8 18 L4 14 L12 14 Z"
+        fill="#60a5fa" stroke="#93c5fd" stroke-width="0.5"/>
+</svg>
+`);
+
+function stateToEntity(state: any[]): GeoEntity | null {
+    // OpenSky state vector: [icao24, callsign, origin_country, time_position, last_contact,
+    //   longitude, latitude, baro_altitude, on_ground, velocity, true_track, vertical_rate,
+    //   sensors, geo_altitude, squawk, spi, position_source]
+    const [icao24, callsign, country, , , lon, lat, baroAlt, onGround, velocity, trueTrack] = state;
+
+    if (onGround) return null;
+    if (typeof lat !== "number" || typeof lon !== "number") return null;
+    if (lat === 0 && lon === 0) return null;
+
+    const altFt = baroAlt != null ? Math.round(baroAlt * 3.28084) : 0;
+    const speedKt = velocity != null ? Math.round(velocity * 1.94384) : 0;
+    const heading = typeof trueTrack === "number" ? trueTrack : 0;
+
+    return {
+        id: `flight-${icao24}`,
+        pluginId: "flights",
+        latitude: lat,
+        longitude: lon,
+        altitude: baroAlt ?? 0,
+        heading,
+        speed: speedKt,
+        timestamp: new Date(),
+        label: (callsign?.trim() || icao24).toUpperCase(),
+        properties: {
+            icao24,
+            callsign: callsign?.trim() || icao24,
+            country: country || "Unknown",
+            altitudeFt: altFt,
+            speedKnots: speedKt,
+            heading,
+        },
+    };
+}
+
+class FlightsPlugin implements WorldPlugin {
+    id = "flights";
+    name = "Live Flights";
+    description = "Real-time global aircraft positions from OpenSky Network (anonymous)";
+    icon = Plane;
+    category = "aviation" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        try {
+            const res = await fetchViaProxy(OPENSKY_URL);
+            const data: { states?: any[][] } = await res.json();
+            if (!data.states) return [];
+
+            const entities: GeoEntity[] = [];
+            for (const state of data.states) {
+                if (entities.length >= MAX_AIRCRAFT) break;
+                const entity = stateToEntity(state);
+                if (entity) entities.push(entity);
+            }
+            return entities;
+        } catch {
+            return [];
+        }
+    }
+
+    getPollingInterval(): number {
+        return 60_000; // 60 seconds
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#60a5fa",
+            iconUrl: PLANE_ICON,
+            clusterEnabled: true,
+            clusterDistance: 30,
+            maxEntities: MAX_AIRCRAFT,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        return {
+            type: "billboard",
+            iconUrl: PLANE_ICON,
+            iconScale: 0.7,
+            rotation: entity.heading ?? 0,
+            color: "#60a5fa",
+            disableDepthTestDistance: 1,
+        };
+    }
+}
+
+export const flightsPlugin = new FlightsPlugin();

--- a/src/plugins/builtins/index.ts
+++ b/src/plugins/builtins/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Built-in plugin registration.
+ * Importing this module registers all 12 built-in plugins into the PluginRegistry
+ * as a module-level side effect.
+ *
+ * Import ONCE from AppShell before pluginRegistry.getAll() is called.
+ */
+import { pluginRegistry } from "@/core/plugins/PluginRegistry";
+
+import { flightsPlugin }    from "./flights";
+import { weatherPlugin }    from "./weather";
+import { newsPlugin }       from "./news";
+import { earthquakesPlugin } from "./earthquakes";
+import { capitalsPlugin }   from "./capitals";
+import { shipsPlugin }      from "./ships";
+import { warZonesPlugin }   from "./warzones";
+import { stocksPlugin }     from "./stocks";
+import { issPlugin }        from "./iss";
+import { volcanoesPlugin }  from "./volcanoes";
+import { disastersPlugin }  from "./disasters";
+import { lightningPlugin }  from "./lightning";
+
+// Register all built-in plugins with the registry.
+// Order determines display order in the sidebar.
+pluginRegistry.register(flightsPlugin);
+pluginRegistry.register(weatherPlugin);
+pluginRegistry.register(newsPlugin);
+pluginRegistry.register(earthquakesPlugin);
+pluginRegistry.register(capitalsPlugin);
+pluginRegistry.register(shipsPlugin);
+pluginRegistry.register(warZonesPlugin);
+pluginRegistry.register(stocksPlugin);
+pluginRegistry.register(issPlugin);
+pluginRegistry.register(volcanoesPlugin);
+pluginRegistry.register(disastersPlugin);
+pluginRegistry.register(lightningPlugin);

--- a/src/plugins/builtins/iss.ts
+++ b/src/plugins/builtins/iss.ts
@@ -1,0 +1,125 @@
+/**
+ * ISS Tracker Plugin — International Space Station real-time position.
+ * Uses the local /api/iss proxy (backed by wheretheiss.at).
+ * Updates every 5 seconds.
+ */
+import { Satellite } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+const ISS_ICON = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36">
+  <circle cx="18" cy="18" r="17" fill="rgba(15,23,42,0.9)"/>
+  <!-- ISS body -->
+  <rect x="14" y="16" width="8" height="4" rx="1" fill="#e2e8f0"/>
+  <!-- Solar panels left -->
+  <rect x="2"  y="14" width="10" height="3" rx="0.5" fill="#fbbf24"/>
+  <rect x="2"  y="19" width="10" height="3" rx="0.5" fill="#fbbf24"/>
+  <!-- Solar panels right -->
+  <rect x="24" y="14" width="10" height="3" rx="0.5" fill="#fbbf24"/>
+  <rect x="24" y="19" width="10" height="3" rx="0.5" fill="#fbbf24"/>
+  <!-- Glow -->
+  <circle cx="18" cy="18" r="5" fill="none" stroke="#fbbf2480" stroke-width="2"/>
+</svg>
+`);
+
+class ISSPlugin implements WorldPlugin {
+    id = "iss";
+    name = "ISS Tracker";
+    description = "International Space Station real-time position — updates every 5 seconds";
+    icon = Satellite;
+    category = "space" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        try {
+            const res = await fetch("/api/iss", { signal: AbortSignal.timeout(6000) });
+            if (!res.ok) {
+                // Fallback to open-notify (may have CORS issues in browser)
+                const fallback = await fetch("http://api.open-notify.org/iss-now.json", {
+                    signal: AbortSignal.timeout(5000),
+                });
+                if (!fallback.ok) return [];
+                const fd = await fallback.json();
+                const pos = fd.iss_position;
+                if (!pos) return [];
+                return [this.buildEntity(
+                    parseFloat(pos.latitude),
+                    parseFloat(pos.longitude),
+                    420,   // ~420 km typical ISS altitude
+                    7.66,  // ~7.66 km/s typical velocity
+                )];
+            }
+
+            const data = await res.json();
+            if (typeof data.latitude !== "number") return [];
+
+            return [this.buildEntity(
+                data.latitude,
+                data.longitude,
+                data.altitude ?? 420,
+                data.velocity ?? 7.66,
+            )];
+        } catch {
+            return [];
+        }
+    }
+
+    private buildEntity(lat: number, lon: number, altKm: number, velocityKms: number): GeoEntity {
+        const speedKnots = Math.round(velocityKms * 1.94384);
+        return {
+            id: "iss-25544",
+            pluginId: "iss",
+            latitude: lat,
+            longitude: lon,
+            altitude: altKm * 1000, // convert km to meters
+            speed: speedKnots,
+            timestamp: new Date(),
+            label: "🛸 ISS",
+            properties: {
+                name: "ISS (ZARYA)",
+                altitudeKm: Math.round(altKm),
+                velocityKms: velocityKms.toFixed(2),
+                speedKnots,
+                latitude: lat.toFixed(4),
+                longitude: lon.toFixed(4),
+            },
+        };
+    }
+
+    getPollingInterval(): number {
+        return 5_000; // 5 seconds
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#fbbf24",
+            iconUrl: ISS_ICON,
+            clusterEnabled: false,
+            clusterDistance: 0,
+            maxEntities: 1,
+        };
+    }
+
+    renderEntity(_entity: GeoEntity): CesiumEntityOptions {
+        return {
+            type: "billboard",
+            iconUrl: ISS_ICON,
+            iconScale: 1.0,
+            color: "#fbbf24",
+            disableDepthTestDistance: 1,
+            disableManualHorizonCulling: true, // ISS is above the horizon from most viewpoints
+        };
+    }
+}
+
+export const issPlugin = new ISSPlugin();

--- a/src/plugins/builtins/lightning.ts
+++ b/src/plugins/builtins/lightning.ts
@@ -1,0 +1,208 @@
+/**
+ * Lightning Plugin — Real-time lightning strikes from Blitzortung.org WebSocket.
+ * Markers flash yellow and disappear after 3 seconds.
+ * No API key required (public Blitzortung network).
+ */
+import { Zap } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+// Blitzortung public WebSocket endpoints (regional, auto-rotate on failure)
+const BLITZORTUNG_HOSTS = [
+    "ws8.blitzortung.org",
+    "ws7.blitzortung.org",
+    "ws6.blitzortung.org",
+    "ws5.blitzortung.org",
+];
+
+const STRIKE_TTL_MS = 3000;     // flash lifetime: 3 seconds
+const MAX_STRIKES = 500;        // max concurrent markers
+
+interface Strike {
+    id: string;
+    lat: number;
+    lon: number;
+    createdAt: number;
+}
+
+class LightningPlugin implements WorldPlugin {
+    id = "lightning";
+    name = "Lightning";
+    description = "Real-time lightning strikes from Blitzortung.org (no key required)";
+    icon = Zap;
+    category = "natural-disaster" as const;
+    version = "1.0.0";
+
+    private ctx: PluginContext | null = null;
+    private ws: WebSocket | null = null;
+    private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+    private strikes: Map<string, Strike> = new Map();
+    private hostIdx = 0;
+
+    async initialize(ctx: PluginContext): Promise<void> {
+        this.ctx = ctx;
+        this.connect();
+
+        // Cleanup expired strikes every second
+        this.cleanupTimer = setInterval(() => this.pruneOldStrikes(), 1000);
+    }
+
+    destroy(): void {
+        if (this.ws) {
+            this.ws.onclose = null;
+            this.ws.close();
+            this.ws = null;
+        }
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        if (this.cleanupTimer) {
+            clearInterval(this.cleanupTimer);
+            this.cleanupTimer = null;
+        }
+        this.strikes.clear();
+    }
+
+    private connect(): void {
+        if (typeof window === "undefined") return;
+
+        const host = BLITZORTUNG_HOSTS[this.hostIdx % BLITZORTUNG_HOSTS.length];
+        const ports = [3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008];
+        const port = ports[Math.floor(Math.random() * ports.length)];
+
+        try {
+            const ws = new WebSocket(`wss://${host}:${port}`);
+
+            ws.onopen = () => {
+                // Subscribe to all regions
+                try { ws.send(JSON.stringify({ west: -180, east: 180, north: 90, south: -90 })); } catch { /* ok */ }
+            };
+
+            ws.onmessage = (ev) => {
+                try {
+                    const msg = JSON.parse(typeof ev.data === "string" ? ev.data : "{}");
+                    this.handleStrike(msg);
+                } catch { /* skip */ }
+            };
+
+            ws.onerror = () => {
+                ws.close();
+            };
+
+            ws.onclose = () => {
+                this.ws = null;
+                this.hostIdx++;
+                // Try next host after 5 seconds
+                this.reconnectTimer = setTimeout(() => this.connect(), 5000);
+            };
+
+            this.ws = ws;
+        } catch { /* ignore */ }
+    }
+
+    private handleStrike(msg: any): void {
+        if (!this.ctx) return;
+
+        // Blitzortung message format: { lat, lon, time } or { lat, lon, time, alt }
+        const lat = typeof msg.lat === "number" ? msg.lat
+            : typeof msg.latitude === "number" ? msg.latitude : null;
+        const lon = typeof msg.lon === "number" ? msg.lon
+            : typeof msg.longitude === "number" ? msg.longitude : null;
+
+        if (lat === null || lon === null) return;
+        if (!isFinite(lat) || !isFinite(lon)) return;
+        if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return;
+
+        const id = `strike-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+        const strike: Strike = { id, lat, lon, createdAt: Date.now() };
+
+        // Enforce max, evict oldest
+        if (this.strikes.size >= MAX_STRIKES) {
+            const oldest = this.strikes.keys().next().value;
+            if (oldest) this.strikes.delete(oldest);
+        }
+
+        this.strikes.set(id, strike);
+        this.pushUpdate();
+    }
+
+    private pruneOldStrikes(): void {
+        const now = Date.now();
+        let changed = false;
+        for (const [id, strike] of this.strikes) {
+            if (now - strike.createdAt > STRIKE_TTL_MS) {
+                this.strikes.delete(id);
+                changed = true;
+            }
+        }
+        if (changed) this.pushUpdate();
+    }
+
+    private pushUpdate(): void {
+        if (!this.ctx) return;
+        const entities = this.buildEntities();
+        this.ctx.onDataUpdate(entities);
+    }
+
+    private buildEntities(): GeoEntity[] {
+        const now = Date.now();
+        return Array.from(this.strikes.values()).map((s): GeoEntity => {
+            const age = now - s.createdAt;
+            const agePct = age / STRIKE_TTL_MS; // 0=new → 1=about to expire
+
+            return {
+                id: s.id,
+                pluginId: "lightning",
+                latitude: s.lat,
+                longitude: s.lon,
+                timestamp: new Date(s.createdAt),
+                label: "⚡",
+                properties: {
+                    agePct, // 0–1, used by renderEntity for fade
+                },
+            };
+        });
+    }
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        return this.buildEntities();
+    }
+
+    getPollingInterval(): number {
+        return 0; // WebSocket push only
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#fde047",
+            clusterEnabled: false,
+            clusterDistance: 0,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        const agePct = (entity.properties.agePct as number) ?? 0;
+        // Fade from bright yellow to transparent as the strike ages
+        const alpha = Math.max(0, 1 - agePct);
+        const intensity = Math.round(255 * alpha).toString(16).padStart(2, "0");
+        const color = `#fde047${intensity}`;
+
+        return {
+            type: "point",
+            color,
+            size: agePct < 0.2 ? 12 : 8, // briefly larger on impact
+            outlineColor: `#fbbf24${intensity}`,
+            outlineWidth: 1,
+        };
+    }
+}
+
+export const lightningPlugin = new LightningPlugin();

--- a/src/plugins/builtins/news.ts
+++ b/src/plugins/builtins/news.ts
@@ -1,0 +1,140 @@
+/**
+ * News Plugin — World news from 5 major RSS feeds, pinned to source capitals.
+ * Feeds fetched via allorigins CORS proxy and parsed with DOMParser.
+ * Refresh: every 15 minutes.
+ */
+import { Newspaper } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+interface RssFeed {
+    name: string;
+    url: string;
+    lat: number;
+    lon: number;
+}
+
+const RSS_FEEDS: RssFeed[] = [
+    {
+        name: "BBC World",
+        url: "https://feeds.bbci.co.uk/news/world/rss.xml",
+        lat: 51.5074,
+        lon: -0.1278,
+    },
+    {
+        name: "Al Jazeera",
+        url: "https://www.aljazeera.com/xml/rss/all.xml",
+        lat: 25.2854,
+        lon: 51.5310,
+    },
+    {
+        name: "New York Times",
+        url: "https://rss.nytimes.com/services/xml/rss/nyt/World.xml",
+        lat: 40.7128,
+        lon: -74.0060,
+    },
+    {
+        name: "ABC Australia",
+        url: "https://www.abc.net.au/news/feed/2942460/rss.xml",
+        lat: -33.8688,
+        lon: 151.2093,
+    },
+    {
+        name: "Times of India",
+        url: "https://timesofindia.indiatimes.com/rssfeedstopstories.cms",
+        lat: 28.6139,
+        lon: 77.2090,
+    },
+];
+
+const MAX_HEADLINES = 5;
+
+async function fetchFeedHeadlines(feed: RssFeed): Promise<string[]> {
+    const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(feed.url)}`;
+    const res = await fetch(proxyUrl, { signal: AbortSignal.timeout(9000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const xml = await res.text();
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, "text/xml");
+    const items = Array.from(doc.querySelectorAll("item")).slice(0, MAX_HEADLINES);
+    return items.map((item) => item.querySelector("title")?.textContent?.trim() ?? "");
+}
+
+class NewsPlugin implements WorldPlugin {
+    id = "news";
+    name = "World News";
+    description = "Top headlines from BBC, Al Jazeera, NYT, ABC Australia, Times of India";
+    icon = Newspaper;
+    category = "intelligence" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        const entities: GeoEntity[] = [];
+
+        for (let i = 0; i < RSS_FEEDS.length; i++) {
+            const feed = RSS_FEEDS[i];
+            // Stagger requests by 300ms
+            if (i > 0) await new Promise((r) => setTimeout(r, 300));
+
+            try {
+                const headlines = await fetchFeedHeadlines(feed);
+                if (headlines.length === 0) continue;
+
+                // Small offset for feeds sharing similar coordinates
+                const latOffset = (i % 2) * 0.05;
+
+                entities.push({
+                    id: `news-${feed.name.replace(/\s+/g, "-").toLowerCase()}`,
+                    pluginId: "news",
+                    latitude: feed.lat + latOffset,
+                    longitude: feed.lon,
+                    timestamp: new Date(),
+                    label: `📰 ${feed.name}`,
+                    properties: {
+                        source: feed.name,
+                        headlines,
+                        headlineCount: headlines.length,
+                    },
+                });
+            } catch {
+                // skip feed on error
+            }
+        }
+
+        return entities;
+    }
+
+    getPollingInterval(): number {
+        return 15 * 60_000; // 15 minutes
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#a78bfa",
+            clusterEnabled: false,
+            clusterDistance: 60,
+        };
+    }
+
+    renderEntity(_entity: GeoEntity): CesiumEntityOptions {
+        return {
+            type: "point",
+            color: "#a78bfa",
+            size: 12,
+            outlineColor: "#7c3aed",
+            outlineWidth: 2,
+        };
+    }
+}
+
+export const newsPlugin = new NewsPlugin();

--- a/src/plugins/builtins/proxy-utils.ts
+++ b/src/plugins/builtins/proxy-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared CORS proxy utility for browser-side plugin fetches.
+ * Tries a chain of public CORS proxies in sequence.
+ */
+
+const CORS_PROXIES = [
+    (url: string) => `https://corsproxy.io/?url=${encodeURIComponent(url)}`,
+    (url: string) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+    (url: string) => `https://thingproxy.freeboard.io/fetch/${url}`,
+];
+
+/**
+ * Fetch a URL via CORS proxy chain, trying each proxy in order.
+ * Returns the first successful response, or throws if all fail.
+ */
+export async function fetchViaProxy(url: string, init?: RequestInit): Promise<Response> {
+    for (const proxy of CORS_PROXIES) {
+        try {
+            const res = await fetch(proxy(url), {
+                signal: AbortSignal.timeout(9000),
+                ...init,
+            });
+            if (res.ok) return res;
+        } catch {
+            // try next proxy
+        }
+    }
+    throw new Error(`All CORS proxies failed for: ${url}`);
+}
+
+/**
+ * Fetch JSON via CORS proxy chain.
+ */
+export async function fetchJsonViaProxy<T = unknown>(url: string): Promise<T> {
+    const res = await fetchViaProxy(url);
+    return res.json() as Promise<T>;
+}

--- a/src/plugins/builtins/ships.ts
+++ b/src/plugins/builtins/ships.ts
@@ -1,0 +1,188 @@
+/**
+ * Ships Plugin — Real-time vessel positions via AISStream WebSocket.
+ * Requires an AISStream API key (free at https://aisstream.io/).
+ * WebSocket-driven, no polling interval.
+ */
+import { Ship } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+const AISSTREAM_URL = "wss://stream.aisstream.io/v0/stream";
+const MAX_SHIPS = 300;
+const LS_KEY_AISSTREAM = "wwv_aisstream_key";
+
+const SHIP_ICON = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+  <circle cx="14" cy="14" r="13" fill="rgba(15,23,42,0.85)"/>
+  <path d="M14 5 L19 14 L14 23 L9 14 Z" fill="#06b6d4" stroke="#67e8f9" stroke-width="0.5"/>
+  <circle cx="14" cy="13" r="2" fill="#f0f9ff"/>
+</svg>
+`);
+
+const NAV_STATUS = [
+    "Under way", "At anchor", "Not under command", "Restricted maneuverability",
+    "Constrained by draft", "Moored", "Aground", "Engaged in fishing",
+    "Under way sailing", "Reserved", "Reserved", "Towing astern",
+    "Pushing ahead", "Reserved", "AIS-SART", "Undefined",
+];
+
+class ShipsPlugin implements WorldPlugin {
+    id = "ships";
+    name = "Live Ships";
+    description = "Real-time vessel positions via AISStream WebSocket (free API key required)";
+    icon = Ship;
+    category = "maritime" as const;
+    version = "1.0.0";
+
+    private ctx: PluginContext | null = null;
+    private ws: WebSocket | null = null;
+    private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    private entities: Map<string, GeoEntity> = new Map();
+    private _enabled = false;
+
+    async initialize(ctx: PluginContext): Promise<void> {
+        this.ctx = ctx;
+        this.connect();
+    }
+
+    destroy(): void {
+        this._enabled = false;
+        if (this.ws) {
+            this.ws.onclose = null;
+            this.ws.close();
+            this.ws = null;
+        }
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        this.entities.clear();
+    }
+
+    private connect(): void {
+        if (typeof window === "undefined") return;
+        const key = localStorage.getItem(LS_KEY_AISSTREAM) || "";
+        if (!key) return; // no key — silently skip
+
+        try {
+            const ws = new WebSocket(AISSTREAM_URL);
+
+            ws.onopen = () => {
+                ws.send(JSON.stringify({
+                    APIKey: key,
+                    BoundingBoxes: [[[-90, -180], [90, 180]]],
+                    FilterMessageTypes: ["PositionReport"],
+                }));
+            };
+
+            ws.onmessage = (ev) => {
+                try {
+                    const msg = JSON.parse(typeof ev.data === "string" ? ev.data : "{}");
+                    this.handleMessage(msg);
+                } catch { /* ignore parse errors */ }
+            };
+
+            ws.onerror = () => ws.close();
+
+            ws.onclose = () => {
+                this.ws = null;
+                // Auto-reconnect after 5s
+                this.reconnectTimer = setTimeout(() => this.connect(), 5000);
+            };
+
+            this.ws = ws;
+        } catch { /* ignore connection errors */ }
+    }
+
+    private handleMessage(msg: any): void {
+        if (!this.ctx) return;
+        const mmsi = msg?.MetaData?.MMSI;
+        const pr = msg?.Message?.PositionReport;
+        if (!mmsi || !pr) return;
+
+        const lat = pr.Latitude;
+        const lon = pr.Longitude;
+        if (typeof lat !== "number" || typeof lon !== "number") return;
+        if (lat === 0 && lon === 0) return;
+
+        const speedKt = typeof pr.Sog === "number" ? Math.round(pr.Sog) : 0;
+        const heading = typeof pr.TrueHeading === "number" && pr.TrueHeading < 360
+            ? pr.TrueHeading
+            : typeof pr.Cog === "number" ? pr.Cog : 0;
+        const navStatus = pr.NavigationalStatus ?? 0;
+        const vesselName = msg?.MetaData?.ShipName?.trim() || `MMSI ${mmsi}`;
+
+        const entity: GeoEntity = {
+            id: `ship-${mmsi}`,
+            pluginId: "ships",
+            latitude: lat,
+            longitude: lon,
+            heading,
+            speed: speedKt,
+            timestamp: new Date(),
+            label: vesselName,
+            properties: {
+                mmsi,
+                vesselName,
+                speedKnots: speedKt,
+                heading,
+                navStatus: NAV_STATUS[navStatus] ?? "Unknown",
+                destination: msg?.MetaData?.Destination?.trim() || "",
+            },
+        };
+
+        // Enforce max ships by evicting oldest entry
+        if (this.entities.size >= MAX_SHIPS && !this.entities.has(entity.id)) {
+            const firstKey = this.entities.keys().next().value;
+            if (firstKey) this.entities.delete(firstKey);
+        }
+
+        this.entities.set(entity.id, entity);
+
+        // Push updated snapshot to the UI
+        const snapshot = Array.from(this.entities.values());
+        this.ctx.onDataUpdate(snapshot);
+    }
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        // Return current in-memory snapshot
+        return Array.from(this.entities.values());
+    }
+
+    getPollingInterval(): number {
+        return 0; // WebSocket push only — polling manager runs fetch once then marks as ws-push-only
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#06b6d4",
+            iconUrl: SHIP_ICON,
+            clusterEnabled: true,
+            clusterDistance: 30,
+            maxEntities: MAX_SHIPS,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        return {
+            type: "billboard",
+            iconUrl: SHIP_ICON,
+            iconScale: 0.7,
+            rotation: entity.heading ?? 0,
+            color: "#06b6d4",
+        };
+    }
+
+    requiresConfiguration(): boolean {
+        if (typeof window === "undefined") return false;
+        return !localStorage.getItem(LS_KEY_AISSTREAM);
+    }
+}
+
+export const shipsPlugin = new ShipsPlugin();

--- a/src/plugins/builtins/stocks.tsx
+++ b/src/plugins/builtins/stocks.tsx
@@ -1,0 +1,276 @@
+"use client";
+/**
+ * Stocks Plugin — Country-aware stock ticker via Alpha Vantage.
+ * Detects current camera country from globe position, shows scrolling ticker.
+ * Requires free Alpha Vantage API key from https://www.alphavantage.co/
+ * Updates every 5 minutes. Renders as a bottom panel ticker tape.
+ */
+import { TrendingUp } from "lucide-react";
+import type { ComponentType } from "react";
+import { useEffect, useState, useRef } from "react";
+import { useStore } from "@/core/state/store";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+const LS_KEY_AV = "wwv_alphavantage_key";
+
+// Country → stock symbols mapping (major indices + top stocks)
+const COUNTRY_SYMBOLS: Record<string, { name: string; symbols: string[] }> = {
+    "United States": { name: "🇺🇸 USA", symbols: ["SPY", "QQQ", "AAPL", "MSFT", "NVDA", "AMZN", "GOOGL"] },
+    "United Kingdom": { name: "🇬🇧 UK", symbols: ["VOD.LON", "HSBA.LON", "BP.LON", "GSK.LON"] },
+    "Japan": { name: "🇯🇵 Japan", symbols: ["7203.TYO", "9984.TYO", "6758.TYO", "9432.TYO"] },
+    "Germany": { name: "🇩🇪 Germany", symbols: ["SAP.XETRA", "BAYN.XETRA", "VOW3.XETRA"] },
+    "China": { name: "🇨🇳 China", symbols: ["BABA", "JD", "PDD", "BIDU", "NIO"] },
+    "India": { name: "🇮🇳 India", symbols: ["INFY", "WIT", "HDB", "IBN"] },
+    "Canada": { name: "🇨🇦 Canada", symbols: ["RY.TSX", "TD.TSX", "SHOP.TSX", "CNR.TSX"] },
+    "Australia": { name: "🇦🇺 Australia", symbols: ["BHP.AX", "CBA.AX", "ANZ.AX"] },
+    "France": { name: "🇫🇷 France", symbols: ["LVMH.PA", "TTE.PA", "SAN.PA"] },
+    "Brazil": { name: "🇧🇷 Brazil", symbols: ["VALE", "PBR", "ITUB", "BBD"] },
+    "South Korea": { name: "🇰🇷 S. Korea", symbols: ["005930.KS", "000660.KS", "005380.KS"] },
+    "Netherlands": { name: "🇳🇱 Netherlands", symbols: ["ASML", "RDSA.AS", "PHIA.AS"] },
+    "Russia": { name: "🇷🇺 Russia", symbols: ["GAZP.ME", "LKOH.ME", "SBER.ME"] },
+    "Saudi Arabia": { name: "🇸🇦 Saudi Arabia", symbols: ["ARAMCO.SR", "SABIC.SR"] },
+    "Switzerland": { name: "🇨🇭 Switzerland", symbols: ["NOVN.SW", "ROG.SW", "NESN.SW"] },
+};
+
+// Approximate country bounding boxes for camera position detection
+const COUNTRY_BOUNDS: Array<{
+    country: string;
+    latMin: number; latMax: number;
+    lonMin: number; lonMax: number;
+}> = [
+    { country: "United States", latMin: 24, latMax: 49, lonMin: -125, lonMax: -66 },
+    { country: "Canada", latMin: 49, latMax: 83, lonMin: -141, lonMax: -52 },
+    { country: "Brazil", latMin: -34, latMax: 5, lonMin: -74, lonMax: -34 },
+    { country: "Russia", latMin: 41, latMax: 82, lonMin: 27, lonMax: 180 },
+    { country: "China", latMin: 18, latMax: 53, lonMin: 73, lonMax: 135 },
+    { country: "India", latMin: 8, latMax: 37, lonMin: 68, lonMax: 97 },
+    { country: "Australia", latMin: -44, latMax: -10, lonMin: 113, lonMax: 154 },
+    { country: "Japan", latMin: 24, latMax: 46, lonMin: 123, lonMax: 146 },
+    { country: "South Korea", latMin: 34, latMax: 38, lonMin: 126, lonMax: 130 },
+    { country: "United Kingdom", latMin: 49, latMax: 61, lonMin: -8, lonMax: 2 },
+    { country: "Germany", latMin: 47, latMax: 55, lonMin: 6, lonMax: 15 },
+    { country: "France", latMin: 42, latMax: 51, lonMin: -5, lonMax: 8 },
+    { country: "Netherlands", latMin: 50, latMax: 54, lonMin: 3, lonMax: 7 },
+    { country: "Switzerland", latMin: 45, latMax: 48, lonMin: 5, lonMax: 11 },
+    { country: "Saudi Arabia", latMin: 16, latMax: 32, lonMin: 36, lonMax: 56 },
+];
+
+function detectCountry(lat: number, lon: number): string | null {
+    for (const b of COUNTRY_BOUNDS) {
+        if (lat >= b.latMin && lat <= b.latMax && lon >= b.lonMin && lon <= b.lonMax) {
+            return b.country;
+        }
+    }
+    return null;
+}
+
+interface StockQuote {
+    symbol: string;
+    price: number;
+    change: number;
+    changePct: number;
+}
+
+async function fetchQuote(symbol: string, apiKey: string): Promise<StockQuote | null> {
+    try {
+        const url = `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${symbol}&apikey=${apiKey}`;
+        const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+        if (!res.ok) return null;
+        const data = await res.json();
+        const q = data["Global Quote"];
+        if (!q || !q["05. price"]) return null;
+        return {
+            symbol,
+            price: parseFloat(q["05. price"]) || 0,
+            change: parseFloat(q["09. change"]) || 0,
+            changePct: parseFloat(q["10. change percent"]?.replace("%", "")) || 0,
+        };
+    } catch {
+        return null;
+    }
+}
+
+// --- Bottom panel ticker component ---
+function StockTickerPanel({ enabled }: { pluginId: string; enabled: boolean }) {
+    const cameraLat = useStore((s) => s.cameraLat);
+    const cameraLon = useStore((s) => s.cameraLon);
+    const cameraAlt = useStore((s) => s.cameraAlt);
+    const [quotes, setQuotes] = useState<StockQuote[]>([]);
+    const [country, setCountry] = useState<string>("Global");
+    const [loading, setLoading] = useState(false);
+    const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
+    const fetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const fetchStocks = async (detectedCountry: string) => {
+        if (typeof window === "undefined") return;
+        const apiKey = localStorage.getItem(LS_KEY_AV) || "";
+        if (!apiKey) return;
+
+        const info = COUNTRY_SYMBOLS[detectedCountry] ?? COUNTRY_SYMBOLS["United States"];
+        const symbols = info.symbols.slice(0, 5);
+        setLoading(true);
+
+        const results = await Promise.allSettled(symbols.map((s) => fetchQuote(s, apiKey)));
+        const valid = results
+            .filter((r): r is PromiseFulfilledResult<StockQuote | null> => r.status === "fulfilled")
+            .map((r) => r.value)
+            .filter(Boolean) as StockQuote[];
+
+        setQuotes(valid);
+        setLastUpdate(new Date());
+        setLoading(false);
+    };
+
+    // Detect country from camera
+    useEffect(() => {
+        if (!enabled) return;
+        // Only detect when zoomed in (altitude < 3000km)
+        if (cameraAlt > 3_000_000) {
+            setCountry("Global");
+            return;
+        }
+        const detected = detectCountry(cameraLat, cameraLon) ?? "United States";
+        setCountry(detected);
+    }, [cameraLat, cameraLon, cameraAlt, enabled]);
+
+    // Fetch on country change
+    useEffect(() => {
+        if (!enabled || country === "Global") return;
+        fetchStocks(country);
+        if (fetchTimer.current) clearTimeout(fetchTimer.current);
+        fetchTimer.current = setTimeout(() => fetchStocks(country), 5 * 60_000);
+        return () => {
+            if (fetchTimer.current) clearTimeout(fetchTimer.current);
+        };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [country, enabled]);
+
+    if (!enabled) {
+        return (
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "var(--text-muted)", fontSize: 13 }}>
+                Enable the Stocks layer to show the ticker
+            </div>
+        );
+    }
+
+    const apiKey = typeof window !== "undefined" ? localStorage.getItem(LS_KEY_AV) : "";
+    if (!apiKey) {
+        return (
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "var(--text-muted)", fontSize: 13, flexDirection: "column", gap: 8 }}>
+                <TrendingUp size={24} style={{ color: "#10b981" }} />
+                <span>Add your Alpha Vantage API key in Settings to enable the stock ticker</span>
+            </div>
+        );
+    }
+
+    return (
+        <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden", padding: "8px 0" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "0 16px 8px", borderBottom: "1px solid var(--border-subtle)", flexShrink: 0 }}>
+                <TrendingUp size={14} style={{ color: "#10b981" }} />
+                <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text-primary)" }}>
+                    Market Data — {COUNTRY_SYMBOLS[country]?.name ?? country}
+                </span>
+                {cameraAlt > 3_000_000 && (
+                    <span style={{ fontSize: 11, color: "var(--text-muted)" }}>(zoom in to detect country)</span>
+                )}
+                {lastUpdate && (
+                    <span style={{ fontSize: 10, color: "var(--text-muted)", marginLeft: "auto" }}>
+                        Updated {lastUpdate.toLocaleTimeString()}
+                    </span>
+                )}
+                {loading && <span style={{ fontSize: 10, color: "#10b981", marginLeft: "auto" }}>Fetching…</span>}
+            </div>
+
+            {quotes.length > 0 ? (
+                <div style={{ flex: 1, overflow: "hidden", position: "relative" }}>
+                    <style>{`
+                        @keyframes ticker-scroll {
+                            0%   { transform: translateX(100%); }
+                            100% { transform: translateX(-100%); }
+                        }
+                        .stock-ticker-track {
+                            display: flex;
+                            gap: 48px;
+                            animation: ticker-scroll 25s linear infinite;
+                            white-space: nowrap;
+                            will-change: transform;
+                        }
+                        .stock-ticker-track:hover { animation-play-state: paused; }
+                    `}</style>
+                    <div className="stock-ticker-track" style={{ paddingTop: 10 }}>
+                        {[...quotes, ...quotes].map((q, i) => (
+                            <span
+                                // eslint-disable-next-line react/no-array-index-key
+                                key={`${q.symbol}-${i}`}
+                                style={{ display: "inline-flex", alignItems: "center", gap: 8, fontSize: 14 }}
+                            >
+                                <span style={{ color: "var(--text-muted)", fontWeight: 600 }}>{q.symbol}</span>
+                                <span style={{ color: "var(--text-primary)", fontFamily: "monospace" }}>
+                                    ${q.price.toFixed(2)}
+                                </span>
+                                <span style={{ color: q.change >= 0 ? "#10b981" : "#ef4444", fontSize: 12 }}>
+                                    {q.change >= 0 ? "▲" : "▼"} {Math.abs(q.changePct).toFixed(2)}%
+                                </span>
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            ) : (
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flex: 1, color: "var(--text-muted)", fontSize: 13 }}>
+                    {loading ? "Fetching stock data…" : "No data — zoom into a country on the map"}
+                </div>
+            )}
+        </div>
+    );
+}
+
+class StocksPlugin implements WorldPlugin {
+    id = "stocks";
+    name = "Stock Ticker";
+    description = "Country-aware market data via Alpha Vantage — updates every 5 min";
+    icon = TrendingUp;
+    category = "economic" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        // No globe entities — data is displayed only in the bottom panel
+        return [];
+    }
+
+    getPollingInterval(): number {
+        return 5 * 60_000;
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#10b981",
+            clusterEnabled: false,
+            clusterDistance: 0,
+        };
+    }
+
+    renderEntity(_entity: GeoEntity): CesiumEntityOptions {
+        return { type: "point", color: "#10b981", size: 6 };
+    }
+
+    getBottomPanelComponent(): ComponentType<{ pluginId: string; enabled: boolean }> {
+        return StockTickerPanel;
+    }
+
+    requiresConfiguration(): boolean {
+        if (typeof window === "undefined") return false;
+        return !localStorage.getItem(LS_KEY_AV);
+    }
+}
+
+export const stocksPlugin = new StocksPlugin();

--- a/src/plugins/builtins/volcanoes.ts
+++ b/src/plugins/builtins/volcanoes.ts
@@ -1,0 +1,147 @@
+/**
+ * Volcanoes Plugin — Active volcanoes from Smithsonian Global Volcanism Program.
+ * Data is hardcoded from GVP records (updated to 2024).
+ * No API key required. Refresh: once daily.
+ */
+import { Flame } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+interface Volcano {
+    name: string;
+    country: string;
+    lat: number;
+    lon: number;
+    elevationM: number;
+    alertLevel: "Normal" | "Advisory" | "Watch" | "Warning";
+    lastEruption: string;
+}
+
+// Data sourced from Smithsonian Global Volcanism Program (GVP) — holocene/current activity
+const VOLCANOES: Volcano[] = [
+    { name: "Kilauea",              country: "United States (Hawaii)", lat: 19.421, lon: -155.287, elevationM:  1247, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Mauna Loa",            country: "United States (Hawaii)", lat: 19.475, lon: -155.608, elevationM:  4170, alertLevel: "Advisory",lastEruption: "2022" },
+    { name: "Etna",                 country: "Italy",                  lat: 37.748, lon:   14.999, elevationM:  3350, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Stromboli",            country: "Italy",                  lat: 38.789, lon:   15.213, elevationM:   924, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Sakurajima",           country: "Japan",                  lat: 31.585, lon:  130.657, elevationM:  1117, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Merapi",               country: "Indonesia",              lat: -7.542, lon:  110.442, elevationM:  2968, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Krakatau",             country: "Indonesia",              lat: -6.102, lon:  105.423, elevationM:   155, alertLevel: "Advisory",lastEruption: "2023" },
+    { name: "Sinabung",             country: "Indonesia",              lat:  3.170, lon:   98.392, elevationM:  2460, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Semeru",               country: "Indonesia",              lat: -8.108, lon:  112.922, elevationM:  3676, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Lewotolok",            country: "Indonesia",              lat: -8.272, lon:  123.506, elevationM:  1431, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Popocatépetl",         country: "Mexico",                 lat: 19.023, lon:  -98.622, elevationM:  5426, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Fuego",                country: "Guatemala",              lat: 14.473, lon:  -90.880, elevationM:  3763, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Santiaguito",          country: "Guatemala",              lat: 14.756, lon:  -91.552, elevationM:  2500, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Reventador",           country: "Ecuador",                lat: -0.077, lon:  -77.656, elevationM:  3562, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Cotopaxi",             country: "Ecuador",                lat: -0.677, lon:  -78.436, elevationM:  5897, alertLevel: "Watch",   lastEruption: "2023" },
+    { name: "Villarrica",           country: "Chile",                  lat:-39.422, lon:  -71.936, elevationM:  2847, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Cotacachi",            country: "Ecuador",                lat:  0.368, lon:  -78.362, elevationM:  4944, alertLevel: "Normal",  lastEruption: "1955" },
+    { name: "Erta Ale",             country: "Ethiopia",               lat: 13.600, lon:   40.670, elevationM:   613, alertLevel: "Advisory",lastEruption: "2024" },
+    { name: "Nyiragongo",           country: "DR Congo",               lat: -1.521, lon:   29.251, elevationM:  3470, alertLevel: "Watch",   lastEruption: "2021" },
+    { name: "Piton de la Fournaise",country: "France (Réunion)",       lat:-21.244, lon:   55.708, elevationM:  2632, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Ol Doinyo Lengai",     country: "Tanzania",               lat: -2.764, lon:   35.902, elevationM:  2962, alertLevel: "Advisory",lastEruption: "2024" },
+    { name: "Kamchatka (Klyuchevskoy)", country: "Russia",            lat: 56.057, lon:  160.638, elevationM:  4750, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Bezymianny",           country: "Russia",                 lat: 55.972, lon:  160.595, elevationM:  2882, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Ebeko",                country: "Russia (Kuril Islands)", lat: 50.686, lon:  156.014, elevationM:   1156, alertLevel: "Watch",  lastEruption: "2024" },
+    { name: "Taal",                 country: "Philippines",            lat: 14.002, lon:  120.997, elevationM:   311, alertLevel: "Advisory",lastEruption: "2022" },
+    { name: "Mayon",                country: "Philippines",            lat: 13.257, lon:  123.685, elevationM:  2462, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Bulusan",              country: "Philippines",            lat: 12.769, lon:  124.055, elevationM:  1565, alertLevel: "Advisory",lastEruption: "2023" },
+    { name: "Ruapehu",              country: "New Zealand",            lat:-39.282, lon:  175.567, elevationM:  2797, alertLevel: "Advisory",lastEruption: "2022" },
+    { name: "Whakaari (White Island)",country: "New Zealand",          lat:-37.521, lon:  177.183, elevationM:   321, alertLevel: "Advisory",lastEruption: "2019" },
+    { name: "Sheveluch",            country: "Russia",                 lat: 56.653, lon:  161.360, elevationM:  3283, alertLevel: "Warning", lastEruption: "2024" },
+    { name: "Veniaminof",           country: "United States (Alaska)", lat: 56.195, lon: -159.390, elevationM:  2507, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Pavlof",               country: "United States (Alaska)", lat: 55.418, lon: -161.894, elevationM:  2519, alertLevel: "Watch",   lastEruption: "2023" },
+    { name: "Bogoslof",             country: "United States (Alaska)", lat: 53.927, lon: -168.035, elevationM:   150, alertLevel: "Normal",  lastEruption: "2017" },
+    { name: "Erebus",               country: "Antarctica",             lat:-77.530, lon:  167.153, elevationM:  3794, alertLevel: "Normal",  lastEruption: "2024" },
+    { name: "Vesuvius",             country: "Italy",                  lat: 40.821, lon:   14.426, elevationM:  1281, alertLevel: "Normal",  lastEruption: "1944" },
+    { name: "Soufrière Hills",      country: "Montserrat",             lat: 16.720, lon:  -62.177, elevationM:   915, alertLevel: "Advisory",lastEruption: "2010" },
+    { name: "La Soufrière",         country: "St Vincent",             lat: 13.334, lon:  -61.180, elevationM:  1234, alertLevel: "Advisory",lastEruption: "2021" },
+    { name: "Cumbre Vieja",         country: "Spain (La Palma)",       lat: 28.574, lon:  -17.873, elevationM:  1949, alertLevel: "Normal",  lastEruption: "2021" },
+    { name: "Fagradalsfjall",       country: "Iceland",                lat: 63.895, lon:  -22.268, elevationM:   385, alertLevel: "Advisory",lastEruption: "2024" },
+    { name: "Hekla",                country: "Iceland",                lat: 63.983, lon:  -19.666, elevationM:  1491, alertLevel: "Normal",  lastEruption: "2000" },
+    { name: "Grimsvotn",            country: "Iceland",                lat: 64.416, lon:  -17.316, elevationM:  1725, alertLevel: "Advisory",lastEruption: "2023" },
+    { name: "Dukono",               country: "Indonesia",              lat:  1.693, lon:  127.894, elevationM:  1087, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Ibu",                  country: "Indonesia",              lat:  1.488, lon:  127.630, elevationM:  1325, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Karangetang",          country: "Indonesia",              lat:  2.781, lon:  125.407, elevationM:  1784, alertLevel: "Watch",   lastEruption: "2024" },
+    { name: "Gamalama",             country: "Indonesia",              lat:  0.800, lon:  127.325, elevationM:  1715, alertLevel: "Advisory",lastEruption: "2022" },
+    { name: "Agung",                country: "Indonesia",              lat: -8.343, lon:  115.508, elevationM:  3142, alertLevel: "Advisory",lastEruption: "2019" },
+    { name: "Bromo",                country: "Indonesia",              lat: -7.942, lon:  112.950, elevationM:  2329, alertLevel: "Advisory",lastEruption: "2024" },
+    { name: "Turrialba",            country: "Costa Rica",             lat: 10.025, lon:  -83.767, elevationM:  3340, alertLevel: "Advisory",lastEruption: "2021" },
+    { name: "Poas",                 country: "Costa Rica",             lat: 10.200, lon:  -84.233, elevationM:  2708, alertLevel: "Advisory",lastEruption: "2021" },
+    { country: "Vanuatu",           name: "Ambae",                     lat:-15.389, lon:  167.835, elevationM:  1496, alertLevel: "Watch",   lastEruption: "2018" },
+    { country: "Papua New Guinea",  name: "Manam",                     lat: -4.080, lon:  145.061, elevationM:  1807, alertLevel: "Watch",   lastEruption: "2024" },
+];
+
+function alertColor(level: Volcano["alertLevel"]): string {
+    switch (level) {
+        case "Warning":  return "#dc2626";
+        case "Watch":    return "#ea580c";
+        case "Advisory": return "#d97706";
+        default:         return "#6b7280";
+    }
+}
+
+const VOLCANO_ENTITIES: GeoEntity[] = VOLCANOES.map((v) => ({
+    id: `volcano-${v.name.replace(/\s+/g, "-").toLowerCase()}`,
+    pluginId: "volcanoes",
+    latitude: v.lat,
+    longitude: v.lon,
+    altitude: 0,
+    timestamp: new Date(0),
+    label: `🌋 ${v.name}`,
+    properties: {
+        name: v.name,
+        country: v.country,
+        elevationM: v.elevationM,
+        elevationFt: Math.round(v.elevationM * 3.28084),
+        alertLevel: v.alertLevel,
+        lastEruption: v.lastEruption,
+    },
+}));
+
+class VolcanoesPlugin implements WorldPlugin {
+    id = "volcanoes";
+    name = "Active Volcanoes";
+    description = "50 active volcanoes worldwide (Smithsonian GVP data)";
+    icon = Flame;
+    category = "natural-disaster" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        return VOLCANO_ENTITIES;
+    }
+
+    getPollingInterval(): number {
+        return 24 * 60 * 60_000; // once daily (static data)
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#f97316",
+            clusterEnabled: false,
+            clusterDistance: 40,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        const level = (entity.properties.alertLevel as Volcano["alertLevel"]) ?? "Normal";
+        return {
+            type: "point",
+            color: alertColor(level),
+            size: level === "Warning" ? 14 : level === "Watch" ? 10 : 7,
+            outlineColor: "#7c2d12",
+            outlineWidth: 2,
+        };
+    }
+}
+
+export const volcanoesPlugin = new VolcanoesPlugin();

--- a/src/plugins/builtins/warzones.ts
+++ b/src/plugins/builtins/warzones.ts
@@ -1,0 +1,148 @@
+/**
+ * War Zones Plugin — Conflict events from ACLED API (last 30 days).
+ * Requires free ACLED API credentials (email + key) from https://developer.acleddata.com/
+ * Refresh: every hour.
+ */
+import { AlertTriangle } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+import { fetchViaProxy } from "./proxy-utils";
+
+const LS_KEY_ACLED_EMAIL = "wwv_acled_email";
+const LS_KEY_ACLED_KEY = "wwv_acled_key";
+
+function getCredentials(): { email: string; key: string } | null {
+    if (typeof window === "undefined") return null;
+    const email = localStorage.getItem(LS_KEY_ACLED_EMAIL) || "";
+    const key = localStorage.getItem(LS_KEY_ACLED_KEY) || "";
+    if (!email || !key) return null;
+    return { email, key };
+}
+
+function getLast30Days(): { start: string; end: string } {
+    const end = new Date();
+    const start = new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const fmt = (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    return { start: fmt(start), end: fmt(end) };
+}
+
+function fatalityColor(fatalities: number): string {
+    if (fatalities >= 50) return "#7f1d1d";
+    if (fatalities >= 10) return "#dc2626";
+    if (fatalities >= 1)  return "#ef4444";
+    return "#f87171";
+}
+
+function fatalitySize(fatalities: number): number {
+    if (fatalities >= 100) return 22;
+    if (fatalities >= 50)  return 18;
+    if (fatalities >= 10)  return 14;
+    if (fatalities >= 1)   return 10;
+    return 7;
+}
+
+class WarZonesPlugin implements WorldPlugin {
+    id = "warzones";
+    name = "War Zones";
+    description = "Active conflict events from ACLED (last 30 days) — free API key required";
+    icon = AlertTriangle;
+    category = "conflict" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        const creds = getCredentials();
+        if (!creds) return [];
+
+        try {
+            const { start, end } = getLast30Days();
+            const params = new URLSearchParams({
+                key: creds.key,
+                email: creds.email,
+                event_date: `${start}|${end}`,
+                event_date_where: "BETWEEN",
+                limit: "1000",
+                fields: "event_id_cnty,event_date,event_type,actor1,actor2,country,location,latitude,longitude,fatalities,notes",
+            });
+
+            const url = `https://api.acleddata.com/acled/read?${params}`;
+            const data = await fetchViaProxy(url);
+            const json: any = await data.json();
+
+            if (!Array.isArray(json.data)) return [];
+
+            return json.data
+                .filter((ev: any) =>
+                    typeof ev.latitude === "string" && typeof ev.longitude === "string"
+                )
+                .map((ev: any) => {
+                    const lat = parseFloat(ev.latitude);
+                    const lon = parseFloat(ev.longitude);
+                    const fatalities = parseInt(ev.fatalities ?? "0", 10) || 0;
+
+                    if (!isFinite(lat) || !isFinite(lon)) return null;
+
+                    return {
+                        id: `warzone-${ev.event_id_cnty}`,
+                        pluginId: "warzones",
+                        latitude: lat,
+                        longitude: lon,
+                        timestamp: new Date(ev.event_date ?? Date.now()),
+                        label: `⚔️ ${ev.location ?? ev.country}`,
+                        properties: {
+                            eventId: ev.event_id_cnty,
+                            eventType: ev.event_type ?? "",
+                            actor1: ev.actor1 ?? "",
+                            actor2: ev.actor2 ?? "",
+                            country: ev.country ?? "",
+                            location: ev.location ?? "",
+                            fatalities,
+                            notes: ev.notes ?? "",
+                            date: ev.event_date ?? "",
+                        },
+                    } satisfies GeoEntity;
+                })
+                .filter(Boolean) as GeoEntity[];
+        } catch {
+            return [];
+        }
+    }
+
+    getPollingInterval(): number {
+        return 60 * 60_000; // 1 hour
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#dc2626",
+            clusterEnabled: false,
+            clusterDistance: 50,
+        };
+    }
+
+    renderEntity(entity: GeoEntity): CesiumEntityOptions {
+        const fatalities = (entity.properties.fatalities as number) ?? 0;
+        return {
+            type: "point",
+            color: fatalityColor(fatalities),
+            size: fatalitySize(fatalities),
+            outlineColor: "#7f1d1d",
+            outlineWidth: 2,
+        };
+    }
+
+    requiresConfiguration(): boolean {
+        return !getCredentials();
+    }
+}
+
+export const warZonesPlugin = new WarZonesPlugin();

--- a/src/plugins/builtins/weather.ts
+++ b/src/plugins/builtins/weather.ts
@@ -1,0 +1,140 @@
+/**
+ * Weather Plugin — Current conditions for 20 major world cities.
+ * Data source: Open-Meteo (free, no API key, CORS-friendly).
+ * Refresh: every 10 minutes.
+ */
+import { Cloud } from "lucide-react";
+import type {
+    WorldPlugin,
+    GeoEntity,
+    TimeRange,
+    PluginContext,
+    LayerConfig,
+    CesiumEntityOptions,
+} from "@/core/plugins/PluginTypes";
+
+const CITIES = [
+    { name: "New York",     lat: 40.7128, lon: -74.0060 },
+    { name: "London",       lat: 51.5074, lon:  -0.1278 },
+    { name: "Tokyo",        lat: 35.6762, lon: 139.6503 },
+    { name: "Paris",        lat: 48.8566, lon:   2.3522 },
+    { name: "Beijing",      lat: 39.9042, lon: 116.4074 },
+    { name: "Sydney",       lat: -33.8688, lon: 151.2093 },
+    { name: "Dubai",        lat: 25.2048, lon:  55.2708 },
+    { name: "São Paulo",    lat: -23.5505, lon: -46.6333 },
+    { name: "Mumbai",       lat: 19.0760, lon:  72.8777 },
+    { name: "Moscow",       lat: 55.7558, lon:  37.6176 },
+    { name: "Cairo",        lat: 30.0444, lon:  31.2357 },
+    { name: "Lagos",        lat:  6.5244, lon:   3.3792 },
+    { name: "Mexico City",  lat: 19.4326, lon: -99.1332 },
+    { name: "Istanbul",     lat: 41.0082, lon:  28.9784 },
+    { name: "Singapore",    lat:  1.3521, lon: 103.8198 },
+    { name: "Toronto",      lat: 43.6532, lon: -79.3832 },
+    { name: "Buenos Aires", lat: -34.6037, lon: -58.3816 },
+    { name: "Seoul",        lat: 37.5665, lon: 126.9780 },
+    { name: "Berlin",       lat: 52.5200, lon:  13.4050 },
+    { name: "Nairobi",      lat: -1.2921, lon:  36.8219 },
+];
+
+// WMO weather interpretation codes → emoji + description
+function wmoToDescription(code: number): { emoji: string; desc: string } {
+    if (code === 0)  return { emoji: "☀️", desc: "Clear sky" };
+    if (code <= 2)   return { emoji: "⛅", desc: "Partly cloudy" };
+    if (code === 3)  return { emoji: "☁️", desc: "Overcast" };
+    if (code <= 49)  return { emoji: "🌫️", desc: "Fog" };
+    if (code <= 57)  return { emoji: "🌧️", desc: "Drizzle" };
+    if (code <= 67)  return { emoji: "🌧️", desc: "Rain" };
+    if (code <= 77)  return { emoji: "❄️", desc: "Snow" };
+    if (code <= 82)  return { emoji: "🌦️", desc: "Rain showers" };
+    if (code <= 86)  return { emoji: "🌨️", desc: "Snow showers" };
+    if (code <= 99)  return { emoji: "⛈️", desc: "Thunderstorm" };
+    return { emoji: "🌡️", desc: "Unknown" };
+}
+
+class WeatherPlugin implements WorldPlugin {
+    id = "weather";
+    name = "World Weather";
+    description = "Current weather conditions for 20 major world cities (Open-Meteo)";
+    icon = Cloud;
+    category = "natural-disaster" as const;
+    version = "1.0.0";
+
+    async initialize(_ctx: PluginContext): Promise<void> {}
+    destroy(): void {}
+
+    async fetch(_timeRange: TimeRange): Promise<GeoEntity[]> {
+        const entities: GeoEntity[] = [];
+
+        await Promise.allSettled(
+            CITIES.map(async (city) => {
+                try {
+                    const url = [
+                        `https://api.open-meteo.com/v1/forecast`,
+                        `?latitude=${city.lat}&longitude=${city.lon}`,
+                        `&current_weather=true`,
+                        `&wind_speed_unit=ms`,
+                    ].join("");
+
+                    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+                    if (!res.ok) return;
+                    const data = await res.json();
+                    const w = data.current_weather;
+                    if (!w) return;
+
+                    const { emoji, desc } = wmoToDescription(w.weathercode ?? 0);
+                    const tempC = Math.round(w.temperature ?? 0);
+                    const windMs = Math.round(w.windspeed ?? 0);
+                    const windKt = Math.round(windMs * 1.94384);
+
+                    entities.push({
+                        id: `weather-${city.name.replace(/\s+/g, "-").toLowerCase()}`,
+                        pluginId: "weather",
+                        latitude: city.lat,
+                        longitude: city.lon,
+                        timestamp: new Date(),
+                        label: `${emoji} ${city.name} ${tempC}°C`,
+                        properties: {
+                            city: city.name,
+                            temperature: tempC,
+                            temperatureF: Math.round(tempC * 9 / 5 + 32),
+                            windSpeedMs: windMs,
+                            windSpeedKnots: windKt,
+                            conditionCode: w.weathercode,
+                            condition: desc,
+                            emoji,
+                            isDay: w.is_day === 1,
+                        },
+                    });
+                } catch {
+                    // skip city on error
+                }
+            })
+        );
+
+        return entities;
+    }
+
+    getPollingInterval(): number {
+        return 10 * 60_000; // 10 minutes
+    }
+
+    getLayerConfig(): LayerConfig {
+        return {
+            color: "#38bdf8",
+            clusterEnabled: false,
+            clusterDistance: 80,
+        };
+    }
+
+    renderEntity(_entity: GeoEntity): CesiumEntityOptions {
+        return {
+            type: "point",
+            color: "#38bdf8",
+            size: 10,
+            outlineColor: "#0ea5e9",
+            outlineWidth: 2,
+        };
+    }
+}
+
+export const weatherPlugin = new WeatherPlugin();


### PR DESCRIPTION
## Summary

- **6 migrated layers** rewritten as CesiumJS plugins: Flights (OpenSky), Weather (Open-Meteo 20 cities), News (5 RSS feeds), Earthquakes (USGS), World Capitals (195 countries), Ships (AISStream WebSocket)
- **6 new plugins**: War Zones (ACLED), Stock Ticker (Alpha Vantage bottom panel), ISS Tracker, Volcanoes (Smithsonian GVP), Global Disasters (GDACS), Lightning (Blitzortung WebSocket 3s TTL)
- New src/plugins/builtins/ — 12 plugin files, index.ts side-effect registration, proxy-utils.ts CORS chain
- New PluginSettingsPanel.tsx — gear icon modal with API key inputs for AISStream, ACLED, Alpha Vantage
- AppShell.tsx: imports @/plugins/builtins/index before pluginRegistry.getAll()
- LayerPanel.tsx: adds space, intelligence, military category labels

## Test plan

- [ ] All 12 layer toggles visible in sidebar grouped by category
- [ ] Enable Flights, Earthquakes, Capitals, ISS — data appears
- [ ] Enable Lightning — Blitzortung WebSocket connects, strikes fade after 3s
- [ ] Gear icon opens settings modal, API keys save to localStorage
- [ ] Ships and Stock Ticker work after adding API keys

Generated with Claude Code