### PR TITLE
fix(proxy): escape URL in base href to prevent reflected XSS

### DIFF
--- a/src/app/api/camera/proxy/iframe/route.ts
+++ b/src/app/api/camera/proxy/iframe/route.ts
@@ -8,6 +8,18 @@ import { safeFetch } from "@/lib/security/ssrf";
 const MAX_IFRAME_DURATION_MS = 10 * 1000; // 10 seconds timeout for HTML
 
 /**
+ * Escape a string for safe inclusion in an HTML attribute value.
+ */
+function escapeHtmlAttr(s: string): string {
+    return s
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#x27;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+
+/**
  * Proxy for iframe HTML pages.
  * Fetches the target HTML, strips X-Frame-Options and CSP, and injects a <base href="...">
  * so that relative scripts/styles load correctly from the original origin.
@@ -62,7 +74,8 @@ export async function GET(req: NextRequest) {
         let html = await upstream.text();
 
         // Inject <base href="..."> right after <head> or at the very beginning of the document
-        const baseTag = `<base href="${targetUrl}">\n`;
+        const escapedUrl = escapeHtmlAttr(targetUrl);
+        const baseTag = `<base href="${escapedUrl}">\n`;
         if (html.includes("<head>")) {
             html = html.replace("<head>", `<head>\n${baseTag}`);
         } else if (html.includes("<HEAD>")) {


### PR DESCRIPTION
## Summary

This PR fixes a reflected cross-site scripting (XSS) vulnerability in the iframe proxy route (`src/app/api/camera/proxy/iframe/route.ts`). The user-supplied `url` query parameter is interpolated directly into an HTML `<base href="...">` tag without escaping, allowing an attacker to break out of the attribute and inject arbitrary HTML/JavaScript.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Performance improvement

## Related Issue

_No existing issue._

## Changes Made

- Added an `escapeHtmlAttr()` utility function in `src/app/api/camera/proxy/iframe/route.ts` that encodes `&`, `"`, `'`, `<`, and `>` to their HTML entity equivalents.
- Applied the escaping to `targetUrl` before it is interpolated into the `<base href="...">` tag, preventing attribute breakout.

## Testing

- [x] I manually tested this in the browser against a live data source
- [ ] I ran `npm test` and all tests pass
- [ ] I added or updated tests for my changes

**Manual verification:** Confirmed that before the fix, a crafted URL containing quote characters is rendered verbatim into the HTML response, allowing attribute breakout. After the fix, quote and angle-bracket characters are entity-encoded in the output, neutralizing the injection.

## Plugin Checklist (if applicable)

_N/A — this change does not affect any plugin._

## Screenshots / Recordings

_N/A — this is a server-side fix with no UI changes._

## Notes for Reviewer

### Vulnerability details (CWE-79: Reflected XSS)

**Affected code:** `src/app/api/camera/proxy/iframe/route.ts`, the `GET` handler for `/api/camera/proxy/iframe`.

**Data flow:** The `url` query parameter is read from the request at line 26, then interpolated directly into an HTML string at line 65 (before this fix):

```typescript
const baseTag = `<base href="${targetUrl}">\n`;
```

Because `targetUrl` is never escaped, an attacker can inject characters that break out of the `href` attribute. The resulting HTML is returned to the user's browser with `Content-Type: text/html`.

### Proof of Concept

An attacker hosts a minimal HTML page on a server they control (e.g. `http://evil.example.com/page`), then crafts a link like:

```
https://<target>/api/camera/proxy/iframe?url=http://evil.example.com/page"%20onmouseover="alert(document.cookie)
```

The proxy fetches the attacker's page successfully (via `safeFetch`), then injects:

```html
<base href="http://evil.example.com/page" onmouseover="alert(document.cookie)">
```

When the victim's browser renders this response, the injected `onmouseover` event handler fires, executing arbitrary JavaScript in the context of the target origin.

### Threat model

Authentication is conditional — when `isDemo` is true (i.e. demo/community edition), `isAuthEnabled` is false and the endpoint is fully unauthenticated. Even in authenticated mode, any logged-in user can exploit this to target other logged-in users via a crafted link.

The attacker must control a publicly reachable HTTP server so that `safeFetch` succeeds and returns HTML content. This is a trivial precondition.

### Fix rationale

The `escapeHtmlAttr()` function encodes all five characters that can break out of an HTML attribute context (`& " ' < >`). This is the standard mitigation for attribute-context XSS per OWASP. The function is intentionally placed in the same file since it is the only consumer; it can be extracted to a shared utility if needed later.

### Adversarial review

Before submitting, we verified that no existing sanitization or framework-level protection prevents this injection. Next.js API routes return raw `Response` objects — there is no automatic HTML escaping. The `safeFetch` utility validates the target URL for SSRF but does not modify the URL string itself, so the attacker-controlled characters pass through intact. The `url` parameter is used as-is from `searchParams.get("url")` with no intermediate encoding step.