### PR TITLE
docs: fix stale path references in .agents/rules/ files

### DIFF
--- a/.agents/rules/cloud-auth-architecture.md
+++ b/.agents/rules/cloud-auth-architecture.md
@@ -2,10 +2,8 @@
 description: Cloud edition implementation details, PostgreSQL Row-Level Security (RLS) isolation, cross-subdomain auth, and cryptographic license keys.
 paths:
   - "src/lib/auth*"
+  - "src/lib/auth/**/*"
   - "src/app/api/auth/**/*"
-  - "src/core/auth.ts"
-  - "src/core/storage.ts"
-  - "src/core/tenant.ts"
 ---
 
 > **SUPERSEDED by ADR-003** (`docs/architecture/decisions/adr-0003-shared-identity-and-ecosystem-auth-host.md`).
@@ -177,13 +175,15 @@ DATABASE_URL=postgresql://...
 
 ## Edition Adapters
 
-Three thin files are all that differs between editions — everything else is edition-unaware:
+Three thin adapter modules provide all edition-specific behaviour -- everything else is edition-unaware:
 
 | Adapter | Local | Cloud | Demo |
 |---|---|---|---|
-| `src/core/auth.ts` | Auth.js `Credentials` (bcrypt + PostgreSQL) | Auth.js `@auth/supabase-adapter` | Disabled |
-| `src/core/storage.ts` | `fs.writeFile()` to `data/` | Supabase Storage SDK | Read-only |
-| `src/core/tenant.ts` | No-op (single tenant) | Sets `app.tenant_id` for RLS | No-op |
+| `src/lib/auth.ts` | Auth.js `Credentials` (bcrypt + PostgreSQL) | Auth.js `@auth/supabase-adapter` | Disabled |
+| Storage adapter (planned) | `fs.writeFile()` to `data/` | Supabase Storage SDK | Read-only |
+| Tenant adapter (planned) | No-op (single tenant) | Sets `app.tenant_id` for RLS | No-op |
+
+> The storage and tenant adapters listed above are planned for the Cloud edition build-out and are not yet implemented as separate files. Auth is fully implemented in `src/lib/auth.ts` and `src/lib/auth.config.ts`.
 
 ---
 

--- a/.agents/rules/deployment-and-testing.md
+++ b/.agents/rules/deployment-and-testing.md
@@ -206,18 +206,10 @@ Hard refresh: `Ctrl+Shift+R`
 
 ## Creating Static OSM Plugins
 
-See full guide: `.agents/skills/osm-static-plugin-creation.md`
+Use the `plugin-new` skill (`.agents/skills/plugin-new/SKILL.md`) to scaffold new plugins, including OSM-based static data plugins. The old `scaffold-osm-plugin.mjs` script and `osm-static-plugin-creation.md` skill were removed; static OSM plugins are now built as standard `bundle` format plugins via the wwv-cli:
 
-**Quick start:**
 ```bash
-node scripts/scaffold-osm-plugin.mjs '{
-  "name": "volcanoes",
-  "displayName": "Volcanoes",
-  "osmTag": "natural=volcano",
-  "icon": "Mountain",
-  "color": "#ef4444",
-  "category": "Natural Disaster"
-}'
+node packages/wwv-cli/dist/index.js create <name> --local
 ```
 
 **Manual Overpass API query (PowerShell):**
@@ -227,26 +219,29 @@ $body = "data=[out:json][timeout:300];(node[$tag];way[$tag];relation[$tag];);out
 Invoke-RestMethod -Uri 'https://overpass-api.de/api/interpreter' -Method Post -Body $body -OutFile 'tmp/raw_data.json'
 ```
 
-**Note:** OSM data is licensed under **ODbL** — include attribution in plugin READMEs.
+**Note:** OSM data is licensed under **ODbL** - include attribution in plugin READMEs.
 
 ---
 
 ## npm Plugin Publishing
 
-See full guide: `.agents/skills/version-control/npm-plugin-publishing.md`
+The `npm-plugin-publishing.md` skill was removed. Use the wwv-cli publish command:
 
 ```bash
-# First-time publish
+# Publish a local plugin
+node packages/wwv-cli/dist/index.js publish <name> [--org <your-org>]
+
+# Or publish directly via pnpm (for packages/ workspace members)
 pnpm publish --workspace=packages/wwv-plugin-<name> --access public
 
