### PR TITLE
feat(cli): non-interactive plugin scaffolding via flags

### DIFF
--- a/.agents/agents/plugin-implementer.md
+++ b/.agents/agents/plugin-implementer.md
@@ -31,11 +31,29 @@ If any are missing, ask the user or tell them to run plugin-researcher first.
 From the project root (`C:\dev\wwv\worldwideview`):
 
 ```bash
-node packages/wwv-cli/dist/index.js create <name> --local
+# Build the CLI first if dist/ is missing (dist is gitignored; fresh worktrees lack it):
+#   pnpm --filter @worldwideview/wwv-cli build
+#
+# The CLI accepts flags for every prompt. Pass them all + --yes for a fully
+# non-interactive scaffold (omit any flag to be prompted for just that value):
+node packages/wwv-cli/dist/index.js create <name> \
+  --display-name "<Display Name>" \
+  --description "<short description>" \
+  --category <aviation|maritime|space|weather|custom> \
+  --architecture <polling|websocket> \
+  --seeder-tier <community|private> \
+  --render-style <billboard|model|point> \
+  --yes
 pnpm install
 ```
 
-This creates `local-plugins/wwv-plugin-<name>/`. Verify it exists before proceeding.
+This creates `local-plugins/wwv-plugin-<name>/`. With `--architecture websocket` it also
+creates the seeder at `local-seeders/<tier>/packages/<name>/` (correct community/private
+layout: `package.json` + `tsup.config.ts` + `src/index.ts`). Verify both exist before proceeding.
+
+> The CLI scaffolds the seeder into `local-seeders/<tier>/packages/<name>/` already —
+> no post-CLI move is required. (Older CLI versions dropped a bare `seeder.mjs` at
+> `local-seeders/<tier>/<name>/`; if you ever see that, the CLI is out of date — rebuild it.)
 
 **NEVER:**
 - Scaffold manually (always use the CLI)

--- a/packages/wwv-cli/package.json
+++ b/packages/wwv-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldwideview/wwv-cli",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "description": "WorldWideView CLI",
   "main": "dist/index.js",

--- a/packages/wwv-cli/src/commands/create.ts
+++ b/packages/wwv-cli/src/commands/create.ts
@@ -4,29 +4,74 @@ import fs from 'fs';
 import path from 'path';
 import prompts from 'prompts';
 
+const VALID_CATEGORIES = ['aviation', 'maritime', 'space', 'weather', 'custom'];
+const VALID_ARCHITECTURES = ['polling', 'websocket'];
+const VALID_SEEDER_TIERS = ['community', 'private'];
+const VALID_RENDER_STYLES = ['billboard', 'model', 'point'];
+
+interface CreateOptions {
+  core?: boolean;
+  displayName?: string;
+  description?: string;
+  category?: string;
+  architecture?: string;
+  seederTier?: string;
+  renderStyle?: string;
+  yes?: boolean;
+}
+
+function assertChoice(label: string, value: string | undefined, valid: string[]): void {
+  if (value !== undefined && !valid.includes(value)) {
+    console.error(`Error: invalid --${label} "${value}". Valid values: ${valid.join(', ')}`);
+    process.exit(1);
+  }
+}
+
 export const createCommand = new Command('create')
-  .description('Interactively scaffold a new WorldWideView plugin')
+  .description('Scaffold a new WorldWideView plugin (flags skip the matching prompt; omit them for interactive mode)')
+  .argument('[pluginId]', 'Unique kebab-case plugin ID (e.g. my-tracker)')
   .option('-c, --core', 'Create inside packages instead of local-plugins (for core contributors)')
