### PR TITLE
fix(ci): ./-prefix npm publish paths (publish-packages was treating them as git repos)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -67,7 +67,7 @@ jobs:
             echo "@worldwideview/wwv-plugin-sdk@${LOCAL_VERSION} already published — skipping"
           else
             echo "Publishing @worldwideview/wwv-plugin-sdk@${LOCAL_VERSION}"
-            npm publish packages/wwv-plugin-sdk --provenance --access public
+            npm publish ./packages/wwv-plugin-sdk --provenance --access public
           fi
 
       - name: Publish @worldwideview/wwv-lib-incidents
@@ -78,7 +78,7 @@ jobs:
             echo "@worldwideview/wwv-lib-incidents@${LOCAL_VERSION} already published — skipping"
           else
             echo "Publishing @worldwideview/wwv-lib-incidents@${LOCAL_VERSION}"
-            npm publish packages/wwv-lib-incidents --provenance --access public
+            npm publish ./packages/wwv-lib-incidents --provenance --access public
           fi
 
       - name: Publish @worldwideview/wwv-lib-aviation
@@ -89,5 +89,5 @@ jobs:
             echo "@worldwideview/wwv-lib-aviation@${LOCAL_VERSION} already published — skipping"
           else
             echo "Publishing @worldwideview/wwv-lib-aviation@${LOCAL_VERSION}"
-            npm publish packages/wwv-lib-aviation --provenance --access public
+            npm publish ./packages/wwv-lib-aviation --provenance --access public
           fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.24",
+  "version": "2.48.25",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",


### PR DESCRIPTION
The publish-packages run on #241's merge failed: `npm publish packages/wwv-plugin-sdk` made npm interpret the path as a GitHub `user/repo` shorthand and attempt `git ls-remote github.com/packages/wwv-plugin-sdk` (exit 128). Prefixing with `./` forces folder semantics. Verified with `npm publish --dry-run`: bare path reproduces the git error, `./packages/...` packs and reaches the publish step cleanly. Patch bump 2.48.24 → 2.48.25.