-# Future versions — via Trusted Publishing (GitHub Actions CI/CD)
+# Future versions via Trusted Publishing (GitHub Actions CI/CD)
 ```
 
 ---
 
 ## Git / Version Control
 
-See full guide: `.agents/skills/version-control/git-version-control.md`
+The `git-version-control.md` skill was removed. See `.agents/skills/using-git-worktrees/SKILL.md` for worktree workflows and `.agents/skills/branch-cleanup/SKILL.md` for the post-merge teardown flow.
 
 **Commit convention:** `feat:`, `fix:`, `chore:`, `docs:` prefixes.
 **Commit when:** A new feature is completed (per project rules).
@@ -255,7 +250,7 @@ See full guide: `.agents/skills/version-control/git-version-control.md`
 
 ## Security Checks
 
-See full guide: `.agents/skills/security/security-check.md`
+The `security-check.md` skill was removed. Security reviews are handled by the `security-reviewer` agent (`.agents/agents/security-reviewer.md`). Trigger it after any change touching auth routes, API routes, plugin loading, or marketplace flows.
 
 ---
 

--- a/.agents/rules/plugin-architecture.md
+++ b/.agents/rules/plugin-architecture.md
@@ -237,7 +237,7 @@ GET marketplace.worldwideview.dev/api/registry
 - Trust is **always stamped server-side** — no client-side trust claims accepted
 - Registry response cached for **5 minutes** (in-memory on each WWV instance)
 - If registry unreachable, last cached result used; new unknowns default to `unverified`
-- **Managing:** Edit `src/data/verifiedPlugins.ts` in marketplace repo and redeploy
+- **Managing:** Use the marketplace admin API (`/api/admin/registry`) to manage the signed plugin registry. The old `src/data/verifiedPlugins.ts` static file was replaced by database-driven registry management.
 - **Revoking:** Remove plugin ID and redeploy — WWV instances drop trust on next cache refresh
 
 ### Unverified Plugin Warning
@@ -437,7 +437,7 @@ This queries Overpass API, converts to GeoJSON, scaffolds the package, and print
 | Power plants | `power=plant` | 15k |
 | Wind farms | `generator:source=wind` | 50k |
 
-See skill: `.agents/skills/osm-static-plugin-creation.md`
+The `osm-static-plugin-creation.md` skill was removed. Use `node packages/wwv-cli/dist/index.js create <name> --local` to scaffold a new plugin, then populate it with OSM data fetched via the Overpass API.
 
 ---
 
@@ -462,7 +462,7 @@ To solve this friction and make third-party plugin hosting highly intuitive, the
 2. **Backend SDK:** They write simple `.ts` fetch scripts returning `GeoEntity[]` and drop them into a mounted `/seeders` volume.
 3. **Zero Configuration:** The Docker engine hot-reloads these seeders, handles the Redis caching, and exposes standardized REST or WebSocket endpoints automatically. The developer focuses only on fetching data, avoiding all backend infrastructure setup.
 
-See skill: `.agents/skills/data-engine-seeder-creation.md`
+The `data-engine-seeder-creation.md` skill was removed. Seeder implementation rules are documented inline in `.agents/rules/data-engine-architecture.md`. Seeders live in `local-seeders/community/` or `local-seeders/private/` (separate git clones).
 
 ---
 


### PR DESCRIPTION
## Summary

- `cloud-auth-architecture.md`: frontmatter `paths:` listed `src/core/auth.ts`, `src/core/storage.ts`, `src/core/tenant.ts` which were never created. Updated to point at actual `src/lib/auth*` files; storage and tenant adapter rows marked as planned (not yet implemented).
- `deployment-and-testing.md`: four skill links removed -- `.agents/skills/osm-static-plugin-creation.md`, `.agents/skills/version-control/npm-plugin-publishing.md`, `.agents/skills/version-control/git-version-control.md`, `.agents/skills/security/security-check.md`. Each section now describes the current replacement (wwv-cli, existing skills, security-reviewer agent).
- `plugin-architecture.md`: `src/data/verifiedPlugins.ts` was replaced by the database-driven marketplace admin API -- updated the "Managing" bullet. Two stale skill links (`osm-static-plugin-creation.md`, `data-engine-seeder-creation.md`) replaced with notes pointing at the current alternatives.

## References that were investigated and found to be valid (no change)

- `cesium-rendering.md`: `local-plugins/wwv-plugin-satellite` -- directory exists.
- `data-engine-architecture.md`: `local-seeders/community/` and `local-seeders/private/` -- both exist.
- `garbage-collection.md`: `local-seeders` -- directory exists.
- `monorepo-workflow.md`: `local-seeders/community/[name]` and `local-seeders/private/[name]` -- valid template placeholders, not file paths.

## Test plan

- [ ] Read each edited rule file and confirm the replaced links point to paths that exist on disk or clearly describe what was removed.
- [ ] `ls .agents/skills/plugin-new/` -- confirms the plugin-new skill exists as the replacement reference.
- [ ] `ls src/lib/auth.ts` -- confirms the correct auth file path.
- [ ] `ls local-seeders/community/ local-seeders/private/` -- confirms seeder dirs exist.

Closes #185