### PR TITLE
fix: add missing basePath to Better Auth client SDK

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -37,6 +37,7 @@ function resolveBaseUrl(): string {
  */
 export const authClient = createAuthClient({
     baseURL: resolveBaseUrl(),
+    basePath: "/api/ba",
 });
 
 /**


### PR DESCRIPTION
## Problem
PR #281 (remove-nextauth) missed setting `basePath: "/api/ba"` on the Better Auth client SDK in `src/lib/auth-client.ts`. Without this, `authClient.signIn.email()` sends requests to `/api/auth/*` (Better Auth default) instead of `/api/ba/*` where the server handler is mounted.

Every login attempt returns 404 silently. Users see "Sign in failed. Check your credentials."

## Fix
One line in `src/lib/auth-client.ts`:
```diff
  export const authClient = createAuthClient({
      baseURL: resolveBaseUrl(),
+     basePath: "/api/ba",
  });
```

## Verification
Fresh-clone smoke test confirmed: setup page loads, admin account created, login succeeds, app loads with globe + AppShell. All working after this fix. Without it, login silently fails with 404.
