### PR TITLE
test: add E2E Playwright tests for auth flows

### DIFF
--- a/tests/auth-login.spec.ts
+++ b/tests/auth-login.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { PrismaClient } from '../src/generated/prisma/index.js';
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { hashPassword } from 'better-auth/crypto';
+import crypto from 'crypto';
+
+const LOGIN_TEST_EMAIL = 'login-e2e-test@test.local';
+const LOGIN_TEST_PASSWORD = 'LoginTestPassword123!';
+
+test.describe('Login Flow', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  let prisma: PrismaClient;
+  let pool: Pool;
+
+  test.beforeAll(async () => {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public" });
+    const adapter = new PrismaPg(pool);
+    prisma = new PrismaClient({ adapter });
+
+    const hashedPassword = await hashPassword(LOGIN_TEST_PASSWORD);
+    const userId = crypto.randomUUID();
+
+    const user = await prisma.betterAuthUser.upsert({
+      where: { email: LOGIN_TEST_EMAIL },
+      update: { name: 'Login E2E Test' },
+      create: {
+        id: userId,
+        email: LOGIN_TEST_EMAIL,
+        name: 'Login E2E Test',
+        emailVerified: true,
+        role: 'user',
+      },
+    });
+
+    await prisma.betterAuthAccount.deleteMany({
+      where: { userId: user.id },
+    });
+    await prisma.betterAuthAccount.create({
+      data: {
+        id: crypto.randomUUID(),
+        accountId: LOGIN_TEST_EMAIL,
+        providerId: 'credential',
+        userId: user.id,
+        password: hashedPassword,
+      },
+    });
+  });
+
+  test('sign in with valid credentials redirects to home', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('#email', LOGIN_TEST_EMAIL);
+    await page.fill('#password', LOGIN_TEST_PASSWORD);
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL('/', { timeout: 30000 });
+    await expect(page.locator('[data-testid="app-ready"]')).toBeVisible({ timeout: 30000 });
+  });
+
+  test('session persists on hard refresh', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('#email', LOGIN_TEST_EMAIL);
+    await page.fill('#password', LOGIN_TEST_PASSWORD);
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL('/', { timeout: 30000 });
+    await expect(page.locator('[data-testid="app-ready"]')).toBeVisible({ timeout: 30000 });
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).not.toContain('/login');
+    await expect(page.locator('[data-testid="app-ready"]')).toBeVisible({ timeout: 30000 });
+  });
+
+  test.afterAll(async () => {
+    try {
+      await prisma.betterAuthAccount.deleteMany({
+        where: { user: { email: LOGIN_TEST_EMAIL } }
+      });
+      await prisma.betterAuthSession.deleteMany({
+        where: { user: { email: LOGIN_TEST_EMAIL } }
+      });
+      await prisma.betterAuthUser.deleteMany({
+        where: { email: LOGIN_TEST_EMAIL }
+      });
+    } catch (e) {
+      console.warn('[Login Test] Cleanup after all failed:', e);
+    }
+    await prisma.$disconnect();
+    await pool.end();
+  });
+});

