### PR TITLE
docs: lock cross-system auth decisions into ADR-0007 and ADR-0008

### DIFF
--- a/docs/architecture/decisions/adr-0001-decentralized-plugin-auth-and-ssrf-mitigation.md
+++ b/docs/architecture/decisions/adr-0001-decentralized-plugin-auth-and-ssrf-mitigation.md
@@ -119,6 +119,17 @@ The Local App stores the API Key in PostgreSQL. It MUST NOT be stored in plainte
 | **Admin rotates Ed25519 key** | Zero downtime (handled via key overlap in JWKS array). |
 | **User revokes API Key** | Immediate for *new* issuances, up to 5 minutes for active streams. |
 
+### Revision (2026-06-23): Revocation Latency Is a Conscious Business Tradeoff
+
+The up-to-5-minute delay between subscription cancellation and stream termination is **not a technical limitation** — it is a deliberate business decision. The 5-minute JWT lifetime was chosen to limit token-theft impact: a stolen JWT is valid for at most 5 minutes. The tradeoff is that cancellation takes up to 5 minutes to propagate to active streams. This is accepted.
+
+Reducing revocation latency would require either:
+
+1. **Shorter JWT lifetimes** (e.g., 1 minute). This increases marketplace token-mint calls by 5x, increasing load on the marketplace and ticket client.
+2. **A push-based revocation channel** (e.g., Redis pub/sub or WebSocket notification from marketplace to all data engines). This adds significant infrastructure complexity for a marginal improvement in cancellation responsiveness.
+
+Neither tradeoff was deemed worth the cost. The 5-minute window is a balanced choice: long enough to avoid excessive token-minting churn, short enough to bound the window for stolen tokens and late cancellations.
+
 ---
 
 ## The End-to-End Auth Flow

