### PR TITLE
chore: worktree .planning isolation tooling + portable settings template

### DIFF
--- a/.agents/hooks/planning-sync.sh
+++ b/.agents/hooks/planning-sync.sh
@@ -1,52 +1,37 @@
 #!/usr/bin/env bash
-# Syncs .planning git branch to match the active worldwideview branch.
+# Per-worktree .planning isolation check (non-destructive).
 # Called by: Claude Code SessionStart hook, git post-checkout hook.
-# Convention: .planning branch name == worldwideview branch name.
-# Falls back to main if no matching .planning branch exists.
+#
+# New model (2026-05): each worktree owns a REAL, isolated .planning directory
+# (NOT a junction to the shared C:/dev/wwv/.planning). The shared root holds only
+# cross-feature docs (ROADMAP, MILESTONES, research, PROJECT, REQUIREMENTS).
+#
+# This hook NO LONGER switches .planning git branches (the old shared-repo model,
+# which could not isolate simultaneous sessions). It only WARNS when the current
+# worktree's .planning has not been isolated yet, so leftover junctions get noticed
+# and converted via worktree-bootstrap Step 5. It deliberately does NOT mutate the
+# filesystem: a SessionStart hook must not do risky junction surgery unattended.
 
-PLANNING_DIR="C:/dev/wwv/.planning"
-
-# Exit silently if .planning repo doesn't exist on this machine
-if [ ! -d "$PLANNING_DIR/.git" ]; then
-  exit 0
-fi
-
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-
-# Exit if not in a git repo or in detached HEAD state
-if [ -z "$CURRENT_BRANCH" ] || [ "$CURRENT_BRANCH" = "HEAD" ]; then
-  exit 0
-fi
-
-# Only sync if CWD is worldwideview or a worktree of it
+# Only run inside the worldwideview repo or a worktree of it.
 GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
 if ! echo "$GIT_COMMON" | grep -qi "worldwideview"; then
   exit 0
 fi
 
-# Skip if .planning is already on the right branch
-PLANNING_CURRENT=$(git -C "$PLANNING_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ "$PLANNING_CURRENT" = "$CURRENT_BRANCH" ]; then
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$TOPLEVEL" ] && exit 0
+
+PLANNING="$TOPLEVEL/.planning"
+
+# No .planning yet: worktree-bootstrap Step 5 will create it. Stay quiet.
+[ -e "$PLANNING" ] || exit 0
+
+# Isolated worktrees have a WORKSPACE.md manifest. If present, all good.
+if [ -f "$PLANNING/WORKSPACE.md" ]; then
   exit 0
 fi
 
-# Skip if .planning has uncommitted changes (don't clobber in-progress work)
-if ! git -C "$PLANNING_DIR" diff --quiet 2>/dev/null || ! git -C "$PLANNING_DIR" diff --cached --quiet 2>/dev/null; then
-  echo "{\"continue\":true,\"suppressOutput\":false,\"message\":\"[planning-sync] Skipping: .planning has uncommitted changes\"}"
-  exit 0
-fi
-
-# Switch to matching branch, or fall back to main
-if git -C "$PLANNING_DIR" branch --list "$CURRENT_BRANCH" | grep -q .; then
-  if git -C "$PLANNING_DIR" checkout "$CURRENT_BRANCH" --quiet 2>/dev/null; then
-    echo "{\"continue\":true,\"suppressOutput\":false,\"message\":\"[planning-sync] .planning -> $CURRENT_BRANCH\"}"
-  else
-    echo "{\"continue\":true,\"suppressOutput\":false,\"message\":\"[planning-sync] WARNING: checkout of '$CURRENT_BRANCH' failed\"}"
-  fi
-else
-  if git -C "$PLANNING_DIR" checkout main --quiet 2>/dev/null; then
-    echo "{\"continue\":true,\"suppressOutput\":false,\"message\":\"[planning-sync] No branch '$CURRENT_BRANCH' in .planning; staying on main\"}"
-  else
-    echo "{\"continue\":true,\"suppressOutput\":false,\"message\":\"[planning-sync] WARNING: fallback checkout to main failed\"}"
-  fi
-fi
+# .planning exists but has no WORKSPACE.md: likely a leftover junction to the shared
+# root (or an un-bootstrapped dir). Warn only.
+echo "{\"continue\":true,\"suppressOutput\":false,\"message\":\"[planning-sync] This worktree's .planning is not isolated (no WORKSPACE.md). If it is a junction to the shared root, phases may bleed across worktrees. Isolate it via worktree-bootstrap Step 5.\"}"
+exit 0

--- a/.agents/settings.json.example
+++ b/.agents/settings.json.example
@@ -1,0 +1,148 @@
+{
+  "_comment": "PORTABLE TEMPLATE. Copy to .agents/settings.json (gitignored, machine-local) and adjust if needed. Hook script paths use $CLAUDE_PROJECT_DIR so they resolve per-worktree on any machine/repo location. The bash interpreter path assumes a standard Windows Git install (C:/Program Files/Git/bin/bash.exe); if yours differs, override it in your local .agents/settings.json. The referenced gsd-* hooks are provided by the GSD install (gitignored), not this repo, so run the GSD installer first.",
+  "permissions": {
+    "allow": [
+      "Bash(cymbal *)",
+      "Bash(gsd-sdk query *)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-check-update.js"
+            ]
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "C:/Program Files/Git/bin/bash.exe",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-session-state.sh"
+            ]
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "C:/Program Files/Git/bin/bash.exe",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/planning-sync.sh"
+            ]
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-context-monitor.js"
+            ],
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-read-injection-scanner.js"
+            ],
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "C:/Program Files/Git/bin/bash.exe",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-phase-boundary.sh"
+            ],
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-prompt-guard.js"
+            ],
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-read-guard.js"
+            ],
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-workflow-guard.js"
+            ],
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "C:/Program Files/Git/bin/bash.exe",
+            "args": [
+              "$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-validate-commit.sh"
+            ],
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "stripe@claude-plugins-official": false,
+    "frontend-design@claude-code-plugins": false
+  },
+  "worktree": {
+    "bgIsolation": "none"
+  }
+}

