### PR TITLE
fix(ci): stub seeder interval+fetch + drop redundant compose mount

### DIFF
--- a/docker/ci/docker-compose.plugin-ci.yml
+++ b/docker/ci/docker-compose.plugin-ci.yml
@@ -18,18 +18,12 @@
 # Reuse the pattern from worldwideview/tests/global.setup.ts. DB migrations
 # are handled automatically by the wwv-app entrypoint at container start.
 #
-# ─── Known foundation gap (deferred) ───
+# ─── Stub seeder source ───
 #
-# The stub-seeder is mounted via `./stub-seeder:/app/seeders/community/stub-seeder`
-# below — a path RELATIVE to this compose file. When a consumer repo downloads
-# only this YAML, that path resolves to nothing. The clean fix is to bake the
-# stub-seeder into the `wwv-data-engine:ci` image at /app/seeders/community/__ci-stub__/
-# so the compose only needs to set STUB_PLUGIN_ID. That requires a coordinated
-# Dockerfile change in the wwv-data-engine repo — tracked as the next session's
-# first task.
-#
-# Until then, this compose only works when the worldwideview source tree
-# (with docker/ci/stub-seeder/) is the working directory.
+# The stub seeder is baked into the `wwv-data-engine:ci` image at
+# /app/seeders/stub (see wwv-data-engine/Dockerfile.ci). The compose only needs
+# to set STUB_PLUGIN_ID — no volume mount, so a consumer repo can download just
+# this YAML and run it without the worldwideview source tree present.
 #
 # Expected env vars from consuming workflow:
 #   PLUGIN_ID         — kebab-case id of the plugin under test (e.g. "aviation")
@@ -71,9 +65,9 @@ services:
       STUB_PLUGIN_ID: ${PLUGIN_ID}
       WWV_SKIP_WS_AUTH: "true"
       NODE_ENV: ci
-    volumes:
-      # Mount only the stub seeder — no other seeders to avoid contamination
-      - ./stub-seeder:/app/seeders/community/stub-seeder:ro
+    # No volume mount: the stub seeder is baked into the :ci image at
+    # /app/seeders/stub, so the engine discovers it as id "stub" with no host
+    # path dependency.
     depends_on:
       wwv-redis:
         condition: service_healthy

--- a/docker/ci/stub-seeder/dist/index.mjs
+++ b/docker/ci/stub-seeder/dist/index.mjs
@@ -10,6 +10,11 @@ const pluginId = process.env.STUB_PLUGIN_ID;
 // When unconfigured (e.g. seeder-CI, where this stub is baked into the shared
 // :ci image but unused), export a nameless module so the seeder-loader skips
 // it instead of crashing the engine.
+//
+// Uses the interval+fetch seeder contract: fetch() RETURNS the array and the
+// scheduler auto-wraps it into a snapshot stored under the seeder id. The
+// cron+fn contract would require the engine-internal setLiveSnapshot, which is
+// NOT exposed on the seeder ctx (ctx is only { redis }).
 
 function makeEntities() {
   const now = new Date().toISOString();
@@ -40,11 +45,11 @@ function makeEntities() {
 export default pluginId
   ? {
       name: pluginId,
-      cron: "*/10 * * * * *",
-      fn: async (ctx) => {
+      interval: 10000,
+      fetch: async () => {
         const entities = makeEntities();
-        await ctx.setLiveSnapshot(pluginId, entities, 300);
-        console.log(`[stub-seeder] emitted ${entities.length} entities for ${pluginId}`);
+        console.log(`[stub-seeder] emitting ${entities.length} entities for ${pluginId}`);
+        return entities;
       },
     }
   : {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.20",
+  "version": "2.48.21",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",


### PR DESCRIPTION
## What

Companion fix to [wwv-data-engine#14](https://github.com/silvertakana/wwv-data-engine/pull/14). Two changes, both in `docker/ci/`:

1. **Source-of-truth stub** (`docker/ci/stub-seeder/dist/index.mjs`) — switched from the broken **cron+fn** contract (which called the nonexistent `ctx.setLiveSnapshot`) to **interval+fetch**: `fetch()` returns the `GeoEntity[]` and the engine scheduler auto-wraps it into a snapshot stored under the seeder id. Kept in sync with the baked copy in the data-engine repo.

2. **Compose cleanup** (`docker/ci/docker-compose.plugin-ci.yml`) — removed the `./stub-seeder` volume mount and the stale "Known foundation gap (deferred)" comment. The stub is now baked into the `:ci` image at `/app/seeders/stub` (data-engine PR #13), so the compose needs no host path — a consumer repo can run it with only this YAML.

## Why

Plan 2 Task C verification caught that the stub emitted no data (`ctx.setLiveSnapshot is not a function` on every run), so the WS probe received nothing. This is the data source for the entire plugin-CI pipeline (Plan 3), so it had to be fixed before per-plugin CI is built on top of it.

## Verify

After data-engine #14 republishes `:ci`:
```
PLUGIN_ID=stub docker compose -f docker/ci/docker-compose.plugin-ci.yml up -d wwv-redis wwv-data-engine
node packages/wwv-ci-probe/dist/index.js ws stub --url ws://localhost:5000/stream --timeout 30000
```
Expected: exit 0, `[ws] OK — received valid payload for "stub" (shape: items-object)`.

Locally confirmed (with the fixed stub mounted over `/app/seeders/stub` against the published `:ci` image): engine logged `Snapshot saved to Redis for stub`, probe exited 0. Version bumped 2.48.20 → 2.48.21 (patch, `fix:`).
