### PR TITLE
Fix UTF-8 corruption in OSM search & add web setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.31.2",
+  "version": "2.31.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Setup script for Claude Code on the web (and any fresh CI/container clone).
+#
+# Point your remote environment's "setup script" at this file, e.g.:
+#     bash scripts/web-setup.sh
+#
+# It is idempotent and safe to re-run. It resolves the repo root from its own
+# location, so it works no matter which directory the environment invokes it
+# from — fixing the `npm error path /home/user/package.json` failure caused by
+# running a package manager from the wrong working directory.
+set -euo pipefail
+
+# Resolve the repo root relative to this script, not the caller's CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[web-setup] Repo root: $REPO_ROOT"
+
+# This is a pnpm monorepo (see pnpm-workspace.yaml). Never use npm/npm ci here.
+# Corepack ships with Node 20+; activate the pinned pnpm from package.json's
+# `packageManager` field if pnpm isn't already on PATH.
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[web-setup] pnpm not found on PATH; enabling via corepack"
+  corepack enable
+  corepack prepare pnpm@9.15.4 --activate
+fi
+
+echo "[web-setup] Using pnpm $(pnpm -v) / node $(node -v)"
+
+# Install workspace dependencies. Use `install` (not `--frozen-lockfile`) so the
+# container's dependency cache is reused across sessions for faster startup.
+pnpm install
+
+# Generate the Prisma client so TypeScript, ESLint and Vitest can resolve
+# @prisma/client types. `prisma generate` reads prisma/schema.prisma only and
+# does NOT require a live database connection.
+pnpm exec prisma generate
+
+echo "[web-setup] Setup complete — dependencies installed and Prisma client generated."

--- a/src/app/api/plugins/osm-search/route.ts
+++ b/src/app/api/plugins/osm-search/route.ts
@@ -23,9 +23,15 @@ async function tryMirror(urlStr: string, query: string, timeoutMs: number) {
             },
             timeout: timeoutMs,
         }, (res) => {
-            let data = "";
-            res.on("data", (chunk) => data += chunk);
+            // Collect raw Buffer chunks and decode the full body as UTF-8 once.
+            // Concatenating Buffers into a string per-chunk (`data += chunk`) decodes
+            // each chunk independently, which corrupts any multi-byte UTF-8 character
+            // (e.g. Cyrillic names) that straddles a chunk boundary — common on large
+            // Overpass responses. Buffering first keeps multi-byte sequences intact.
+            const chunks: Buffer[] = [];
+            res.on("data", (chunk: Buffer) => chunks.push(chunk));
             res.on("end", () => {
+                const data = Buffer.concat(chunks).toString("utf8");
                 resolve({
                     ok: res.statusCode && res.statusCode >= 200 && res.statusCode < 300,
                     status: res.statusCode || 500,


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the OSM search API where multi-byte UTF-8 characters (e.g., Cyrillic names) were corrupted when they straddled HTTP response chunk boundaries. It also adds a new idempotent setup script for web deployments and CI environments.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Changes Made

### 1. **Fix UTF-8 Corruption in OSM Search** (`src/app/api/plugins/osm-search/route.ts`)
   - **Problem**: Concatenating Buffer chunks into a string per-chunk (`data += chunk`) decodes each chunk independently, corrupting multi-byte UTF-8 sequences that span chunk boundaries. This is especially common on large Overpass API responses with non-Latin characters.
   - **Solution**: Buffer all raw chunks first, then decode the complete body as UTF-8 once using `Buffer.concat(chunks).toString("utf8")`.
   - **Impact**: Cyrillic, Arabic, CJK, and other multi-byte character names in OSM search results now render correctly.

### 2. **Add Web Setup Script** (`scripts/web-setup.sh`)
   - New idempotent setup script for fresh CI/container clones and web deployments.
   - Resolves repo root relative to script location (not caller's CWD), fixing `npm error path /home/user/package.json` failures.
   - Activates pnpm via Corepack if not on PATH (Node 20+).
   - Installs workspace dependencies and generates Prisma client (required for TypeScript/ESLint/Vitest type resolution).
   - Safe to re-run multiple times.

### 3. **Version Bump** (`package.json`)
   - Bumped from `2.31.1` → `2.31.3` (patch for bug fix + setup tooling).

## Testing

- [x] Existing tests pass (no new test files needed; this is a straightforward buffer handling fix)
- [x] Manual verification: OSM search with Cyrillic/non-Latin characters now decodes correctly
- [x] Setup script is idempotent and works from any directory

## Notes for Reviewer

The UTF-8 fix is a common Node.js gotcha: string concatenation of Buffers triggers implicit per-chunk decoding. The solution (buffer first, decode once) is the standard pattern for streaming HTTP responses in Node.js.

The setup script follows the monorepo convention (pnpm + Corepack) and is designed to be invoked by CI/container orchestration tools without requiring manual environment setup.

https://claude.ai/code/session_01J9986diBmJ6oCu6dD5A8m9