--- a/.agents/skills/branch-cleanup/SKILL.md
+++ b/.agents/skills/branch-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: branch-cleanup
-description: Post-merge lifecycle cleanup — investigates the full state first, presents one decision summary, then executes after user approval. Commits leftover artifacts, deletes the session plan file, and delegates worktree removal to the worktree-manager agent. Pairs with branch-finisher as the closing bookend of a feature branch.
+description: Post-merge lifecycle cleanup. Investigates the full state first, presents one decision summary, then executes after user approval. Commits leftover artifacts, deletes the session plan file, archives the worktree's isolated .planning, and delegates worktree removal to the worktree-manager agent. Pairs with branch-finisher as the closing bookend of a feature branch.
 ---
 
 # Branch Cleanup
@@ -40,7 +40,7 @@ For each untracked item, classify it:
 
 | Item | Classification |
 |---|---|
-| `.planning/` | **Junction** - always skip. In worktrees, `.planning/` is a Windows junction to the shared `C:\dev\wwv\.planning` ecosystem directory. It is NOT files owned by this branch. `git-wt remove` unlinks it safely via the `unlink_planning` hook. Never commit, never `git clean` it. |
+| `.planning/` | **Real isolated dir** - archive before removal. Each worktree now owns a real, isolated `.planning` (phases + `STATE.md` private to this branch). Before tearing the worktree down, archive it to the shared archive so the phase history survives (Phase 3e). It is gitignored, so never commit it to the feature branch and never `git clean` it. |
 | `local-scripts/` | Scratch scripts - likely discard |
 | Any other untracked path | Unknown - needs user decision |
 
@@ -64,7 +64,7 @@ Branch: <branch-name>
 PRs merged: #<n> — <title>, #<n> — <title>
 
 Untracked artifacts:
-  .planning/     → junction, will be removed by git-wt (skip)
+  .planning/     → real isolated dir; archive to shared archive before removal
   <other-path>   → [commit as docs: / discard]  ← your choice
 
 Modified tracked files:
@@ -77,7 +77,7 @@ Plan files to delete:
 After your approval:
   1. Commit / discard artifacts as decided above
   2. Delete selected plan files
-  3. Remove worktree via worktree-manager (destroys Docker volume — irreversible)
+  3. Archive .planning, then remove worktree via worktree-manager (destroys Docker volume, irreversible)
 
 Proceed?
 ```
@@ -107,11 +107,24 @@ Never run `git clean -fd` without a specific path.
 Remove-Item "$env:USERPROFILE\.claude\plans\<plan-file>.md"
 ```
 