-  .action(async (options) => {
-    const response = await prompts([
-      {
+  .option('-n, --display-name <name>', 'Display name (e.g. "My Live Tracker")')
+  .option('-d, --description <text>', 'Short description')
+  .option('--category <category>', `One of: ${VALID_CATEGORIES.join(', ')}`)
+  .option('--architecture <architecture>', `One of: ${VALID_ARCHITECTURES.join(', ')}`)
+  .option('--seeder-tier <tier>', `One of: ${VALID_SEEDER_TIERS.join(', ')} (websocket only)`)
+  .option('--render-style <style>', `One of: ${VALID_RENDER_STYLES.join(', ')}`)
+  .option('-y, --yes', 'Non-interactive: fail instead of prompting for missing values')
+  .action(async (pluginIdArg: string | undefined, options: CreateOptions) => {
+    // Validate any flags supplied up front so we fail fast and consistently.
+    assertChoice('category', options.category, VALID_CATEGORIES);
+    assertChoice('architecture', options.architecture, VALID_ARCHITECTURES);
+    assertChoice('seeder-tier', options.seederTier, VALID_SEEDER_TIERS);
+    assertChoice('render-style', options.renderStyle, VALID_RENDER_STYLES);
+
+    // Build the prompt list, skipping any value already supplied via flag/arg.
+    // In --yes mode we never prompt; missing required values are an error.
+    const promptList: prompts.PromptObject[] = [];
+
+    if (!pluginIdArg) {
+      promptList.push({
         type: 'text',
         name: 'pluginId',
         message: 'What is the unique ID for your plugin? (e.g. my-tracker)',
-        validate: value => value.length > 0 ? true : 'Plugin ID is required'
-      },
-      {
+        validate: value => value.length > 0 ? true : 'Plugin ID is required',
+      });
+    }
+    if (options.displayName === undefined) {
+      promptList.push({
         type: 'text',
         name: 'displayName',
         message: 'What is the display name? (e.g. My Live Tracker)',
-        initial: (prev: string) => prev.replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())
-      },
-      {
-        type: 'text',
-        name: 'description',
-        message: 'Enter a short description:'
-      },
-      {
+        initial: pluginIdArg
+          ? pluginIdArg.replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())
+          : undefined,
+      });
+    }
+    if (options.description === undefined) {
+      promptList.push({ type: 'text', name: 'description', message: 'Enter a short description:' });
+    }
+    if (options.category === undefined) {
+      promptList.push({
         type: 'select',
         name: 'category',
         message: 'Which category does this plugin belong to?',
@@ -35,45 +80,70 @@ export const createCommand = new Command('create')
           { title: 'Maritime (Ship icon)', value: 'maritime' },
           { title: 'Space (Satellite icon)', value: 'space' },
           { title: 'Weather (Cloud icon)', value: 'weather' },
-          { title: 'Custom (Box icon)', value: 'custom' }
-        ]
-      },
-      {
+          { title: 'Custom (Box icon)', value: 'custom' },
+        ],
+      });
+    }
+    if (options.architecture === undefined) {
+      promptList.push({
         type: 'select',
         name: 'architecture',
         message: 'How will your plugin receive data?',
         choices: [
           { title: 'REST Polling / Static Data (Frontend only)', value: 'polling' },
-          { title: 'Real-Time WebSockets (Generates backend seeder)', value: 'websocket' }
-        ]
-      },
-      {
-        type: (prev: string) => prev === 'websocket' ? 'select' : null,
+          { title: 'Real-Time WebSockets (Generates backend seeder)', value: 'websocket' },
+        ],
+      });
+    }
+    if (options.seederTier === undefined) {
+      promptList.push({
+        // Only ask about seeder tier when architecture resolves to websocket.
+        type: (_prev, values) => {
+          const arch = options.architecture ?? values.architecture;
+          return arch === 'websocket' ? 'select' : null;
+        },
         name: 'seederTier',
         message: 'Which tier should your backend seeder belong to?',
         choices: [
           { title: 'Community (Open data, shared)', value: 'community' },
-          { title: 'Private (Requires API keys, restricted)', value: 'private' }
-        ]
-      },
-      {
+          { title: 'Private (Requires API keys, restricted)', value: 'private' },
+        ],
+      });
+    }
+    if (options.renderStyle === undefined) {
+      promptList.push({
         type: 'select',
         name: 'renderStyle',
         message: 'How should entities be rendered on the 3D globe?',
         choices: [
           { title: '2D Billboard (Great for static icons)', value: 'billboard' },
           { title: '3D Model with LOD (Transitions 2D to 3D)', value: 'model' },
-          { title: 'Simple Point (High performance dots)', value: 'point' }
-        ]
-      }
-    ]);
+          { title: 'Simple Point (High performance dots)', value: 'point' },
+        ],
+      });
+    }
 
