### PR TITLE
fix(worktree): git-wt link-planning hook creates real isolated .planning

### DIFF
--- a/.agents/scripts/link-planning.ps1
+++ b/.agents/scripts/link-planning.ps1
@@ -1,8 +1,161 @@
 param([string]$worktreePath)
+
+# git-wt (Worktrunk) pre-start hook.
+# Per the per-worktree isolation model, each worktree gets its OWN real, isolated
+# .planning directory -- NEVER a junction to the shared root. A shared junction caused
+# GSD phase bleed across simultaneous worktree sessions. See worktree-bootstrap SKILL Step 5
+# and C:\dev\wwv\.planning\WORKSPACE-OPTIMIZATION-BACKLOG.md.
+#
+# This hook is idempotent:
+#   - existing REAL .planning with a WORKSPACE.md  -> left untouched (preserve phase history)
+#   - existing REAL .planning missing manifests    -> manifests seeded, contents preserved
+#   - existing JUNCTION (old-model leftover)        -> junction removed, real dir created
+#   - nothing there                                 -> real isolated dir created
+
+$ErrorActionPreference = 'Stop'
+
 # Convert Unix-style path (/c/dev/...) to Windows path (C:\dev\...) if needed
 if ($worktreePath -match '^/([a-zA-Z])/(.+)$') {
     $worktreePath = $matches[1].ToUpper() + ':/' + $matches[2]
 }
+
+$sharedRoot = 'C:\dev\wwv\.planning'
 $target = Join-Path $worktreePath '.planning'
-if (Test-Path $target) { Remove-Item $target -Force }
-New-Item -ItemType Junction -Path $target -Target 'C:\dev\wwv\.planning' | Out-Null
+
+# If a junction/symlink leftover from the old model exists, remove only the reparse
+# point (never recurse into the shared root it points at).
+if (Test-Path $target) {
+    $item = Get-Item -LiteralPath $target -Force
+    $isReparse = ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq [IO.FileAttributes]::ReparsePoint
+    if ($isReparse) {
+        [System.IO.Directory]::Delete($target, $false)
+    } elseif (Test-Path (Join-Path $target 'WORKSPACE.md')) {
+        # Already a fully set-up real isolated dir -- preserve it, do nothing.
+        exit 0
+    }
+}
+
+# Resolve the branch name (fall back to the worktree folder leaf).
+$branch = $null
+try { $branch = (& git -C $worktreePath rev-parse --abbrev-ref HEAD 2>$null) } catch {}
+if (-not $branch) { $branch = Split-Path $worktreePath -Leaf }
+$branch = $branch.Trim()
+
+$date = (Get-Date).ToString('yyyy-MM-dd')
+$isoDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.000Z')
+
+# Create the isolated structure.
+foreach ($d in @('phases', 'debug', 'surveys')) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $target $d) | Out-Null
+}
+
+# Copy the GSD config from the shared root if present.
+$sharedConfig = Join-Path $sharedRoot 'config.json'
+$localConfig = Join-Path $target 'config.json'
+if ((Test-Path $sharedConfig) -and -not (Test-Path $localConfig)) {
+    Copy-Item $sharedConfig $localConfig -Force
+}
+
+# Seed the three manifest files (only if missing -- never overwrite existing).
+$workspaceFile = Join-Path $target 'WORKSPACE.md'
+if (-not (Test-Path $workspaceFile)) {
+    $workspace = @"
+# Workspace: $branch
+
+Created: $date
+Strategy: worktree (git-wt)
+Branch: $branch
+Repo: $worktreePath
+
+## Isolation
+
+This ``.planning`` is a REAL, isolated directory (not a junction to the shared root).
+Phases and STATE.md here are private to this worktree. Changes do NOT bleed into
+other worktrees or the shared root. Created automatically by the git-wt pre-start
+hook (link-planning.ps1), per the per-worktree isolation model.
+
+## Member Repos
+
+| Repo | Source | Branch | Strategy |
+|------|--------|--------|----------|
+| worldwideview | C:\dev\wwv\worldwideview | $branch | worktree |
+
+## Notes
+
+Cross-feature docs are NOT duplicated here. See SHARED-DOCS.md.
+"@
+    Set-Content -LiteralPath $workspaceFile -Value $workspace -Encoding UTF8
+}
+
+$stateFile = Join-Path $target 'STATE.md'
+if (-not (Test-Path $stateFile)) {
+    $state = @"
+---
+gsd_state_version: 1.0
+milestone: none
+milestone_name: $branch
+status: idle
+last_updated: "$isoDate"
+last_activity: $date -- isolated .planning created (git-wt pre-start hook)
+progress:
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
+---
+
+# Project State
+
+## Project Reference
+
+This is an ISOLATED worktree workspace. Its planning state is private to the
+``$branch`` worktree and intentionally distinct from the shared root
+(C:\dev\wwv\.planning).
+
+Cross-feature docs (ROADMAP, MILESTONES, research) are NOT duplicated here.
+See SHARED-DOCS.md for how to reach them.
+
+## Current Position
+
+No active milestone. Workspace is idle.
+"@
+    Set-Content -LiteralPath $stateFile -Value $state -Encoding UTF8
+}
+
+$sharedDocsFile = Join-Path $target 'SHARED-DOCS.md'
+if (-not (Test-Path $sharedDocsFile)) {
+    $sharedDocs = @"
+# Shared Cross-Feature Docs
+
+This worktree's ``.planning`` is isolated (phases + STATE are private). But some
+documents are cross-feature and must stay authoritative in ONE place rather than
+being copied per worktree (copies drift out of sync).
+
+## Where they live
+
+Shared root: ``C:\dev\wwv\.planning``
+
+| Doc | Purpose |
+|-----|---------|
+| ROADMAP.md | Cross-milestone roadmap |
+| MILESTONES.md | Milestone definitions and ship status |
+| research/ | ARCHITECTURE / FEATURES / PITFALLS / STACK |
+| PROJECT.md | Project identity |
+| REQUIREMENTS.md | Cross-cutting requirements |
+
+## How to reach them
+
+A ``WWV_SHARED_PLANNING`` env var in each worktree's ``.env.local`` points at the
+shared root, and GSD skills that need a cross-feature doc read
+``\$WWV_SHARED_PLANNING/<doc>`` instead of the local ``.planning/<doc>``.
+
+Do NOT copy these docs into this worktree. Single source of truth lives at the
+shared root.
+"@
+    Set-Content -LiteralPath $sharedDocsFile -Value $sharedDocs -Encoding UTF8
+}
+
+# Always report success: the internal git probe above may set a non-zero $LASTEXITCODE,
+# which would otherwise be propagated as this hook's exit code and read as a failure.
+exit 0