--- a/docs/architecture/decisions/adr-0007-globe-local-auth-with-cloud-provisioning.md
+++ b/docs/architecture/decisions/adr-0007-globe-local-auth-with-cloud-provisioning.md
@@ -1,0 +1,197 @@
+# ADR-0007: Globe Local Authentication with Cloud Provisioning
+
+## Status
+Accepted *(2026-06-23)*
+
+## Date
+2026-06-23 *(revised — this document supersedes the previous ADR-0007 draft from the same date, which documented an incorrect Hub-dependent architecture)*
+
+## Related
+- **Supersedes:** The original ADR-0007 draft (`adr-0007-edition-conditional-cloud-auth.md`) — that document described a Hub-dependent model where `cloudAuthorize()` delegated to `supabase.auth.signInWithPassword()` on every cloud login. This ADR replaces it entirely. The old file should be deleted.
+- **Builds on:** ADR-0003 (Shared Identity & Ecosystem Auth Host) — the Hub's Supabase Auth serves as the ecosystem identity provider for signup, billing, and OAuth, but the Globe does not depend on it for day-to-day authentication.
+- **Builds on:** ADR-0004 (httpOnly Session Cookies) — the Globe's single NextAuth session cookie remains the only session artifact in the browser.
+- **Builds on:** ADR-0008 (Cross-Service Linking & HMAC) — the HMAC-authenticated provisioning API and the auto-link JWT mechanism (HS256, `POST /api/connect/direct`) are used during instance creation to inject the Marketplace API key.
+- **Complements:** ADR-0005 (Demo Service Account) — the demo edition authenticates locally like all other editions, with a synthetic admin account.
+
+---
+
+## Context
+
+The WorldWideView globe app (`worldwideview/`) must serve two fundamentally different deployment populations:
+
+| Population | How they get the Globe | Identity relationship to Hub |
+|---|---|---|
+| **Cloud users** | Provisioned by the Hub (`worldwideview-web`) | Have a Hub account (Supabase Auth), but the Globe should not depend on it after setup |
+| **Local users** | Self-install (Docker, etc.) | No Hub account — the Globe is fully standalone |
+
+A previous draft of this ADR documented a Hub-dependent model: cloud edition logins delegated to `supabase.auth.signInWithPassword()` server-side, creating a permanent runtime dependency from the Globe to the Hub's Supabase project. That design was **wrong**. It violated the core architectural principle:
+
+> **The Globe must function standalone.** A user who bookmarks their Globe URL must be able to log in directly without the Hub being reachable.
+
+This is not negotiable:
+- Local/self-hosted users run without Supabase (open-source deployment contract)
+- Cloud users should have the same independence once provisioned — the Hub creates the instance, but after that the Globe stands alone
+
+### Everyday-life analogy
+
+A building manager pre-cuts a key and leaves it at the front desk for the new tenant. The tenant arrives, picks up their key, and from then on uses it directly — they never need the manager again to enter their own apartment. The Hub is the building manager; the Globe is the apartment. The manager creates the apartment, hands over the key, and steps back.
+
+---
+
+## Decisions
+
+### ADR-007A: Globe Authenticates Locally for ALL Editions
+
+NextAuth v5 (Credentials provider, JWT strategy) validates credentials against the **Globe's own Prisma `User` table** for every edition — local, cloud, and demo. There is no edition branching in the auth provider selection, no delegation to an external identity provider at login time, and no runtime dependency on the Hub's Supabase project.
+
+This means:
+
+- **Local edition:** Users sign up directly on the Globe. Their email + bcrypt-hashed password are stored in the Globe's `User` table. NextAuth validates against this table. No external dependency exists.
+- **Cloud edition:** Users were provisioned at instance creation time (see ADR-007B). Their email + bcrypt-hashed password are stored in the Globe's `User` table — the same table, the same schema, the same validation logic. NextAuth validates against this table. No Supabase call on login.
+- **Demo edition:** A synthetic admin account pre-seeded in the `User` table at startup. NextAuth validates against this table. Same path.
+
+The auth provider configuration reduces to a single path:
+
+```typescript
+// Conceptually — no edition branch
+providers: [localCredentialsProvider],
+```
+
+The `localCredentialsProvider` validates email + password against the Globe's own `User` table via bcrypt comparison. This is the only provider. There is no `cloudCredentialsProvider`, no `supabase.auth.signInWithPassword()` call, no `isCloud` gate.
+
+### ADR-007B: Cloud Provisioning Flow — Hub Creates the Globe User at Instance Creation
+
+Cloud users don't self-register on an empty Globe. The Hub creates their Globe identity during **instance provisioning**, before the user ever visits the Globe:
+
+```
+Hub (worldwideview-web)                  Globe (worldwideview)
+     │                                        │
+     │ 1. User creates instance via Hub UI    │
+     │                                        │
+     │ 2. POST /api/instance                  │
+     │    (HMAC-SHA256, per ADR-0008)         │
+     │────────────────────────────────────────►
+     │                                        │── Create Globe User row with:
+     │                                        │     • one-time setup token (UUID)
+     │                                        │     • linked Hub UUID (NOT email)
+     │                                        │     • status: "pending_setup"
+     │                                        │
+     │ 3. POST /api/connect/direct            │
+     │    (HS256 JWT, auto-link, ADR-0008)    │
+     │────────────────────────────────────────►
+     │                                        │── Obtain Marketplace API key
+     │                                        │── Store encrypted in marketplaceCredential
+     │                                        │
+     │◄── instance + user created ────────────│
+     │                                        │
+     │ 4. Redirect user to:                   │
+     │    globe.example.com/setup?token=XXX   │
+```
+
+Key properties of this flow:
+
+- **Provisioning closes the registration race condition.** In the previous model, the Globe sat empty between instance creation and user registration — an attacker who learned the Globe URL could register first. Provisioning eliminates that window: the Globe account exists before the user arrives, protected by the one-time setup token.
+- **The setup token is linked to a Hub UUID, not an email.** This handles every edge case: OAuth providers that don't return email (GitHub private email), phone-based signup, and any future identity source. The Globe identity is linked to the Hub identity via the provisioning record, not via email matching.
+- **The Marketplace API key is injected at provisioning time** via the existing auto-link JWT mechanism (ADR-0008). Cloud users never see the PKCE OAuth flow — their marketplace credential is ready before they log in for the first time.
+- **All Hub-to-Globe calls during provisioning use HMAC-SHA256** (ADR-0008B). The provisioning API is not publicly accessible.
+
+### ADR-007C: Dedicated Setup Page — Independent Globe Identity
+
+When the user arrives at `globe.example.com/setup?token=XXX`, they see a dedicated setup page:
+
+1. **"Set up your admin account"** — a clean form with email and password fields
+2. **No email prefill.** The Globe identity is fully independent from the Hub identity. The user chooses their Globe email from scratch.
+3. The user sets their email + password
+4. The Globe validates the setup token (one-time use, time-limited), creates the account, marks the token as used, auto-logs-in via NextAuth, and redirects to the dashboard
+5. From this point: the Globe authenticates locally. No Hub calls on login. The Marketplace API key is already stored.
+
+The Globe account is linked to the Hub account via the provisioning record: `Hub UUID → setup token → Globe account`. This is a database relationship, not an email-based join. It survives email changes, OAuth edge cases, and any future identity model changes.
+
+### ADR-007D: Local User Flow — Self-Registration, PKCE for Marketplace
+
+Local users install the Globe standalone (Docker, self-hosted). They have no Hub account:
+
+1. User signs up directly on the Globe — email + password stored in the Globe's `User` table
+2. NextAuth validates against the local `User` table on every login
+3. When the user wants Marketplace plugins, they go through the PKCE OAuth flow (ADR-0008, Path 2) to link their Globe instance to their Marketplace account and obtain an API key
+4. The Marketplace API key is stored encrypted in the `marketplaceCredential` table
+
+This flow has no Hub involvement. It is the standard self-hosted experience.
+
+### ADR-007E: UX Guard Rails
+
+Two UX rules follow from this architecture:
+
+1. **Authenticated users visiting `/login` or `/signup` are redirected to the dashboard.** This is standard best practice and prevents confusion when a user with an active session lands on the login page.
+2. **The setup page (`/setup`) is a dedicated route, separate from `/login` and `/signup`.** It is keyed on the setup token in the URL query parameter. Without a valid token, the page redirects to `/login`. This prevents the setup flow from being confused with the regular login flow.
+
+---
+
+## Implementation Gap
+
+> **The current code does not yet match this ADR.** The `cloudAuthorize()` function at `src/lib/auth.ts:138-176` calls `supabase.auth.signInWithPassword()` for cloud edition logins, creating the Hub dependency that this ADR explicitly rejects. The `cloudCredentialsProvider` (lines 183-191) is wired into the NextAuth providers array when `isCloud` is true.
+>
+> This is a known divergence. The intended fix is:
+> 1. Remove `cloudAuthorize()` and `cloudCredentialsProvider`
+> 2. Make the `localCredentialsProvider` validate against the Globe's `User` table for all editions
+> 3. Implement the provisioning API endpoint (HMAC-protected) that creates user records with setup tokens
+> 4. Implement the `/setup` page that consumes setup tokens
+> 5. Remove the `isCloud` gate from the provider selection in `auth.ts`
+>
+> Until this is resolved, the cloud edition remains Hub-dependent at login time, contrary to this ADR's decision.
+
+---
+
+## Consequences
+
+**Positive:**
+- The Globe is fully standalone. A bookmarked Globe URL works without the Hub being reachable — the only session is the Globe's own NextAuth JWT.
+- Local/self-hosted users have zero Supabase dependency. The open-source deployment contract is fulfilled by design, not by edition branching.
+- Cloud users get the same independence after a one-time provisioning step. The Hub creates the apartment; the tenant gets the key and never needs the manager again.
+- A single auth code path serves all editions. No `isCloud ? cloudProvider : localProvider` branch. Less surface area for bugs.
+- The registration race condition is eliminated — the Globe account exists before the user arrives.
+- No email-matching identity linking. Globe identity and Hub identity are linked by provisioning record (UUID), not by a fragile email string comparison.
+
+**Negative / accepted tradeoffs:**
+- The provisioning API must be available during instance creation. If the Globe is unreachable, instance creation fails. This is acceptable — a Globe that can't be reached can't be provisioned.
+- Setup tokens must be single-use and time-limited. A leaked setup token could be used by an attacker before the legitimate user arrives. Mitigation: short token expiry (e.g., 1 hour) and the user is notified immediately if the token is already used.
+- The Hub must maintain a provisioning record (Hub UUID → setup token → Globe account) for auditing and support. This is a small additional table.
+- **Implementation gap:** The current `cloudAuthorize()` function still delegates to Supabase. Until the code is updated, cloud logins retain the Hub dependency this ADR rejects. See Implementation Gap section above.
+- Password resets for cloud users must be handled by the Globe (since the Globe owns the credential), not by the Hub's Supabase Auth. This means the Globe must implement its own password reset flow — a follow-up task.
+
+---
+
+## Rejected Alternatives
+
+This section is the load-bearing part of this ADR. Every alternative listed here was considered and rejected. Future agents: if you are about to propose one of these, **stop — it was already considered and rejected.**
+
+### "Delegate cloud logins to Supabase Auth (the previous ADR-0007 draft)"
+**Rejected.** This was the model documented in the original ADR-0007 draft: `cloudAuthorize()` calls `supabase.auth.signInWithPassword()` on every cloud login, with `isCloud ? cloudCredentialsProvider : localCredentialsProvider` branching. It was rejected because:
+- The Globe cannot function standalone — a Supabase outage means cloud users cannot log in
+- It creates a two-class auth system: local users get independence, cloud users get a permanent dependency
+- The edition branch in the provider array is a code smell — the same `Credentials` form should validate the same way regardless of edition
+- It contradicts the core architectural principle that the Globe must be independently bookmarkable and functional
+
+This ADR replaces that model entirely. The old `adr-0007-edition-conditional-cloud-auth.md` file should be deleted.
+
+### "Pre-fill the setup email from the Hub"
+**Rejected.** Passing the Hub-registered email to the Globe and only asking the user to set a password seems simpler — one less field to fill. But:
+- OAuth providers like GitHub may not expose the user's email (GitHub's "Keep my email private" setting returns a `users.noreply.github.com` address)
+- Phone-based signup has no email to pass
+- The Globe identity should be fully independent from the Hub identity — email prefill ties them together in a way that breaks if the user changes their Hub email or uses a provider without email
+- A blank slate setup page is conceptually cleaner: "This is your Globe. Set up your identity for it."
+
+### "No provisioning — let users self-register on an empty Globe"
+**Rejected.** In this model, the Hub creates an empty Globe instance with no user, and the first person to visit the URL registers as admin. This creates a race condition: if an attacker learns the Globe URL before the legitimate user, the attacker registers first and gains admin access. Provisioning eliminates this window entirely. It also means cloud users would need to separately link their Globe to the Hub for billing — provisioning bundles this step.
+
+### "Shared user table — Globe reads/writes Supabase auth.users directly"
+**Rejected.** This would mean the Globe's `User` table is Supabase's `auth.users`. Local/self-hosted users have no Supabase instance, so this model breaks the local edition entirely. Even for cloud, it creates a data residency concern (user credentials live in Supabase, not the Globe's own database) and makes the Globe dependent on the Supabase GoTrue Admin API for user management operations.
+
+### "Hub proxies all Globe login requests"
+**Rejected.** In this model, the user always logs in at the Hub, and the Hub forwards authenticated requests to the Globe. This makes the Hub a single point of failure for Globe authentication — if the Hub is down, cloud users cannot access their Globe. It also means the Globe login page is a redirect to the Hub, which breaks the bookmarkable-URL principle.
+
+### "Unify on a single auth provider across the ecosystem (NextAuth OR Supabase)"
+**Rejected** for the same reasons documented in the original ADR-0007 (which was correct about this specific point). The Globe's local edition must operate without Supabase — removing NextAuth breaks self-hosted users. The Hub's ecosystem needs Supabase Auth for shared sessions across subdomains — removing Supabase breaks cross-product login. Both frameworks serve different purposes in different contexts, and removing either creates more problems than it solves.
+
+### "Let cloud users create a Globe account with the same email as their Hub account, match by email"
+**Rejected.** Email matching is fragile: users change emails, OAuth providers don't always return email, and email matching creates an implicit trust relationship ("if your email matches, you get admin access") that is vulnerable to email takeover attacks. The provisioning model's explicit token-based link (Hub UUID → setup token → Globe account) is cryptographically sound and immune to email changes.

--- a/docs/architecture/decisions/adr-0008-cross-service-linking-and-hmac.md
+++ b/docs/architecture/decisions/adr-0008-cross-service-linking-and-hmac.md
@@ -1,0 +1,224 @@
+# ADR-0008: Cross-Service Linking Topology & HMAC Authentication
+
+## Status
+Accepted *(2026-06-23)*
+
+## Date
+2026-06-23
+
+## Related
+- **Builds on:** ADR-0001 (Decentralized Plugin Auth) — the same marketplace API key from PKCE is used for engine ticket exchange; cloud users skip PKCE via provisioning-time auto-link
+- **Builds on:** ADR-0003 (Shared Identity) — cloud users are identified by their Supabase UUID across marketplace and globe
+- **Builds on:** ADR-0007 (Globe Local Authentication with Cloud Provisioning) — the auto-link JWT runs during instance provisioning, not at login; the Globe authenticates locally for all editions after setup
+
+---
+
+## Context
+
+The WorldWideView ecosystem spans four repositories. A user's identity in the marketplace must be linked to their globe instance so that plugin subscriptions, API keys, and engine tickets function. Additionally, the web hub (`worldwideview-web/`) must make server-to-server calls to the globe (`worldwideview/`) for provisioning, billing, and account management.
+
+Two fundamentally different user populations drive a two-path design, separated by **when** linking happens, not just who does it:
+
+| Path | User type | When linking runs | Trust basis |
+|---|---|---|---|
+| Auto-link (HS256 JWT) | Cloud users | **At provisioning time** (instance creation, Hub-to-Globe) | Hub's Supabase UUID is verified identity; marketplace API key is injected before user ever visits the Globe |
+| PKCE OAuth | Local users | **On demand** (when user wants Marketplace plugins) | User must explicitly authorize marketplace access via browser redirect |
+
+The key architectural insight: cloud users experience **zero manual linking**. The auto-link JWT runs server-to-server during instance creation (ADR-0007 provisioning flow), injecting the Marketplace API key into the Globe before the user sets up their account. By the time the user completes the setup page, their Marketplace credential is already stored and ready.
+
+Local users follow the PKCE path — they must explicitly connect to the Marketplace through a browser redirect. This is the standard OAuth 2.0 Authorization Code flow with PKCE (RFC 7636), suitable for public clients that cannot keep a client secret.
+
+The web hub's server-to-server calls to the globe require a separate mechanism — HMAC-SHA256 with per-request integrity, freshness, and replay protection.
+
+Prior sessions saw GSD agents repeatedly propose collapsing these paths into one. This ADR exists to make those fights stop.
+
+---
+
+## Decision
+
+### ADR-008A: Two-Path Marketplace Linking — Provisioning vs. On-Demand
+
+The globe app links a user to the marketplace via one of two mutually exclusive paths, selected by when the linking happens:
+
+#### Path 1: Auto-link at provisioning time (cloud edition)
+
+Used when a cloud instance is created. The Hub (not the user's browser) drives this flow server-to-server during instance provisioning, as part of the ADR-0007 cloud provisioning flow. The Hub calls the Globe's provisioning API, which in turn calls the marketplace to obtain an API key:
+
+```
+Globe server                    Marketplace server
+     │                                 │
+     │ POST /api/connect/direct        │
+     │ Authorization: Bearer <HS256 JWT>│
+     │                                 │── Verify JWT with MARKETPLACE_CONNECT_SECRET
+     │                                 │── Look up marketplace user by sub (Supabase UUID)
+     │                                 │── Generate marketplace API key
+     │◄─ { apiKey: "<key>" } ─────────│
+     │                                 │
+     │── Encrypt API key (AES-256-GCM) │
+     │── Store in marketplaceCredential│
+```
+
+**JWT claims** (`signAutoLinkJwt` in `src/lib/cross-service/jwtSigner.ts`):
+- `sub`: The user's Supabase Auth UUID
+- `iat`: Issued at (Unix seconds)
+- `exp`: 60 seconds after `iat`
+- Algorithm: HS256, keyed with `MARKETPLACE_CONNECT_SECRET`
+
+**Why 60 seconds:** The token only needs to survive one round-trip from globe to marketplace. A shorter expiry limits the window for replay. If the globe's clock is within 60s of the marketplace's, no clock sync issues arise.
+
+**Idempotency:** `autoLinkToMarketplace()` checks for an existing `marketplaceCredential` row before calling the marketplace. If already linked, it returns `{ error: "already_linked" }` — no duplicate API keys are minted.
+
+#### Path 2: PKCE OAuth at connection time (local/demo edition)
+
+Used when a local user wants to connect to the Marketplace. The user has no Hub/Supabase identity, so they must explicitly consent to linking their globe instance to the marketplace. This is a browser-mediated OAuth 2.0 PKCE flow:
+
+```
+Browser                    Globe                    Marketplace
+  │                         │                         │
+  │ Click "Connect"         │                         │
+  │── GET /api/marketplace/connect ──►                 │
+  │                         │── Generate code_verifier │
+  │                         │── SHA256 → code_challenge│
+  │◄── 302 to marketplace   │                         │
+  │    /oauth/authorize?    │                         │
+  │    client_id=local-app  │                         │
+  │    code_challenge=S256  │                         │
+  │    scope=plugins:read   │                         │
+  │─────────────────────────►                         │
+  │                         │                         │── Validate Supabase session
+  │                         │                         │   (or redirect to login)
+  │                         │                         │── Show consent screen
+  │                         │                         │── Issue auth code (60s TTL)
+  │◄── 302 with code ─────────────────────────────────│
+  │                         │                         │
+  │── GET /api/marketplace/callback?code=X ──►         │
+  │                         │── POST /api/oauth/token │
+  │                         │   grant_type=authorization_code
+  │                         │   code + code_verifier  │
+  │                         │─────────────────────────►
+  │                         │◄── { access_token } ────│
+  │                         │── Encrypt and store     │
+  │◄── success ─────────────│                         │
+```
+
+### ADR-008B: Hub-to-Globe HMAC-SHA256 Server Authentication
+
+The web hub makes server-to-server calls to the globe for provisioning, billing, and account management (~10 endpoints). These calls are authenticated with **HMAC-SHA256** using a shared secret (`CROSS_SERVICE_SECRET`).
+
+**Signing** (`src/lib/cross-service/sign.ts`):
+
+```typescript
+// Input: method, path, body, timestamp
+// Produces three headers:
+X-Service-Signature: t=1719000000,n=<uuid>,sig=<hex-hmac>
+X-Service-Timestamp: 1719000000
+X-Service-Nonce: <uuid>
+```
+
+The canonical string signed is: `{METHOD}\n{PATH}\n{TIMESTAMP}\n{SHA256(BODY)}`
+
+**Verification** (`src/lib/cross-service/verify.ts`):
+
+1. **Timestamp window:** Reject if `|now - timestamp| > 300_000` (5 minutes)
+2. **Nonce replay:** Reject if nonce has been seen before (in-memory `NonceCache`, 5-min TTL)
+3. **Signature:** Rebuild canonical string, compute HMAC-SHA256, compare with `crypto.timingSafeEqual`
+
+**Why HMAC, not a static API key:**
+
+| Property | Static API Key | HMAC-SHA256 (chosen) |
+|---|---|---|
+| Per-request integrity | No — key is opaque; body tampering undetected | Yes — body hash is part of the signature |
+| Replay protection | No — captured key can be replayed indefinitely | Yes — nonce + 5-min timestamp window |
+| Freshness guarantee | No — a key from last month still works | Yes — requests expire after 5 minutes |
+| Rotation complexity | Revoke old key, distribute new key | Rotate `CROSS_SERVICE_SECRET` with a brief overlap window |
+
+### ADR-008C: Auto-Link API Key Encryption at Rest
+
+The marketplace API key obtained via either path is stored encrypted in the globe's `marketplaceCredential` table:
+
+- **Algorithm:** AES-256-GCM
+- **Key derivation:** PBKDF2 over `ENCRYPTION_MASTER_KEY` (the env var used by `src/lib/auth/encryption.ts`), 100,000 iterations, SHA-256, 32-byte output
+- **Storage:** Separate columns for `version`, `salt`, `nonce`, and `ciphertext`
+- **Versioning:** The `version` column (currently `v1`) supports future key rotation
+
+For cloud users, the credential is keyed by `tenantId = "marketplace-{supabaseUuid}"`. For local users, `tenantId = "local"`.
+
+### ADR-008D: Hub-to-Globe Endpoint Catalog
+
+All hub-to-globe calls use the HMAC mechanism. The following endpoints are protected by the `crossServiceAuth` middleware:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/account` | Read account status (plan, trial, Stripe IDs) |
+| GET | `/api/instance` | List user instances |
+| POST | `/api/instance` | Create instance |
+| PATCH | `/api/instance/{id}` | Rename instance |
+| DELETE | `/api/instance/{id}` | Soft-delete instance |
+| GET | `/api/instance/{id}/members` | List instance members |
+| POST | `/api/instance/{id}/invite` | Create invitation |
+| POST | `/api/internal/account/update` | Push billing changes from Stripe webhooks |
+| GET | `/api/internal/account` | Read internal account details |
+| POST | `/api/access-code` | Redeem access code |
+
+---
+
+## Implementation Details
+
+### Auto-link JWT construction
+
+The JWT is built manually in `jwtSigner.ts` (not using the `jose` library) because `jose` v6's webapi build relies on `instanceof Uint8Array`, which fails across jsdom realms in unit tests. The output is fully compatible with `jose.jwtVerify` on the marketplace side.
+
+### HMAC middleware
+
+The `crossServiceAuth()` middleware (`src/lib/cross-service/middleware.ts`) is a drop-in gate for globe API routes:
+
+```typescript
+const authError = await crossServiceAuth(request);
+if (authError) return authError; // 401
+// Route handler continues...
+```
+
+For routes that need `request.json()` after auth, the request body must be cloned before calling the middleware, since `verifyCrossServiceSignature` consumes the body to compute its hash.
+
+### Nonce replay protection
+
+The `NonceCache` (`src/lib/cross-service/nonceCache.ts`) is an in-memory `Map<string, number>` with an expiry-based cleanup interval (every 60 seconds). It is scoped to a single process — if the globe runs multiple instances behind a load balancer, a nonce could be replayed against a different instance. At current scale (single-instance Coolify deployment), this is acceptable. A Redis-backed nonce store is the follow-up if horizontal scaling is introduced.
+
+---
+
+## Consequences
+
+**Positive:**
+- Cloud users get completely invisible marketplace linking — the auto-link JWT runs server-to-server during instance provisioning before the user ever visits the Globe. By the time they complete the setup page, their Marketplace API key is already stored.
+- Local users get explicit consent via standard OAuth PKCE — no trust assumptions required. They initiate the connection when they want Marketplace plugins.
+- Hub-to-globe calls carry per-request integrity proofs — a leaked `CROSS_SERVICE_SECRET` from past logs does not enable replay of captured requests
+- Each auth mechanism is scoped to exactly its caller-provider pair — no mechanism is overloaded
+
+**Negative / accepted tradeoffs:**
+- Two linking paths means two code paths to maintain and test. The provisioning flag (whether the instance was cloud-provisioned) gates which path is active, so only one path executes per deployment.
+- The HMAC nonce cache is process-local — a horizontally scaled globe would need a shared nonce store (Redis). This is deferred.
+- `CROSS_SERVICE_SECRET` and `MARKETPLACE_CONNECT_SECRET` must be identical between hub and globe, and globe and marketplace, respectively. No automated rotation mechanism exists. Manual rotation requires a brief overlap window during which both old and new secrets are accepted (not yet implemented).
+- PKCE requires the browser to complete a redirect chain. If the user closes the browser during the flow, the code verifier is lost and the flow must restart.
+- The auto-link JWT runs during provisioning — if the marketplace is unreachable at instance creation time, the API key injection fails. The provisioning flow must handle this gracefully (retry or deferred linking).
+
+---
+
+## Rejected Alternatives
+
+### "Single shared API key for hub-to-globe instead of HMAC"
+**Rejected.** A static API key provides no per-request integrity (body tampering is undetected), no replay protection (a captured key works forever), and no freshness guarantee (a key from months ago still authenticates). HMAC-SHA256 addresses all three. The additional complexity is an HMAC computation per request — negligible.
+
+### "Remove PKCE, use the auto-link flow for all users"
+**Rejected.** Local users do not have a hub/Supabase identity that can be passed as a JWT `sub` claim. There is no UUID to embed. Forcing local users through an auto-link would require either (a) creating a Supabase account for every local user (breaking the open-source contract) or (b) minting synthetic UUIDs not backed by any identity provider (creating an impersonation vector).
+
+### "Remove auto-link, force all users through PKCE"
+**Rejected.** Cloud users are already authenticated at the hub with Supabase. Forcing them through a browser redirect to the marketplace consent screen, when they have already consented during cloud plan signup, adds unnecessary friction. The auto-link path is a UX optimization for the population that already has verified identity.
+
+### "Collapse auto-link and PKCE into one unified flow"
+**Rejected.** The two paths exist because the two user populations have fundamentally different trust starting points. Cloud users arrive with a verified Supabase UUID — the globe can prove who they are to the marketplace without user interaction. Local users arrive anonymous to the marketplace — they must establish a relationship through explicit OAuth consent. A unified flow would either add unnecessary interaction for cloud users or remove necessary consent for local users.
+
+### "Use JWT for hub-to-globe instead of HMAC"
+**Rejected.** JWT requires an issuer (who signs?) and a key distribution mechanism (JWKS endpoint or shared secret). A JWT with a shared secret is functionally equivalent to HMAC but with added complexity (header parsing, claim validation, algorithm negotiation). HMAC-SHA256 is simpler: sign a canonical string, attach the signature, verify on the other side. No JWT library dependency needed for this specific path.
+
+### "Use mTLS for hub-to-globe instead of HMAC"
+**Rejected.** Mutual TLS provides transport-level authentication but requires certificate management infrastructure (CA, issuance, rotation, revocation). At current scale (two services on a private network), the operational burden of mTLS outweighs its benefits. HMAC over HTTPS provides application-level integrity that survives TLS termination at reverse proxies. mTLS can be reconsidered if the ecosystem grows to 10+ services.

--- a/prisma/migrations/20260614000000_rls_policies/migration.sql
+++ b/prisma/migrations/20260614000000_rls_policies/migration.sql
@@ -1,0 +1,56 @@
+-- DropIndex
+DROP INDEX IF EXISTS "users_tenantId_email_key";
+
+-- AlterTable: Remove tenantId column from users (IF EXISTS for idempotency)
+ALTER TABLE "users" DROP COLUMN IF EXISTS "tenantId";
+
+-- AlterTable: Add workspace tenant foundation fields
+ALTER TABLE "workspaces" ADD COLUMN     "ownerId" TEXT,
+ADD COLUMN     "trialEndsAt" TIMESTAMP(3);
+
+-- CreateIndex: RLS-performance indices on tenantId for all scoped tables
+CREATE INDEX "favorites_tenantId_idx" ON "favorites"("tenantId");
+CREATE INDEX "installed_plugins_tenantId_idx" ON "installed_plugins"("tenantId");
+CREATE INDEX "marketplace_credentials_tenantId_idx" ON "marketplace_credentials"("tenantId");
+CREATE INDEX "settings_tenantId_idx" ON "settings"("tenantId");
+CREATE INDEX "user_api_keys_tenantId_idx" ON "user_api_keys"("tenantId");
+
+-- CreateIndex: New unique constraint on users.email (replaces composite tenantId+email)
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- ============================================================
+-- PostgreSQL Row-Level Security (RLS) — Defense-in-depth
+-- ============================================================
+
+-- Enable RLS on all tenant-scoped tables
+ALTER TABLE "favorites" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "installed_plugins" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "settings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "marketplace_credentials" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "user_api_keys" ENABLE ROW LEVEL SECURITY;
+
+-- RLS policy: each scoped table filters by app.current_tenant_id
+-- The db.ts Prisma extension sets app.current_tenant_id via SELECT set_config()
+-- BEFORE any query executes. The policy compares the row's tenantId against
+-- the session variable (both TEXT). Rows with NULL tenantId are invisible
+-- to tenant-scoped queries, which is correct for post-backfill state.
+
+CREATE POLICY tenant_isolation ON "favorites"
+  FOR ALL
+  USING ("tenantId" = current_setting('app.current_tenant_id', true)::text);
+
+CREATE POLICY tenant_isolation ON "installed_plugins"
+  FOR ALL
+  USING ("tenantId" = current_setting('app.current_tenant_id', true)::text);
+
+CREATE POLICY tenant_isolation ON "settings"
+  FOR ALL
+  USING ("tenantId" = current_setting('app.current_tenant_id', true)::text);
+
+CREATE POLICY tenant_isolation ON "marketplace_credentials"
+  FOR ALL
+  USING ("tenantId" = current_setting('app.current_tenant_id', true)::text);
+
+CREATE POLICY tenant_isolation ON "user_api_keys"
+  FOR ALL
+  USING ("tenantId" = current_setting('app.current_tenant_id', true)::text);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,6 @@ datasource db {
 
 model User {
   id             String            @id @default(uuid())
-  tenantId       String?
   email          String
   name           String
   hashedPassword String
@@ -23,7 +22,7 @@ model User {
   memberships    WorkspaceMember[]
   apiKeys        UserApiKey[]
 
-  @@unique([tenantId, email])
+  @@unique([email])
   @@map("users")
 }
 
@@ -40,6 +39,7 @@ model Favorite {
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, entityId])
+  @@index([tenantId])
   @@map("favorites")
 }
 
@@ -54,6 +54,7 @@ model InstalledPlugin {
   updatedAt   DateTime @updatedAt
 
   @@unique([tenantId, pluginId])
+  @@index([tenantId])
   @@map("installed_plugins")
 }
 
@@ -64,6 +65,7 @@ model Setting {
   value    String
 
   @@unique([tenantId, key])
+  @@index([tenantId])
   @@map("settings")
 }
 
@@ -71,10 +73,12 @@ model Workspace {
   id                   String            @id @default(uuid())
   name                 String
   subdomain            String            @unique
+  ownerId              String?
   status               String            @default("trialing")
   plan                 String            @default("basic")
   stripeCustomerId     String?
   stripeSubscriptionId String?
+  trialEndsAt          DateTime?
   createdAt            DateTime          @default(now())
   updatedAt            DateTime          @updatedAt
   members              WorkspaceMember[]
@@ -106,6 +110,7 @@ model MarketplaceCredential {
   updatedAt  DateTime @updatedAt
 
   @@unique([tenantId])
+  @@index([tenantId])
   @@map("marketplace_credentials")
 }
 
@@ -120,5 +125,6 @@ model UserApiKey {
   lastUsedAt   DateTime?
   user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId])
   @@map("user_api_keys")
 }


### PR DESCRIPTION
## Summary

Formalizes the cross-system authentication architecture for the WWV ecosystem into Architecture Decision Records, preventing GSD agents from relitigating decisions that were already hashed out.

## ADR Files

### ADR-0007: Globe Local Authentication with Cloud Provisioning (NEW)
- **Decision:** Globe authenticates locally for ALL editions — NextAuth v5 against own User table. No Hub/Supabase dependency after setup. Cloud users are provisioned at instance creation via a one-time setup token + auto-injected Marketplace API key.
- **7 rejected alternatives** documented, including the Hub-dependent model it replaces.
- **Implementation gap:** Current code at \cloudAuthorize()\ calls Supabase on cloud logins — contradicts this ADR. Fix plan included.

### ADR-0008: Cross-Service Linking and HMAC (NEW)
- **Decision:** Two-path Marketplace linking — auto-link JWT during cloud provisioning, PKCE OAuth for local users — plus HMAC-SHA256 for Hub→Globe server calls (~10 endpoints with nonce + 5-min window).
- **6 rejected alternatives** documented.

### ADR-0001: Revision (5-Min Revocation Window)
- Added 2026-06-23 revision clarifying the 5-minute JWT revocation window is a conscious business tradeoff, not a technical limitation.

## Files Changed
- \docs/architecture/decisions/adr-0001-*.md\ — 11 lines added (revision)
- \docs/architecture/decisions/adr-0007-*.md\ — 197 lines (new)
- \docs/architecture/decisions/adr-0008-*.md\ — ~250 lines (new)