-    if (!response.pluginId) {
+    if (options.yes && promptList.length > 0) {
+      const missing = promptList.map(p => p.name).join(', ');
+      console.error(`Error: --yes given but these required values are missing: ${missing}`);
+      process.exit(1);
+    }
+
+    const answers = promptList.length > 0 ? await prompts(promptList) : {};
+
+    // Merge flags/args (authoritative) over interactive answers.
+    const pluginId: string | undefined = pluginIdArg ?? answers.pluginId;
+    const displayName: string = options.displayName ?? answers.displayName ?? '';
+    const description: string = options.description ?? answers.description ?? '';
+    const category: string = options.category ?? answers.category;
+    const architecture: string = options.architecture ?? answers.architecture;
+    const seederTier: string | undefined = options.seederTier ?? answers.seederTier;
+    const renderStyle: string = options.renderStyle ?? answers.renderStyle;
+
+    if (!pluginId) {
       console.log('Plugin creation cancelled.');
       return;
     }
-
-    const { pluginId, displayName, description, category, architecture, seederTier, renderStyle } = response;
 
     const targetBaseDir = options.core ? 'packages' : 'local-plugins';
     const pluginDir = path.join(process.cwd(), targetBaseDir, `wwv-plugin-${pluginId}`);
@@ -85,21 +155,19 @@ export const createCommand = new Command('create')
 
     fs.mkdirSync(pluginDir, { recursive: true });
 
-    // Determine category icon
     const iconMap: Record<string, string> = {
       aviation: 'Plane',
       maritime: 'Ship',
       space: 'Satellite',
       weather: 'Cloud',
-      custom: 'Box'
+      custom: 'Box',
     };
     const defaultIcon = iconMap[category] || 'Box';
 
-    // Package.json boilerplate
-    const streamUrlField = architecture === 'websocket' 
-      ? `\n    "streamUrl": "wss://dataenginev2.worldwideview.dev/stream",` 
+    const streamUrlField = architecture === 'websocket'
+      ? `\n    "streamUrl": "wss://dataenginev2.worldwideview.dev/stream",`
       : '';
-      
+
     const packageJsonContent = `{
   "name": "@worldwideview/wwv-plugin-${pluginId}",
   "version": "1.0.0",
@@ -131,7 +199,6 @@ export const createCommand = new Command('create')
 }
 `;
 
-    // index.ts boilerplate
     const renderBoilerplate = {
       billboard: `return {
       type: 'billboard',
@@ -152,14 +219,14 @@ export const createCommand = new Command('create')
       size: 8,
       outlineColor: '#ffffff',
       outlineWidth: 2
-    };`
+    };`,
     }[renderStyle as string] || `return {};`;
 
-    const fetchBoilerplate = architecture === 'polling' 
+    const fetchBoilerplate = architecture === 'polling'
       ? `\n  async fetch(): Promise<GeoEntity[]> {
     // Implement REST polling logic here
     return [];
-  }\n` 
+  }\n`
       : '';
 
     const indexTsContent = `import { WorldPlugin, GeoEntity, CesiumEntityOptions } from '@worldwideview/wwv-plugin-sdk';
@@ -195,41 +262,75 @@ ${fetchBoilerplate}
 
     console.log(`\n✅ Successfully created plugin frontend at ${pluginDir}`);
 
-    // Generate seeder backend if requested
+    // Generate seeder backend if requested. Matches the real community/private
+    // seeder layout: local-seeders/<tier>/packages/<pluginId>/ with a tsup build
+    // and a src/index.ts that exports the canonical { name, cron, fn } shape.
     if (architecture === 'websocket' && seederTier) {
-      const seederDir = path.join(process.cwd(), 'local-seeders', seederTier, pluginId);
-      
-      if (!fs.existsSync(seederDir)) {
-        fs.mkdirSync(seederDir, { recursive: true });
-        
-        const seederContent = `// WWV Data Engine Seeder for ${pluginId}
-export default async function run(context) {
-  console.log('Starting ${displayName} seeder...');
-  
-  // Example: Emit a mock entity to the engine
-  setInterval(() => {
-    context.emit({
-      id: '${pluginId}-mock-1',
-      lat: 0,
-      lng: 0,
-      alt: 10000,
-      heading: 0,
-      velocity: 250,
-      properties: {
-        status: 'active'
-      }
-    });
-  }, 1000);
+      const seederDir = path.join(process.cwd(), 'local-seeders', seederTier, 'packages', pluginId);
+
+      if (fs.existsSync(seederDir)) {
+        console.error(`Warning: Seeder directory ${seederDir} already exists. Skipping seeder scaffold.`);
+      } else {
+        fs.mkdirSync(path.join(seederDir, 'src'), { recursive: true });
+
+        const seederPackageJson = `{
+  "name": "@wwv-seeders/${pluginId}",
+  "version": "1.0.0",
+  "main": "dist/index.mjs",
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "@worldwideview/seeder-sdk": "^1.0.0"
+  }
 }
 `;
-        fs.writeFileSync(path.join(seederDir, 'seeder.mjs'), seederContent);
+
+        const tsupConfig = `import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  clean: true,
+  shims: true,
+  noExternal: [/@wwv-seeders\\/.*/],
+  external: [/^(?!@wwv-seeders)[a-z@].*/],
+});
+`;
+
+        // The seeder's exported `name` MUST equal the frontend plugin id
+        // (kebab-case). See ADR-0002 / data-engine-architecture.md section 6.
+        const seederIndexTs = `import { setLiveSnapshot, fetchWithTimeout, withRetry } from '@worldwideview/seeder-sdk';
+
+async function seed${pluginId.replace(/-/g, '')}() {
+  // TODO: fetch from the real data source and map into GeoEntity-shaped items.
+  const items: Array<{ id: string; lat: number; lon: number; name: string }> = [];
+
+  await setLiveSnapshot('${pluginId}', {
+    source: '${pluginId}',
+    fetchedAt: new Date().toISOString(),
+    items,
+    totalCount: items.length,
+  }, 3600);
+}
+
+export default {
+  name: '${pluginId}', // MUST match the frontend plugin id exactly (kebab-case)
+  cron: '*/15 * * * *',
+  fn: seed${pluginId.replace(/-/g, '')},
+};
+`;
+
+        fs.writeFileSync(path.join(seederDir, 'package.json'), seederPackageJson);
+        fs.writeFileSync(path.join(seederDir, 'tsup.config.ts'), tsupConfig);
+        fs.writeFileSync(path.join(seederDir, 'src', 'index.ts'), seederIndexTs);
         console.log(`✅ Successfully created plugin seeder at ${seederDir}`);
       }
     }
 
     console.log(`\nNext steps:
 1. Run \`pnpm install\` from the project root.
-2. Edit \`index.ts\` in your plugin directory.
-${architecture === 'websocket' ? '3. Edit `seeder.mjs` in your local-seeders directory.' : ''}
+2. Edit \`src/index.ts\` in your plugin directory.
+${architecture === 'websocket' && seederTier ? `3. Edit \`src/index.ts\` in local-seeders/${seederTier}/packages/${pluginId}/, then \`pnpm build\` it.` : ''}
 `);
   });

--- a/packages/wwv-cli/src/index.ts
+++ b/packages/wwv-cli/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name('wwv')
   .description('WorldWideView Plugin CLI')
-  .version('1.1.2');
+  .version('1.3.0');
 
 program.addCommand(createCommand);
 program.addCommand(publishCommand);


### PR DESCRIPTION
## What

Makes `wwv create` scriptable so the **plugin-implementer** agent can scaffold a plugin in one command instead of falling back to slow manual file creation.

## Why

The agent docs told agents to run `create <name> --local` — but `--local` never existed, and the command was prompts-only (no way to answer non-interactively). Agents couldn't drive it, so they hand-built the scaffold (the ~220s scaffold the user noticed). The CLI also wrote the seeder to the wrong path in the wrong shape.

## Changes

- **Flag-driven create**: positional `[pluginId]` + a flag for every prompt (`--display-name`, `--description`, `--category`, `--architecture`, `--seeder-tier`, `--render-style`) and `--yes` to fail fast on missing values. Omitting a flag still prompts, so interactive use is unchanged.
- **Correct seeder layout**: now scaffolds `local-seeders/<tier>/packages/<name>/{package.json,tsup.config.ts,src/index.ts}` matching real community seeders, exporting the canonical `{ name, cron, fn }` with `name === plugin id` (kebab-case) per ADR-0002. Was: a bare `seeder.mjs` at the wrong path with an unusable `context.emit` stub.
- **Docs**: `plugin-implementer.md` drops `--local`, documents the flag invocation + correct seeder path + the CLI build step for fresh worktrees.
- **Version**: CLI bumped to 1.3.0; fixed the stale hardcoded `--version` string (was 1.1.2, package was 1.2.0).

## Verification

- `pnpm build` clean at 1.3.0.
- `create test-plugin --display-name ... --architecture websocket --seeder-tier community --render-style point --yes` → frontend at `local-plugins/wwv-plugin-test-plugin/`, seeder at `local-seeders/community/packages/test-plugin/`, seeder `name: 'test-plugin'` matches plugin id.
- `--yes` with a missing required value exits 1 with a clear message and creates nothing.

> Note: this branch was originally cut for a `/plugin-new` pipeline test; the scope became the CLI fix. The throwaway test scaffolds were removed and are not part of this diff (they live in gitignored nested clones regardless).