### PR TITLE
feat(plugins): plugin management UX overhaul

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.24.5",
+  "version": "2.25.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/src/components/common/PluginIcon.tsx
+++ b/src/components/common/PluginIcon.tsx
@@ -38,8 +38,9 @@ export function PluginIcon({ icon, size = 18, color }: PluginIconProps) {
     if (typeof icon === "string") {
         const Resolved = icons[icon as keyof typeof icons] as LucideIcon | undefined;
         if (Resolved) return <Resolved size={size} color={color} />;
-        // Treat as emoji or text fallback
-        return <span>{icon}</span>;
+        // Emoji: render as text. Unresolved ASCII icon name: render fallback so stale names don't leak as text.
+        if (/[^\x00-\x7F]/.test(icon)) return <span>{icon}</span>;
+        return <FallbackIcon size={size} />;
     }
 
     const IconComponent = icon;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -36,6 +36,7 @@ import { FeedbackDialog } from "@/components/common/FeedbackDialog";
 import { isDemo } from "@/core/edition";
 
 import { injectHostGlobals } from "@/core/plugins/hostGlobals";
+import { getDisabledPluginIds } from "@/core/plugins/pluginPreferences";
 import { initLogCatcher } from "@/lib/logCatcher";
 import { MobileCameraStats } from "./MobileCameraStats";
 import { MobileHudBar } from "./MobileHudBar";
@@ -88,17 +89,7 @@ export function AppShell() {
             await injectHostGlobals();
             setHostReady(true);
 
-            // Fetch disabled built-in plugins before registration
-            let disabledIds = new Set<string>();
-            try {
-                const res = await fetch("/api/marketplace/disabled-builtins");
-                if (res.ok) {
-                    const data = await res.json();
-                    disabledIds = new Set<string>(data.disabledIds ?? []);
-                }
-            } catch {
-                // Non-critical — load all built-ins if endpoint fails
-            }
+            const disabledIds = getDisabledPluginIds();
 
             // Setup demo defaults
             const demoDefaultPlugins = new Set<string>();

--- a/src/components/panels/LayerItem.css
+++ b/src/components/panels/LayerItem.css
@@ -74,6 +74,19 @@
   margin-top: 3px;
 }
 
+/* ─── Local Icon ─────────────────────────────────── */
+.layer-item__local-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.layer-item__local-icon {
+  color: var(--accent-cyan);
+  flex-shrink: 0;
+  cursor: help;
+}
+
 /* ─── Unverified Icon ────────────────────────────── */
 .layer-item__unverified-icon-wrapper {
   position: relative;

--- a/src/components/panels/LayerItem.tsx
+++ b/src/components/panels/LayerItem.tsx
@@ -7,7 +7,7 @@
  * @module src/components/panels
  */
 
-import { ShieldAlert } from "lucide-react";
+import { ShieldAlert, Wrench } from "lucide-react";
 import { PluginIcon } from "@/components/common/PluginIcon";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { pluginManager } from "@/core/plugins/PluginManager";
@@ -27,29 +27,46 @@ const CATEGORY_LABELS: Record<string, string> = {
     custom: "Custom",
 };
 
-// ─── Trust Helpers ──────────────────────────────────────────
+// ─── Source / Trust Helpers ─────────────────────────────────
 
-type TrustTier = "built-in" | "verified" | "unverified";
-
-function getTrust(pluginId: string): TrustTier {
+function isLocalPlugin(pluginId: string): boolean {
     const manifest = pluginManager.getManifest(pluginId);
-    return manifest?.trust ?? "unverified";
+    if (!manifest) return true;
+    const entry = manifest.entry ?? "";
+    return entry.startsWith("/plugins-local/") || entry.startsWith("http://localhost") || entry.startsWith("http://127.0.0.1");
 }
 
-function TrustIcon({ trust }: { trust: TrustTier }) {
-    if (trust !== "unverified") return null;
+function TrustIcon({ pluginId, pluginName }: { pluginId: string; pluginName: string }) {
+    if (isLocalPlugin(pluginId)) {
+        return (
+          <Tooltip content={`Local plugin: ${pluginName}`}>
+            <span className="layer-item__local-icon-wrapper">
+              <Wrench
+                size={11}
+                className="layer-item__local-icon"
+                aria-label="Local plugin"
+              />
+            </span>
+          </Tooltip>
+        );
+    }
 
-    return (
-      <Tooltip content="Unverified plugin, use at your own risk">
-        <span className="layer-item__unverified-icon-wrapper">
-          <ShieldAlert
-            size={12}
-            className="layer-item__unverified-icon"
-            aria-label="Unverified plugin"
-          />
-        </span>
-      </Tooltip>
-    );
+    const manifest = pluginManager.getManifest(pluginId);
+    if (manifest?.trust === "unverified") {
+        return (
+          <Tooltip content="Unverified plugin, use at your own risk">
+            <span className="layer-item__unverified-icon-wrapper">
+              <ShieldAlert
+                size={12}
+                className="layer-item__unverified-icon"
+                aria-label="Unverified plugin"
+              />
+            </span>
+          </Tooltip>
+        );
+    }
+
+    return null;
 }
 
 // ─── LayerItem Component ────────────────────────────────────
@@ -88,8 +105,6 @@ export function LayerItem({
     onToggle,
     onSelect,
 }: LayerItemProps) {
-    const trust = getTrust(plugin.id);
-
     return (
       <div
         className={`layer-item ${isSelected ? "layer-item--selected" : ""}`}
@@ -102,7 +117,7 @@ export function LayerItem({
         <div className="layer-item__info">
           <div className="layer-item__header">
             <span className="layer-item__name">{plugin.name}</span>
-            <TrustIcon trust={trust} />
+            <TrustIcon pluginId={plugin.id} pluginName={plugin.name} />
           </div>
           <div className="layer-item__desc">{plugin.description}</div>
           <div className="layer-item__footer">

--- a/src/components/panels/PluginsTab.css
+++ b/src/components/panels/PluginsTab.css
@@ -69,6 +69,7 @@
 .plugin-item__header {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 1px;
 }
@@ -77,9 +78,7 @@
     font-size: 13px;
     font-weight: 500;
     color: var(--text-primary);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    word-break: break-word;
 }
 
 .plugin-item__version {
@@ -184,6 +183,7 @@
     text-decoration: none;
     font-size: 13px;
     font-weight: 500;
+    text-align: center;
     cursor: pointer;
     transition: all var(--duration-normal) var(--ease-spring);
     flex-shrink: 0%;

--- a/src/components/panels/PluginsTab.tsx
+++ b/src/components/panels/PluginsTab.tsx
@@ -11,12 +11,16 @@
 import { useState, useEffect, useCallback } from "react";
 import {
  Trash2, ExternalLink, RefreshCw, Download, PowerOff, Power,
- ShieldCheck, ShieldAlert, Shield
+ ShieldCheck, ShieldAlert, HardDrive
 } from "lucide-react";
 import { PluginIcon } from "@/components/common/PluginIcon";
+import type { ComponentType } from "react";
 import { pluginManager } from "@/core/plugins/PluginManager";
+import { useStore } from "@/core/state/store";
+import { getDisabledPluginIds, setPluginDisabled } from "@/core/plugins/pluginPreferences";
 import { trackEvent } from "@/lib/analytics";
 import { isPluginInstallEnabled } from "@/core/edition";
+import type { PluginManifest } from "@/core/plugins/PluginManifest";
 import "./PluginsTab.css";
 
 // ─── Types ──────────────────────────────────────────────────
@@ -35,9 +39,9 @@ function TrustBadge({ trust }: { trust: string }) {
     if (trust === "built-in") {
         return (
           <span className="trust-badge trust-badge--builtin">
-            <Shield size={9} />
+            <HardDrive size={9} />
             {' '}
-            Built-in
+            Local
           </span>
         );
     }
@@ -96,13 +100,9 @@ function getTrust(record: PluginRecord): string {
     }
 }
 
-function getIcon(record: PluginRecord): string {
+function getIcon(record: PluginRecord): string | ComponentType<{ size?: number; color?: string }> {
     const managed = pluginManager.getPlugin(record.pluginId);
-    if (managed) {
-        return typeof managed.plugin.icon === "string"
-            ? managed.plugin.icon
-            : "📦";
-    }
+    if (managed) return managed.plugin.icon ?? "📦";
     try {
         return JSON.parse(record.config).icon ?? "📦";
     } catch {
@@ -118,6 +118,11 @@ function getName(record: PluginRecord): string {
     } catch {
         return record.pluginId;
     }
+}
+
+function getVersion(record: PluginRecord): string {
+    if (record.version !== "built-in") return record.version;
+    return pluginManager.getManifest(record.pluginId)?.version ?? "";
 }
 
 // ─── PluginsTab ─────────────────────────────────────────────
@@ -145,7 +150,8 @@ export function PluginsTab() {
             const dbPlugins: PluginRecord[] = data.plugins ?? [];
             const dbPluginMap = new Map(dbPlugins.map((p) => [p.pluginId, p]));
 
-            // Add built-in and local plugins that don't have a DB record yet (enabled by default)
+            // Add built-in and local plugins that don't have a DB record yet
+            const disabledIds = getDisabledPluginIds();
             const allManaged = pluginManager.getAllPlugins();
             for (const managed of allManaged) {
                 if (!dbPluginMap.has(managed.plugin.id)) {
@@ -154,10 +160,15 @@ export function PluginsTab() {
                         version: "built-in",
                         config: "{}",
                         installedAt: new Date().toISOString(),
-                        enabled: true
+                        enabled: !disabledIds.has(managed.plugin.id)
                     });
                 }
             }
+
+            // Apply localStorage disabled state to all records
+            dbPlugins.forEach((p) => {
+                if (disabledIds.has(p.pluginId)) p.enabled = false;
+            });
 
             setPlugins(dbPlugins);
             if (typeof data.canManagePlugins === "boolean") {
@@ -192,32 +203,48 @@ export function PluginsTab() {
 
     const handleDisable = async (pluginId: string) => {
         setRemoving(pluginId);
-        try {
-            await fetch("/api/marketplace/disable", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ pluginId }),
-            });
-            trackEvent("plugin-disable", { plugin: pluginId });
-            setNeedsReload(true);
-        } catch {
-            setRemoving(null);
-        }
+        setPluginDisabled(pluginId, true);
+        pluginManager.disablePlugin(pluginId);
+        const state = useStore.getState();
+        state.setLayerEnabled(pluginId, false);
+        state.clearEntities(pluginId);
+        state.setEntityCount(pluginId, 0);
+        if (state.hoveredEntity?.pluginId === pluginId) state.setHoveredEntity(null, null);
+        if (state.selectedEntity?.pluginId === pluginId) state.setSelectedEntity(null);
+        setNeedsReload(true);
+        trackEvent("plugin-disable", { plugin: pluginId });
+        await loadPlugins();
+        setRemoving(null);
     };
 
     const handleEnable = async (pluginId: string) => {
         setRemoving(pluginId);
-        try {
-            await fetch("/api/marketplace/enable", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ pluginId }),
-            });
-            trackEvent("plugin-enable", { plugin: pluginId });
-            setNeedsReload(true);
-        } catch {
-            setRemoving(null);
+        setPluginDisabled(pluginId, false);
+        setNeedsReload(false);
+
+        const alreadyRegistered = pluginManager.getPlugin(pluginId);
+        if (!alreadyRegistered) {
+            // Plugin was disabled at startup — its script was never loaded.
+            // Hot-load the script so it's available; leave the layer toggle off.
+            try {
+                const res = await fetch("/api/marketplace/load");
+                if (res.ok) {
+                    const { manifests } = await res.json() as { manifests: PluginManifest[] };
+                    const manifest = manifests.find((m) => m.id === pluginId);
+                    if (manifest) {
+                        await pluginManager.loadFromManifest(manifest);
+                        useStore.getState().initLayer(pluginId, false);
+                    }
+                }
+            } catch (err) {
+                console.error("[PluginsTab] Failed to hot-load plugin:", pluginId, err);
+            }
         }
+        // Layer stays off — user controls it via the Data Layers toggle.
+
+        trackEvent("plugin-enable", { plugin: pluginId });
+        await loadPlugins();
+        setRemoving(null);
     };
 
     const handleCheckUpdates = async () => {
@@ -352,10 +379,12 @@ export function PluginsTab() {
                   <span className="plugin-item__name">
                     {getName(record)}
                   </span>
+                  {getVersion(record) && (
                   <span className="plugin-item__version">
                     v
-                    {record.version}
+                    {getVersion(record)}
                   </span>
+                  )}
                 </div>
                 <div className="plugin-item__meta">
                   <TrustBadge trust={getTrust(record)} />
@@ -415,10 +444,12 @@ export function PluginsTab() {
                       <span className="plugin-item__name">
                         {getName(record)}
                       </span>
+                      {getVersion(record) && (
                       <span className="plugin-item__version">
                         v
-                        {record.version}
+                        {getVersion(record)}
                       </span>
+                      )}
                     </div>
                     <div className="plugin-item__meta">
                       <TrustBadge trust={getTrust(record)} />

--- a/src/core/hooks/useMarketplaceSync.ts
+++ b/src/core/hooks/useMarketplaceSync.ts
@@ -10,6 +10,7 @@ import {
   getApprovedUnverifiedIds,
   approveUnverifiedPlugin,
 } from "@/lib/marketplace/trustedPlugins";
+import { getDisabledPluginIds } from "@/core/plugins/pluginPreferences";
 import { isDemo } from "@/core/edition";
 
 /**
@@ -66,6 +67,7 @@ export function useMarketplaceSync(hostReady: boolean) {
 
     async function loadManifest(manifest: PluginManifest) {
         if (!manifest.id || loadedIds.current.has(manifest.id)) return;
+        if (getDisabledPluginIds().has(manifest.id)) return;
         if (pluginManager.getPlugin(manifest.id)) {
             loadedIds.current.add(manifest.id);
             return;

--- a/src/core/plugins/pluginPreferences.ts
+++ b/src/core/plugins/pluginPreferences.ts
@@ -1,0 +1,25 @@
+const DISABLED_KEY = "wwv-disabled-plugins";
+
+export function getDisabledPluginIds(): Set<string> {
+    try {
+        const raw = localStorage.getItem(DISABLED_KEY);
+        if (!raw) return new Set();
+        return new Set<string>(JSON.parse(raw));
+    } catch {
+        return new Set();
+    }
+}
+
+export function setPluginDisabled(pluginId: string, disabled: boolean): void {
+    try {
+        const ids = getDisabledPluginIds();
+        if (disabled) {
+            ids.add(pluginId);
+        } else {
+            ids.delete(pluginId);
+        }
+        localStorage.setItem(DISABLED_KEY, JSON.stringify([...ids]));
+    } catch {
+        // ignore storage errors
+    }
+}

--- a/src/plugins/geojson/geojson-importer.css
+++ b/src/plugins/geojson/geojson-importer.css
@@ -24,28 +24,36 @@
 }
 
 .geojson-btn--primary {
-    background: linear-gradient(135deg, #00e5ff 0%, #00b0ff 100%);
-    color: #0a0e17;
+    background: var(--bg-glass);
+    color: var(--text-primary);
+    border: 1px solid rgba(var(--accent-rgb), 0.3);
 }
 
 .geojson-btn--primary:hover:not(:disabled) {
-    box-shadow: 0 0 16px rgba(0, 229, 255, 0.4);
+    background: var(--bg-glass-hover);
+    box-shadow: var(--glass-shadow-inner);
     transform: translateY(-1px);
+}
+
+.geojson-btn--primary:active:not(:disabled) {
+    transform: scale(0.98);
 }
 
 .geojson-btn--primary:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
 }
 
 .geojson-btn--secondary {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--bg-glass);
     color: var(--text-primary);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    border: 1px solid var(--glass-border-inner);
 }
 
 .geojson-btn--secondary:hover:not(:disabled) {
-    background: rgba(255, 255, 255, 0.14);
+    background: var(--bg-glass-hover);
 }
 
 .geojson-btn--secondary:disabled {
@@ -87,7 +95,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 16px 20px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid var(--glass-border-inner);
 }
 
 .geojson-modal__header h3 {
@@ -117,7 +125,7 @@
     display: flex;
     gap: 4px;
     padding: 12px 20px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid var(--glass-border-inner);
 }
 
 .geojson-tab {
@@ -136,13 +144,13 @@
 }
 
 .geojson-tab:hover {
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(var(--accent-rgb), 0.06);
     color: var(--text-primary);
 }
 
 .geojson-tab--active {
-    background: rgba(0, 229, 255, 0.12);
-    color: #00e5ff;
+    background: rgba(var(--accent-rgb), 0.12);
+    color: var(--accent-cyan);
 }
 
 /* ─── Body ────────────────────────────────────────────────── */
@@ -163,7 +171,7 @@
     justify-content: center;
     gap: 8px;
     padding: 32px 20px;
-    border: 2px dashed rgba(255, 255, 255, 0.15);
+    border: 2px dashed rgba(var(--accent-rgb), 0.2);
     border-radius: 10px;
     color: var(--text-muted);
     cursor: pointer;
@@ -173,9 +181,9 @@
 
 .geojson-dropzone:hover,
 .geojson-dropzone--active {
-    border-color: #00e5ff;
-    background: rgba(0, 229, 255, 0.04);
-    color: #00e5ff;
+    border-color: var(--accent-cyan);
+    background: rgba(var(--accent-rgb), 0.04);
+    color: var(--accent-cyan);
 }
 
 .geojson-dropzone p {
@@ -194,9 +202,9 @@
     width: 100%;
     min-height: 140px;
     padding: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--glass-border-inner);
     border-radius: 8px;
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--bg-secondary);
     color: var(--text-primary);
     font-family: "JetBrains Mono", "Fira Code", monospace;
     font-size: 12px;
@@ -206,7 +214,7 @@
 
 .geojson-textarea:focus {
     outline: none;
-    border-color: #00e5ff;
+    border-color: var(--accent-cyan);
 }
 
 /* ─── Inputs ──────────────────────────────────────────────── */
@@ -214,9 +222,9 @@
 .geojson-input {
     width: 100%;
     padding: 8px 12px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--glass-border-inner);
     border-radius: 6px;
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--bg-secondary);
     color: var(--text-primary);
     font-size: 13px;
     transition: border-color 0.2s;
@@ -224,7 +232,7 @@
 
 .geojson-input:focus {
     outline: none;
-    border-color: #00e5ff;
+    border-color: var(--accent-cyan);
 }
 
 .geojson-input::placeholder {
@@ -245,7 +253,7 @@
     width: 32px;
     height: 32px;
     padding: 0;
-    border: 2px solid rgba(255, 255, 255, 0.15);
+    border: 2px solid var(--glass-border-inner);
     border-radius: 6px;
     background: none;
     cursor: pointer;
@@ -256,8 +264,8 @@
 .geojson-preview {
     padding: 10px 14px;
     border-radius: 8px;
-    background: rgba(0, 229, 255, 0.06);
-    border: 1px solid rgba(0, 229, 255, 0.15);
+    background: rgba(var(--accent-rgb), 0.06);
+    border: 1px solid rgba(var(--accent-rgb), 0.15);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -299,7 +307,7 @@
     justify-content: flex-end;
     gap: 8px;
     padding: 12px 20px;
-    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    border-top: 1px solid var(--glass-border-inner);
 }
 
 /* ─── Layer List ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Wrench icon badge on Data Layers panel for locally-installed plugins
- Plugin disable/enable now works without a page reload — disable persists to localStorage, enable hot-loads the script dynamically
- GeoJSON importer fully re-themed using CSS variables (no hardcoded cyan)

## Changes
- `pluginPreferences.ts` — new localStorage helper for disabled plugin IDs
- `AppShell.tsx` / `useMarketplaceSync.ts` — skip loading disabled plugins at startup
- `PluginsTab.tsx` — disable stops plugin immediately + shows reload banner; enable hot-loads script + clears banner; layer stays off until user toggles it
- `LayerItem.tsx/css` — wrench icon with tooltip for local plugins
- `PluginIcon.tsx` — graceful fallback for unknown/renamed Lucide icon names
- `geojson-importer.css` — all hardcoded `#00e5ff` replaced with `var(--accent-cyan)` / `var(--accent-rgb)` / `var(--bg-secondary)`

## Test Plan
- [ ] Disable a plugin — layer clears immediately, reload banner appears
- [ ] Re-enable the same plugin without reloading — banner clears, plugin available
- [ ] Reload with plugin disabled — plugin stays off, icon shows correctly
- [ ] Local plugin layers show wrench icon with plugin name tooltip
- [ ] GeoJSON importer looks correct on all themes (dark, light, navy)