### PR TITLE
fix: add missing REDIS_URL and WWV_SKIP_WS_AUTH to self-host docker-compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.52.0",
+  "version": "2.52.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "WWV_DEMO_ADMIN_SECRET=${WWV_DEMO_ADMIN_SECRET:-}"
       - "WWV_BRIDGE_TOKEN=${WWV_BRIDGE_TOKEN:-}"
       - "DATABASE_URL=postgresql://postgres:postgres@db:5432/worldwideview?schema=public"
+      - "REDIS_URL=redis://wwv-redis:6379"
     depends_on:
       db:
         condition: service_healthy
@@ -53,6 +54,7 @@ services:
       - REDIS_URL=redis://wwv-redis:6379
       - SEEDERS_DIR=/app/seeders
       - DB_PATH=/app/data/engine.db
+      - WWV_SKIP_WS_AUTH=true
     depends_on:
       wwv-redis:
         condition: service_healthy


### PR DESCRIPTION
## Problem

Three configuration gaps in Docker compose files prevent fresh installs from working:

### Self-host (`self-host/docker-compose.yml`)
1. **wwv-data-engine crashes** — `WWV_SKIP_WS_AUTH` not set, so the engine requires `JWKS_URL` (which doesn't exist in self-host) and exits.
2. **wwv ignores Redis** — `REDIS_URL` not set on the wwv service, so it falls back to `redis://localhost:6379` inside the container where no Redis is running.

### Production (`deploy/production/docker-compose.engine.yml`)
3. **Both `JWKS_URL` and `WWV_SKIP_WS_AUTH` missing** — engine starts with auth on by default, requires JWKS_URL, and crashes. `WWV_SKIP_WS_AUTH=true` added as backward-compat fallback so deployments work out of the box; `JWKS_URL` added so the auth path is pre-configured when skip is removed. (Currently masked on Coolify by UI overrides.)

## Fix

Three env var additions across two files:

### `self-host/docker-compose.yml`
- `REDIS_URL=redis://wwv-redis:6379` on the `wwv` service
- `WWV_SKIP_WS_AUTH=true` on the `wwv-data-engine` service

### `deploy/production/docker-compose.engine.yml`
- `JWKS_URL=https://marketplace.worldwideview.dev/api/auth/jwks` on `wwv-data-engine`
- `WWV_SKIP_WS_AUTH=true` on `wwv-data-engine` (backward compat — remove to enable JWKS auth)

All env vars already present in other compose files (dev compose, data engine's own compose).
Fixes `setup.sh` and `setup.ps1` both (they download the self-host template).

## Verification

- Dev compose has both patterns already and works correctly
- Production Coolify instance confirmed running with both vars via Coolify overrides
- Data engine's own `wwv-data-engine/docker-compose.yaml` has `JWKS_URL` at same value