### PR TITLE
fix: reduce plugin build concurrency to prevent Rolldown native stack overflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @worldwideview/wwv-plugin-sdk build
       - run: npx prisma generate
       - run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.48.30",
+  "version": "2.48.31",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/scripts/sync-local-plugins.mjs
+++ b/scripts/sync-local-plugins.mjs
@@ -466,7 +466,7 @@ export async function syncAll() {
         return { built: 0, cached: 0, failed: 0 };
     }
 
-    const concurrency = Math.max(2, Math.min(plugins.length, Math.ceil(os.cpus().length / 2)));
+    const concurrency = Math.max(1, Math.min(plugins.length, 4)); // Reduced from CPUs/2 to avoid Rolldown native crash (STATUS_STACK_BUFFER_OVERRUN)
     console.log(`[sync] Found ${plugins.length} local plugin(s); building with concurrency=${concurrency}`);
     const started = Date.now();
 


### PR DESCRIPTION
Capping concurrent Vite/Rolldown builds at 4 instead of CPUs/2 avoids
a native STATUS_STACK_BUFFER_OVERRUN crash during pnpm dev prebuild.

- concurrency was Math.ceil(os.cpus().length / 2) ~8 on 16-core machines
- Rolldown 0.28 native module overflows stack under high parallelism
- With concurrency=4, all 33 plugins build in ~94s with no crash