--- a/tests/auth-migration.spec.ts
+++ b/tests/auth-migration.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { PrismaClient } from '../src/generated/prisma/index.js';
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+
+const LEGACY_MIGRATION_EMAIL = 'legacy-migration-test@test.local';
+const LEGACY_MIGRATION_PASSWORD = 'MigrationTestPassword123!';
+
+test.describe('Legacy User Migration', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  let prisma: PrismaClient;
+  let pool: Pool;
+
+  test.beforeAll(async () => {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public" });
+    const adapter = new PrismaPg(pool);
+    prisma = new PrismaClient({ adapter });
+
+    await prisma.betterAuthAccount.deleteMany({
+      where: { user: { email: LEGACY_MIGRATION_EMAIL } }
+    });
+    await prisma.betterAuthSession.deleteMany({
+      where: { user: { email: LEGACY_MIGRATION_EMAIL } }
+    });
+    await prisma.betterAuthUser.deleteMany({
+      where: { email: LEGACY_MIGRATION_EMAIL }
+    });
+
+    const hashedPassword = bcrypt.hashSync(LEGACY_MIGRATION_PASSWORD, 10);
+    await prisma.user.upsert({
+      where: { email: LEGACY_MIGRATION_EMAIL },
+      update: { hashedPassword },
+      create: {
+        id: crypto.randomUUID(),
+        email: LEGACY_MIGRATION_EMAIL,
+        name: 'Legacy Migration Test',
+        hashedPassword,
+        role: 'ADMIN',
+      },
+    });
+  });
+
+  test('legacy user is migrated and can sign in', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('#email', LEGACY_MIGRATION_EMAIL);
+    await page.fill('#password', LEGACY_MIGRATION_PASSWORD);
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL('/', { timeout: 30000 });
+    await expect(page.locator('[data-testid="app-ready"]')).toBeVisible({ timeout: 30000 });
+
+    const migratedUser = await prisma.betterAuthUser.findUnique({
+      where: { email: LEGACY_MIGRATION_EMAIL }
+    });
+    expect(migratedUser).not.toBeNull();
+    expect(migratedUser!.email).toBe(LEGACY_MIGRATION_EMAIL);
+
+    const migratedAccount = await prisma.betterAuthAccount.findFirst({
+      where: { accountId: LEGACY_MIGRATION_EMAIL }
+    });
+    expect(migratedAccount).not.toBeNull();
+  });
+
+  test('migration is idempotent - second login does not create duplicate', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('#email', LEGACY_MIGRATION_EMAIL);
+    await page.fill('#password', LEGACY_MIGRATION_PASSWORD);
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL('/', { timeout: 30000 });
+    await expect(page.locator('[data-testid="app-ready"]')).toBeVisible({ timeout: 30000 });
+
+    const users = await prisma.betterAuthUser.findMany({
+      where: { email: LEGACY_MIGRATION_EMAIL }
+    });
+    expect(users.length).toBe(1);
+
+    const accounts = await prisma.betterAuthAccount.findMany({
+      where: { accountId: LEGACY_MIGRATION_EMAIL }
+    });
+    expect(accounts.length).toBe(1);
+  });
+
+  test.afterAll(async () => {
+    try {
+      await prisma.betterAuthAccount.deleteMany({
+        where: { user: { email: LEGACY_MIGRATION_EMAIL } }
+      });
+      await prisma.betterAuthSession.deleteMany({
+        where: { user: { email: LEGACY_MIGRATION_EMAIL } }
+      });
+      await prisma.betterAuthUser.deleteMany({
+        where: { email: LEGACY_MIGRATION_EMAIL }
+      });
+      await prisma.user.deleteMany({
+        where: { email: LEGACY_MIGRATION_EMAIL }
+      });
+    } catch (e) {
+      console.warn('[Migration Test] Cleanup after all failed:', e);
+    }
+    await prisma.$disconnect();
+    await pool.end();
+  });
+});


### PR DESCRIPTION
## Summary
Adds two Playwright E2E test files covering the core auth flows on the globe app. These are the first tests that directly exercise the login UI and migration hook — previously, login was treated as infrastructure (global.setup.ts) rather than a tested feature.

## Tests Added

### tests/auth-login.spec.ts
Creates a BetterAuthUser with known password via Prisma, then:
1. **Sign in** — fills /login form, submits, verifies redirect to / and app-ready renders
2. **Session persistence** — same flow, then hard refresh, verifies session survives (not redirected to /login)

### tests/auth-migration.spec.ts
Creates a legacy `User` (old users table) with bcrypt password via Prisma, with no BetterAuthUser existing:
1. **Migration** — signs in via /login, migration hook fires, verifies BetterAuthUser + BetterAuthAccount created in DB
2. **Idempotency** — signs in again, verifies only ONE BetterAuthUser and ONE BetterAuthAccount exist

## Verification
- 12/12 passed across chromium, firefox, webkit
- No regressions in existing 23 test suite
- Each file seeds/cleans its own data with unique emails (login-e2e-test@test.local and legacy-migration-test@test.local)
- No changes to existing tests, global.setup, or Playwright config

## Notes
- Tests use `test.describe.configure({ mode: 'serial' })` to prevent parallel worker DB races
- Tests override storageState to start unauthenticated
- Tests clean up DB records in afterAll