### PR TITLE
fix(ci-probe): working WS subscribe probe + safe stub + plugin-CI auth bypass

### DIFF
--- a/docker/ci/docker-compose.plugin-ci.yml
+++ b/docker/ci/docker-compose.plugin-ci.yml
@@ -69,6 +69,8 @@ services:
       DB_PATH: /tmp/engine.db
       # Stub seeder reads the target plugin id from this env var
       STUB_PLUGIN_ID: ${PLUGIN_ID}
+      WWV_SKIP_WS_AUTH: "true"
+      NODE_ENV: ci
     volumes:
       # Mount only the stub seeder — no other seeders to avoid contamination
       - ./stub-seeder:/app/seeders/community/stub-seeder:ro

--- a/docker/ci/stub-seeder/dist/index.mjs
+++ b/docker/ci/stub-seeder/dist/index.mjs
@@ -7,10 +7,9 @@
 // fine in CI. Do NOT copy this pattern into real seeders.
 
 const pluginId = process.env.STUB_PLUGIN_ID;
-if (!pluginId) {
-  console.error("[stub-seeder] STUB_PLUGIN_ID env var is required");
-  process.exit(1);
-}
+// When unconfigured (e.g. seeder-CI, where this stub is baked into the shared
+// :ci image but unused), export a nameless module so the seeder-loader skips
+// it instead of crashing the engine.
 
 function makeEntities() {
   const now = new Date().toISOString();
@@ -38,13 +37,14 @@ function makeEntities() {
   ];
 }
 
-export default {
-  name: pluginId,
-  // Run immediately and every 10s — CI doesn't wait for cron schedules
-  cron: "*/10 * * * * *",
-  fn: async (ctx) => {
-    const entities = makeEntities();
-    await ctx.setLiveSnapshot(pluginId, entities, 300);
-    console.log(`[stub-seeder] emitted ${entities.length} entities for ${pluginId}`);
-  },
-};
+export default pluginId
+  ? {
+      name: pluginId,
+      cron: "*/10 * * * * *",
+      fn: async (ctx) => {
+        const entities = makeEntities();
+        await ctx.setLiveSnapshot(pluginId, entities, 300);
+        console.log(`[stub-seeder] emitted ${entities.length} entities for ${pluginId}`);
+      },
+    }
+  : {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.19",
+  "version": "2.48.20",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/packages/wwv-ci-probe/src/ws.test.ts
+++ b/packages/wwv-ci-probe/src/ws.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocketServer } from "ws";
+import { probeWs } from "./ws.js";
+
+let server: WebSocketServer | undefined;
+afterEach(() => { server?.close(); server = undefined; });
+
+function startEngine(opts: { pluginId: string; requireSubscribe: boolean }) {
+  server = new WebSocketServer({ port: 0 });
+  server.on("connection", (sock) => {
+    sock.send(JSON.stringify({ type: "welcome", engine: "test", plugins: [opts.pluginId] }));
+    const send = () =>
+      sock.send(JSON.stringify({ type: "data", pluginId: opts.pluginId, payload: [{ id: "x" }] }));
+    if (!opts.requireSubscribe) { setInterval(send, 20); return; }
+    sock.on("message", (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.action === "subscribe" && msg.pluginId === opts.pluginId) send();
+    });
+  });
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return `ws://127.0.0.1:${port}/stream`;
+}
+
+describe("probeWs", () => {
+  it("receives data from a subscribe-required engine (sends subscribe frame)", async () => {
+    const url = startEngine({ pluginId: "stub", requireSubscribe: true });
+    const ok = await probeWs({ name: "stub", wsUrl: url, timeoutMs: 3000 });
+    expect(ok).toBe(true);
+  });
+  it("times out (false) when the plugin never produces data", async () => {
+    const url = startEngine({ pluginId: "other", requireSubscribe: true });
+    const ok = await probeWs({ name: "stub", wsUrl: url, timeoutMs: 800 });
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/wwv-ci-probe/src/ws.ts
+++ b/packages/wwv-ci-probe/src/ws.ts
@@ -31,7 +31,11 @@ export async function probeWs(opts: {
     }, opts.timeoutMs);
 
     ws.on("open", () => {
-      console.log(`[ws] connected to ${opts.wsUrl}, waiting for pluginId="${opts.name}"`);
+      // The engine is subscribe-required: it only broadcasts a plugin's data to
+      // connections that have subscribed to it (websocket.ts broadcastPluginData).
+      // Auth is bypassed in CI via WWV_SKIP_WS_AUTH=true, so no auth frame is sent.
+      ws.send(JSON.stringify({ action: "subscribe", pluginId: opts.name }));
+      console.log(`[ws] connected to ${opts.wsUrl}, subscribed to pluginId="${opts.name}"`);
     });
 
     ws.on("message", (raw) => {


### PR DESCRIPTION
## What (Plan 2, Repo A)

Makes the CI integration probe actually work against the data engine, plus a safety fix.

- **Probe WS fix (the core bug):** investigation confirmed the engine's `/stream` is **subscribe-required** (`broadcastPluginData` only sends to connections subscribed to that pluginId). The probe previously connected and only listened, so it received nothing and always timed out. It now sends `{ action: "subscribe", pluginId }` on open. Auth is bypassed in CI via `WWV_SKIP_WS_AUTH=true`, so no auth frame is sent (correct: the probe is CI-only and would be rejected by a production engine).
- **Safe stub seeder:** the CI stub used `process.exit(1)` when `STUB_PLUGIN_ID` was unset, which would crash the shared `:ci` engine in seeder-CI. It now exports a nameless module so the seeder loader skips it when unconfigured.
- **plugin-CI compose:** added `WWV_SKIP_WS_AUTH: "true"` and `NODE_ENV: ci` (the auth bypass refuses to run under `NODE_ENV=production`).

## Verify

- `pnpm exec vitest run packages/wwv-ci-probe` -> 11 pass, including a new `ws.test.ts` that stands up a subscribe-required `ws` server and confirms the probe now receives data (and still times out correctly when the plugin produces nothing).
- Probe builds clean.

## Related

Builds on PR #236 (CI foundation). Paired with the wwv-data-engine `:ci` image PR (Plan 2 Repo B), which bakes the stub so plugin-CI has deterministic data. End-to-end verification runs once both land and `:ci` is published.