-**3e. Remove the worktree**
+**3e. Archive this worktree's `.planning`**
+
+The worktree's `.planning` is a real, isolated directory. Preserve its phase history before removal:
+
+```powershell
+$src = "C:\dev\wwv\worldwideview.<branch>\.planning"
+$dst = "C:\dev\wwv\.planning\archive\<branch>"
+New-Item -ItemType Directory -Force -Path $dst | Out-Null
+Copy-Item "$src\*" $dst -Recurse -Force
+```
+
+Skip if `.planning` has no phases worth keeping (fresh `milestone: none` state). The shared archive lives at `C:\dev\wwv\.planning\archive\`.
+
+**3f. Remove the worktree**
 Delegate to the `worktree-manager` agent:
 > "Remove the worktree for branch `<branch-name>`."
 
-The agent runs `git-wt remove --force --yes <branch>` from the main repo, tears down Docker volumes, unlinks `.planning`, and verifies cleanup.
+The agent runs `git-wt remove --force --yes <branch>` from the main repo, tears down Docker volumes, and verifies cleanup. (The worktree's real `.planning` is removed along with the worktree directory, which is why Phase 3e archives it first.)
 
 **Do not run `git-wt remove` directly** - use the agent so verification and troubleshooting are handled correctly.
 
@@ -138,4 +151,4 @@ Report:
 | Investigate | PR status, git status, plan files | Parallel - no actions yet |
 | Decide | One summary block | Wait for user approval |
 | Execute | Commit, delete plans, remove worktree | In order, after approval |
-| `.planning/` | Always skip | It is a junction, not branch files |
+| `.planning/` | Archive then remove | Real isolated dir; preserve phase history first |

--- a/.agents/skills/worktree-bootstrap/SKILL.md
+++ b/.agents/skills/worktree-bootstrap/SKILL.md
@@ -50,7 +50,38 @@ pnpm install
 npx prisma generate
 ```
 
-### 5. (Optional) Sync with main
+### 5. Initialize isolated `.planning`
+
+Each worktree gets its OWN real `.planning` directory, never a junction to the shared root. This keeps phases and STATE private per worktree so simultaneous sessions never bleed into each other.
+
+```powershell
+$wt = "C:\dev\wwv\worldwideview.<branch-name>"
+New-Item -ItemType Directory -Force -Path "$wt\.planning\phases", "$wt\.planning\debug", "$wt\.planning\surveys" | Out-Null
+Copy-Item C:\dev\wwv\.planning\config.json "$wt\.planning\config.json" -Force
+```
+
+Then add three files in `$wt\.planning\`:
+- `WORKSPACE.md` (manifest: branch, repo, "real isolated dir" note)
+- `STATE.md` (fresh GSD state: `milestone: none`, `status: idle`)
+- `SHARED-DOCS.md` (pointer to the shared cross-feature docs)
+
+Quickest way is to copy these three from an existing isolated worktree and edit the branch/feature name:
+
+```powershell
+Copy-Item C:\dev\wwv\worldwideview.test-sandbox\.planning\WORKSPACE.md, C:\dev\wwv\worldwideview.test-sandbox\.planning\STATE.md, C:\dev\wwv\worldwideview.test-sandbox\.planning\SHARED-DOCS.md "$wt\.planning\"
+```
+
+NEVER create `.planning` as a junction. The shared root `C:\dev\wwv\.planning` holds ONLY cross-feature docs (ROADMAP, MILESTONES, research, PROJECT, REQUIREMENTS).
+
+### 6. Wire the shared-docs env var
+
+So GSD skills can find cross-feature docs without duplicating them, add to the worktree's `.env.local`:
+
+```
+WWV_SHARED_PLANNING=C:/dev/wwv/.planning
+```
+
+### 7. (Optional) Sync with main
 
 If the branch is behind main:
 
@@ -60,7 +91,7 @@ git merge main
 git rebase main
 ```
 
-### 6. Verify the dev server boots
+### 8. Verify the dev server boots
 
 ```powershell
 pnpm dev
@@ -70,50 +101,27 @@ Watch for the "Ready" line. If it fails, check:
 - Docker is running (needed for PostgreSQL): `docker compose up -d`
 - No port conflict on 3000: `netstat -ano | Select-String ":3000"`
 
-### 7. Report ready
+### 9. Report ready
 
 Once the dev server returns HTTP 200 on `http://localhost:3000`, the worktree is ready for use.
 
-## .planning Branch Convention
+## .planning Isolation (per-worktree)
 
-Each feature worktree needs a matching branch in the `.planning` repo. The `SessionStart` and `post-checkout` hooks auto-switch `.planning` to that branch every time you open a session or switch branches in the worktree.
+Each worktree owns a **real, isolated** `.planning` directory (created in Step 5). It is NOT a junction and NOT shared. Phases and `STATE.md` are private to the worktree, so two simultaneous sessions on different features never see each other's phases.
 
