### PR TITLE
docs(rules): seeder authoring contract + close-context-gaps meta-directive

### DIFF
--- a/.agents/rules/data-engine-architecture.md
+++ b/.agents/rules/data-engine-architecture.md
@@ -89,3 +89,60 @@ This means:
 
 > [!CAUTION]
 > The most common silent bug: seeder sends `{ items: [...] }` (an object), frontend plugin omits `mapWebsocketPayload`. Data arrives but WsClient drops it with a console warning. The globe stays empty. Always implement `mapWebsocketPayload` for any plugin whose seeder sends an object payload.
+
+## 8. Seeder Authoring Contract — the module shape
+
+§7 covers what a seeder **sends**. This covers how you **write** one. The engine
+auto-discovers a seeder by scanning `SEEDERS_DIR` for any folder with
+`dist/index.mjs` and importing its **default export**. The seeder's `id` is the
+**folder name**, not the `name` field. You never call a register function — the
+authoritative reference is `wwv-data-engine/README.md` → "Authoring a Seeder".
+
+The default export is `{ name }` plus **one** of these shapes:
+
+| Shape | You provide | How data is published |
+|---|---|---|
+| `interval` + `fetch(ctx)` | `fetch` **returns** the array | scheduler wraps + stores + broadcasts it for you |
+| `cron` + `fn(ctx)` | `fn` publishes itself | `import { setLiveSnapshot } from '@worldwideview/seeder-sdk'` and call it |
+| `init(ctx)` | a persistent listener | publish via the SDK as push data arrives |
+
+**The trap (this caused a real, silent CI failure):** `ctx` is **only `{ redis }`**.
+There is no `ctx.setLiveSnapshot`. Reaching for it throws at runtime and the
+snapshot never lands. Publish helpers come from `@worldwideview/seeder-sdk`, not
+from `ctx`. The engine now types `ctx` as `SeederContext { redis }`, so this is a
+compile error for any typed seeder — but `.mjs` seeders without type-checking get
+no such safety net, so know the contract.
+
+<bad-example>
+```ts
+// cron + fn reaching for a method that does not exist on ctx
+export default {
+  name: "earthquakes",
+  cron: "0 * * * *",
+  fn: async (ctx) => {
+    await ctx.setLiveSnapshot("earthquakes", items, 3600); // ❌ not a function — dies silently
+  },
+};
+```
+</bad-example>
+
+<good-example>
+```ts
+// Option A — cron + fn: publish via the SDK (dominant idiom)
+import { setLiveSnapshot } from "@worldwideview/seeder-sdk";
+export default {
+  name: "earthquakes",
+  cron: "0 * * * *",
+  fn: async () => {
+    await setLiveSnapshot("earthquakes", { source: "earthquakes", fetchedAt: new Date().toISOString(), items, totalCount: items.length }, 3600);
+  },
+};
+
+// Option B — interval + fetch: just return the array, scheduler does the rest
+export default {
+  name: "earthquakes",
+  interval: 60_000,
+  fetch: async () => items, // ✅ no publishing call needed
+};
+```
+</good-example>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Agents MUST respect these at all times:
 > - **MUST** require explicit user authorization before any state-changing action that isn't simple/safe.
 > - **MUST** ask clarifying questions rather than assume when requirements are unclear.
 > - **MUST** update `.agents/rules/` files immediately whenever an architectural shift invalidates them.
+> - **MUST** close context gaps: when missing/wrong/undocumented context made you err, struggle, or go slow, fix the relevant doc/context (or add a type/guardrail) at its source — or ask the user to update it when it depends on their knowledge. In autonomous mode, log the gap to revisit later. Never fix only the symptom and leave the trap armed for the next contributor.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.22",
+  "version": "2.48.23",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.21",
+  "version": "2.48.22",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",


### PR DESCRIPTION
## What

Adds **§8 "Seeder Authoring Contract"** to `.agents/rules/data-engine-architecture.md`. This rule auto-loads whenever anyone edits `local-seeders/**`, so it reaches contributors (and agents) exactly when they're writing a seeder.

Documents:
- the auto-discovery model (folder with `dist/index.mjs`; id = folder name)
- the three module shapes (`interval+fetch`, `cron+fn`, `init`) and how each publishes
- the `{ redis }`-only `ctx` and why `ctx.setLiveSnapshot` does not exist
- publishing via `@worldwideview/seeder-sdk`
- `<good-example>` / `<bad-example>` blocks (per the repo's XML-tagging convention) contrasting the trap against both correct shapes

## Why

Companion to wwv-data-engine#15. The seeder that broke CI used the nonexistent `ctx.setLiveSnapshot`; the contract was documented nowhere a contributor would look. §7 already covered what a seeder *sends*; this covers how to *write* one.

## Verify

Docs-only. Read §8 of the rule file. Version bumped 2.48.21 → 2.48.22 (patch, `docs:`).
