### PR TITLE
fix(ui): stabilize bottom-panel resize drag on webkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.14",
+  "version": "2.48.15",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/src/components/layout/BottomPanelManager.tsx
+++ b/src/components/layout/BottomPanelManager.tsx
@@ -24,6 +24,7 @@ export function BottomPanelManager() {
     );
 
     const isCoveredRef = useRef(false);
+    const isDraggingRef = useRef(false);
 
     useEffect(() => {
         if (activeBottomPanel) {
@@ -39,17 +40,18 @@ export function BottomPanelManager() {
     }, [activeBottomPanel]);
 
     // Pointer-capture drag handlers — attached directly to the resize handle element.
-    // Using setPointerCapture ensures pointermove/pointerup are delivered to the
-    // element even when the pointer leaves it, which is required for webkit
-    // (without capture, webkit drops synthetic pointermove events from Playwright
-    // and from fast real-user drags that leave the element bounds).
+    // setPointerCapture ensures pointermove/pointerup are delivered to the element even
+    // when the pointer leaves its bounds (required for fast real-user drags and Playwright).
+    // isDraggingRef guards the move handler instead of hasPointerCapture, which has
+    // inconsistent behaviour across webkit versions in CI for repeated drag sequences.
     const handleResizePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
         e.currentTarget.setPointerCapture(e.pointerId);
+        isDraggingRef.current = true;
         document.body.classList.add("is-dragging-bottom-panel");
     };
 
     const handleResizePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-        if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+        if (!isDraggingRef.current) return;
         const newHeight = window.innerHeight - e.clientY;
         const clampedHeight = Math.max(120, Math.min(newHeight, window.innerHeight - 100));
         setBottomPanelHeight(clampedHeight);
@@ -57,6 +59,7 @@ export function BottomPanelManager() {
 
     const handleResizePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
         e.currentTarget.releasePointerCapture(e.pointerId);
+        isDraggingRef.current = false;
         document.body.classList.remove("is-dragging-bottom-panel");
     };
 


### PR DESCRIPTION
## What
Guard the bottom-panel resize `pointermove` handler with an `isDraggingRef` flag instead of `hasPointerCapture()`, which behaves inconsistently across webkit versions in CI for repeated drag sequences. `setPointerCapture` still ensures move/up events are delivered when the pointer leaves the handle bounds.

## Why
Salvaged from the now-deleted `feat/phase-2-auth-gate` branch (original commit `d91cc429`) — it was the **only** change on that branch not already merged to `main`. `main` still uses the older `hasPointerCapture` guard (0 uses of `isDraggingRef`), so this webkit/CI drag-stability fix was never upstreamed.

## Verification
- `pnpm test` -> 1004/1004 pass · `pnpm build` -> exit 0.

## Note
Version bumped 2.48.13 -> 2.48.14 (also claimed by #232). Whichever merges second needs a trivial 1-line version resolution.
