### PR TITLE
fix(libs): add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.25",
+  "version": "2.48.26",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/packages/wwv-lib-aviation/package.json
+++ b/packages/wwv-lib-aviation/package.json
@@ -2,6 +2,11 @@
   "name": "@worldwideview/wwv-lib-aviation",
   "version": "1.0.2",
   "description": "Shared abstract base classes for WorldWideView aviation plugins (commercial, military, specialized)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/silvertakana/worldwideview.git",
+    "directory": "packages/wwv-lib-aviation"
+  },
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [

--- a/packages/wwv-lib-incidents/package.json
+++ b/packages/wwv-lib-incidents/package.json
@@ -2,6 +2,11 @@
   "name": "@worldwideview/wwv-lib-incidents",
   "version": "1.0.4",
   "description": "Shared abstract base classes for WorldWideView incident plugins (earthquakes, wildfires, conflicts)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/silvertakana/worldwideview.git",
+    "directory": "packages/wwv-lib-incidents"
+  },
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [


### PR DESCRIPTION
wwv-lib-incidents/aviation publish failed E422 — `--provenance` requires package.json `repository.url` to match the building repo, and both libs lacked it. Added the same `repository` block the SDK uses (it published fine at 1.7.1). Unblocks Task 0.2. Root patch bump 2.48.25 → 2.48.26.