--- a/.agents/scripts/unlink-planning.ps1
+++ b/.agents/scripts/unlink-planning.ps1
@@ -1,7 +1,29 @@
 param([string]$worktreePath)
+
+# git-wt (Worktrunk) pre-remove hook.
+# Per the per-worktree isolation model, a worktree's .planning is a REAL isolated
+# directory (its phase history is archived by /branch-cleanup before removal, and the
+# directory itself is deleted along with the worktree by `git-wt remove`).
+#
+# This hook therefore ONLY cleans up a leftover JUNCTION from the old shared-link model.
+# It must NEVER recursively delete a real .planning directory -- doing so would destroy
+# phase history that /branch-cleanup is responsible for archiving.
+
 # Convert Unix-style path (/c/dev/...) to Windows path (C:\dev\...) if needed
 if ($worktreePath -match '^/([a-zA-Z])/(.+)$') {
     $worktreePath = $matches[1].ToUpper() + ':/' + $matches[2]
 }
 $target = Join-Path $worktreePath '.planning'
-if (Test-Path $target) { Remove-Item $target -Force }
+
+if (Test-Path $target) {
+    $item = Get-Item -LiteralPath $target -Force
+    $isReparse = ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq [IO.FileAttributes]::ReparsePoint
+    if ($isReparse) {
+        # Old-model junction: remove only the reparse point (do not follow into the target).
+        [System.IO.Directory]::Delete($target, $false)
+    }
+    # Real directory: leave it. git-wt remove deletes the worktree (and this dir) anyway;
+    # /branch-cleanup is responsible for archiving its phase history first.
+}
+
+exit 0


### PR DESCRIPTION
## What

Rewrites the two git-wt (Worktrunk) `.planning` lifecycle hooks to match the per-worktree isolation model.

**`link-planning.ps1`** (pre-start, runs on every worktree creation):
- Before: deleted any `.planning` and replaced it with a **junction** to the shared root `C:\dev\wwv\.planning`.
- After: creates a **real, isolated `.planning`** (`phases/`, `debug/`, `surveys/` + `config.json` + `WORKSPACE.md` / `STATE.md` / `SHARED-DOCS.md` in the same format the other worktrees use).
- Idempotent: an existing real `.planning` with a `WORKSPACE.md` is left untouched; a leftover junction is converted to a real dir; nothing-there gets a fresh real dir.

**`unlink-planning.ps1`** (pre-remove):
- Before: `Remove-Item -Force` on `.planning` (misleading under the new model).
- After: removes **only** a leftover junction reparse point; never recurses into a real dir. Phase history is archived by `/branch-cleanup` before removal.

Both scripts now `exit 0` explicitly so the internal `git rev-parse` branch probe can't poison the hook exit code.

## Why

The shared-junction behavior was the root cause of GSD phase bleed across simultaneous worktree sessions. PRs #204/#206 fixed the skills (`worktree-bootstrap` Step 5, `planning-sync.sh`, `branch-cleanup`) but left this automatic Worktrunk hook on the old model, so a freshly `git-wt`-created worktree still got a junction until a human ran the bootstrap skill. This closes that gap flagged in `WORKSPACE-OPTIMIZATION-BACKLOG.md`.

## Verify

Run the harness (creates temp worktrees in `$env:TEMP`, no side effects on real worktrees):
- fresh create -> real isolated dir with all subdirs + manifests
- idempotent re-run -> existing phase files preserved
- junction leftover -> converted to real dir, shared root untouched
- unlink on junction -> reparse point removed, shared root intact
- unlink on real dir -> phase history preserved

All 18 checks pass; harness exits 0.

## After merge

The live hook runs the **main** repo working-tree copy (`wt.toml` hardcodes `C:/dev/wwv/worldwideview/.agents/scripts/...`). After merge, run `git pull` in `C:\dev\wwv\worldwideview` so the live hook picks up the fix.

Infra-only chore, no app/`package.json` change, so no semver bump (consistent with #204/#206).