### PR TITLE
fix(data-engine): replace remaining WWV_DATA_ENGINE_URL references

### DIFF
--- a/src/app/api/mcp/discoveryHelpers.ts
+++ b/src/app/api/mcp/discoveryHelpers.ts
@@ -15,7 +15,7 @@
 import type { PluginDataSnapshot } from "@/lib/data-query/types";
 import type { RegionOptions } from "@/lib/data-query/types";
 import type { FilterDefinition } from "@/core/plugins/PluginTypes";
-import { getAllPluginSnapshots } from "@/lib/data-query/service";
+import { getEngineUrl, getAllPluginSnapshots } from "@/lib/data-query/service";
 import { getLocalSourceIds } from "@/lib/data-query/localSources";
 import { readActiveSessions, readGlobeState } from "@/lib/globeStateStore";
 import { readSessionCatalog } from "@/lib/mcpSessionCatalog";
@@ -112,7 +112,7 @@ export interface ListStreamingPluginsResult {
  * are not blocked waiting for a slow engine.
  */
 async function probeEngineReachable(): Promise<boolean> {
-    const engineUrl = (process.env.WWV_DATA_ENGINE_URL ?? "http://localhost:5001") + "/manifest";
+    const engineUrl = getEngineUrl() + "/manifest";
     try {
         const res = await fetch(engineUrl, { signal: AbortSignal.timeout(2000) });
         return res.ok;

--- a/src/lib/data-query/service.ts
+++ b/src/lib/data-query/service.ts
@@ -12,7 +12,8 @@ import type { FilterValue } from "@/core/plugins/PluginTypes";
 import { hasLocalSource, resolveLocalSnapshot, getLocalSourceIds } from "./localSources";
 
 export function getEngineUrl(): string {
-    return process.env.WWV_DATA_ENGINE_URL ?? "http://localhost:5001";
+    const port = process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT || '5001';
+    return `http://localhost:${port}`;
 }
 
 function normalizeEntity(raw: unknown): GeoEntity | null {


### PR DESCRIPTION
## Summary

Replaces the last 2 remaining references to \WWV_DATA_ENGINE_URL\ with \NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT\, consolidating engine URL configuration across the codebase.

## Changes

- **\service.ts\**: \getEngineUrl()\ now reads \NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT\ and constructs \http://localhost:\\ — matching the pattern established in \ngineManifest.ts\
- **\discoveryHelpers.ts\**: Now imports and calls \getEngineUrl()\ instead of inlining the env var access, removing the last direct reference to the old env var

## Context

PR #235 attempted this rename but was only partially applied. Most files already use the new env var name. These were the last 2 stragglers.

Closes #182