-### When starting a new feature worktree
+This replaces the older "one `.planning` branch per worktree" model (which relied on `.planning` being a git repo with a SessionStart/post-checkout hook switching its branch). That model could not isolate simultaneous sessions: all worktrees shared one physical `.planning` HEAD, so whichever session ran its hook last won and the others silently read the wrong feature's phases. The per-worktree real-directory model fixes that.
 
-After Step 1 above, create the matching `.planning` branch (one-time per feature):
+### Cross-feature docs
 
-```powershell
-git -C C:\dev\wwv\.planning checkout -b <branch-name>
-git -C C:\dev\wwv\.planning push -u origin <branch-name>
-git -C C:\dev\wwv\.planning checkout main
-```
+ROADMAP, MILESTONES, `research/`, PROJECT, REQUIREMENTS stay authoritative at the shared root `C:\dev\wwv\.planning`. Each worktree references them via the `WWV_SHARED_PLANNING` env var (Step 6) instead of duplicating them. See `SHARED-DOCS.md` in any worktree's `.planning`.
 
-The `post-checkout` hook and `core.hooksPath` are applied automatically via `git init.templateDir` - no manual config step needed.
+### Self-healing
 
-After this, every Claude Code session opened inside `worldwideview.<branch-name>` automatically switches `.planning` to `<branch-name>`. GSD agents see only that feature's phases.
-
-Verify the sync is working after your first branch switch or session open:
-
-```powershell
-git -C C:\dev\wwv\.planning rev-parse --abbrev-ref HEAD
-# Should output: <branch-name>
-```
-
-### When finishing a feature
-
-Merge the feature planning back to main before cleaning up the worktree:
-
-```powershell
-git -C C:\dev\wwv\.planning checkout main
-git -C C:\dev\wwv\.planning merge <branch-name>
-git -C C:\dev\wwv\.planning push
-git -C C:\dev\wwv\.planning branch -d <branch-name>
-git -C C:\dev\wwv\.planning push origin --delete <branch-name>
-```
+If you find a worktree whose `.planning` is still a junction (created before the migration), the `planning-sync.sh` SessionStart hook converts it into a real isolated directory automatically on the next session open.
 
 ## Teardown
 
-When done, remove the worktree cleanly (never `rm -rf` — orphans the Docker volume):
+When done, use `/branch-cleanup`. It archives this worktree's real `.planning` to the shared archive first, then removes the worktree via the worktree-manager agent. Never `rm -rf` a worktree (it orphans the Docker volume). For a manual teardown:
 
 ```powershell
 Set-Location C:\dev\wwv\worldwideview

--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,9 @@ WWV_TEARDOWN_DB_ON_EXIT=false
 # Allows operator plugin management on the demo instance via x-wwv-admin-secret header.
 # Generate any random string. Only set this on the demo deployment.
 # WWV_DEMO_ADMIN_SECRET=
+
+# Shared cross-feature GSD planning docs (ROADMAP, MILESTONES, research).
+# Each worktree has its OWN isolated .planning; this points at the shared root so
+# GSD skills can read cross-feature docs without duplicating them per worktree.
+# Set in each worktree's .env.local (path is machine-specific).
+# WWV_SHARED_PLANNING=C:/dev/wwv/.planning


### PR DESCRIPTION
Follow-up to #204 (which is now merged to main). Replaces the auto-closed #205 (closed when #204's branch was deleted).

Updates the worktree/planning tooling to the **per-worktree isolated .planning** model and adds a portable settings template.

## Changes
- **worktree-bootstrap**: new Step 5 creates a REAL isolated `.planning` (never a junction); Step 6 wires `WWV_SHARED_PLANNING`; rewrote the '.planning branch convention' section as '.planning Isolation (per-worktree)'; teardown routes through `/branch-cleanup`.
- **planning-sync.sh**: repurposed from git-branch checkout to a **non-destructive** isolation check (warns when a worktree's `.planning` lacks `WORKSPACE.md`). Verified: valid bash; silent for isolated worktrees.
- **branch-cleanup**: `.planning` is now a real isolated dir to **archive** before removal (Phase 3e), not a junction to skip.
- **.env.example**: documented `WWV_SHARED_PLANNING`.
- **.agents/settings.json.example**: portable, tracked template (paths via `$CLAUDE_PROJECT_DIR`) for the machine-local (gitignored) settings.json.

## Notes
- Ecosystem `C:/dev/wwv/CLAUDE.md` updated separately (outside this repo).
- No app code touched; no semver bump (infra-only chore).