### PR TITLE
Phase 2: Globe provisioning endpoint + cloud setup mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.55.0",
+  "version": "2.56.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/prisma/migrations/20260702121851_add_setup_token/migration.sql
+++ b/prisma/migrations/20260702121851_add_setup_token/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "setup_tokens" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "setup_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "setup_tokens_tokenHash_key" ON "setup_tokens"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "setup_tokens_tokenHash_idx" ON "setup_tokens"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "setup_tokens_userId_idx" ON "setup_tokens"("userId");
+
+-- AddForeignKey
+ALTER TABLE "setup_tokens" ADD CONSTRAINT "setup_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,7 @@ model BetterAuthUser {
   favorites     Favorite[]
   memberships   WorkspaceMember[]
   apiKeys       UserApiKey[]
+  setupTokens   SetupToken[]
 
   @@map("user")
 }
@@ -267,4 +268,19 @@ model PluginJwks {
   expiresAt  DateTime?
 
   @@map("jwks")
+}
+
+model SetupToken {
+  id             String         @id @default(uuid())
+  tokenHash      String         @unique
+  userId         String
+  user           BetterAuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String?
+  expiresAt      DateTime
+  usedAt         DateTime?
+  createdAt      DateTime       @default(now())
+
+  @@index([tokenHash])
+  @@index([userId])
+  @@map("setup_tokens")
 }

--- a/src/app/api/provision/route.ts
+++ b/src/app/api/provision/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+import { prisma } from "@/lib/db";
+import { hashPassword } from "better-auth/crypto";
+import { generateSetupToken } from "@/lib/setup-token";
+import crypto from "node:crypto";
+
+interface ProvisionBody {
+    email: string;
+    name: string;
+    hubUserId: string;
+}
+
+/**
+ * Provision a new globe user and return a setup token.
+ *
+ * HMAC-protected — called by the hub when a new user signs up for cloud.
+ * Creates a BetterAuthUser, BetterAuthAccount (with placeholder password),
+ * PluginOrganization, PluginMember (owner), and a SetupToken.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+    const rawBody = await request.clone().text();
+    const authError = await crossServiceAuth(new Request(request.url, {
+        method: request.method,
+        headers: request.headers,
+        body: rawBody,
+    }));
+    if (authError) return authError;
+
+    let body: ProvisionBody;
+    try {
+        body = JSON.parse(rawBody) as ProvisionBody;
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!body.email || !body.name || !body.hubUserId) {
+        return NextResponse.json({ error: "Missing required fields: email, name, hubUserId" }, { status: 400 });
+    }
+
+    const email = body.email.trim().toLowerCase();
+
+    const existingUser = await prisma.betterAuthUser.findUnique({
+        where: { email },
+        select: { id: true },
+    });
+    if (existingUser) {
+        return NextResponse.json({ error: "User already provisioned" }, { status: 409 });
+    }
+
+    const placeholderPassword = crypto.randomBytes(32).toString("hex");
+    const hashedPlaceholder = await hashPassword(placeholderPassword);
+
+    const user = await prisma.betterAuthUser.create({
+        data: {
+            name: body.name,
+            email,
+            emailVerified: false,
+            role: "user",
+        },
+    });
+
+    await prisma.betterAuthAccount.create({
+        data: {
+            userId: user.id,
+            accountId: email,
+            providerId: "credential",
+            password: hashedPlaceholder,
+        },
+    });
+
+    const slug = email.replace(/[^a-zA-Z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+    let uniqueSlug = slug;
+    let attempt = 0;
+    while (true) {
+        const existingOrg = await prisma.pluginOrganization.findUnique({
+            where: { slug: uniqueSlug },
+            select: { id: true },
+        });
+        if (!existingOrg) break;
+        attempt++;
+        uniqueSlug = `${slug}-${attempt}`;
+    }
+
+    const org = await prisma.pluginOrganization.create({
+        data: {
+            name: `${body.name}'s Workspace`,
+            slug: uniqueSlug,
+        },
+    });
+
+    await prisma.pluginMember.create({
+        data: {
+            organizationId: org.id,
+            userId: user.id,
+            role: "owner",
+        },
+    });
+
+    const { rawToken } = await generateSetupToken(user.id, org.id);
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "";
+    return NextResponse.json({
+        setupToken: rawToken,
+        setupUrl: `${appUrl}/setup?token=${rawToken}`,
+    });
+}

--- a/src/app/setup/actions.ts
+++ b/src/app/setup/actions.ts
@@ -4,6 +4,7 @@ import { hashPassword } from "better-auth/crypto";
 import { prisma } from "@/lib/db";
 import { isDemo } from "@/core/edition";
 import { evaluatePasswordStrength, MIN_PASSWORD_SCORE } from "@/lib/password-strength";
+import { validateSetupToken, consumeSetupToken } from "@/lib/setup-token";
 
 interface SetupResult {
     success: boolean;
@@ -106,6 +107,88 @@ export async function createAdminAccount(formData: FormData): Promise<SetupResul
                 userId: userId,
                 password: hashedPassword,
             },
+        }),
+    ]);
+
+    return { success: true };
+}
+
+/**
+ * Validate a provision token and return the pre-filled user info.
+ *
+ * Returns valid=false if the token is missing, used, or expired.
+ * Returns valid=true with the user's email and name when the token is valid.
+ */
+export async function validateProvisionToken(token: string): Promise<{
+    valid: boolean;
+    email?: string;
+    name?: string;
+    error?: string;
+}> {
+    const record = await validateSetupToken(token);
+    if (!record) {
+        return { valid: false, error: "Invalid or expired setup link." };
+    }
+
+    const user = await prisma.betterAuthUser.findUnique({
+        where: { id: record.userId },
+        select: { email: true, name: true },
+    });
+    if (!user) {
+        return { valid: false, error: "Setup user not found." };
+    }
+
+    return { valid: true, email: user.email, name: user.name };
+}
+
+/**
+ * Activate a provisioned cloud account by consuming the setup token and
+ * setting the user's real password.
+ *
+ * Atomically consumes the setup token, updates the BetterAuthAccount with
+ * the user's chosen password, and marks the user as emailVerified.
+ *
+ * After activation, the user must log in manually at /login (no auto-login).
+ */
+export async function activateProvisionedAccount(
+    token: string,
+    name: string,
+    email: string,
+    password: string,
+): Promise<SetupResult> {
+    if (!name || !email || !password) {
+        return { success: false, error: "All fields are required." };
+    }
+    const strength = evaluatePasswordStrength(password);
+    if (strength.score < MIN_PASSWORD_SCORE) {
+        return { success: false, error: strength.feedback };
+    }
+    if (password.length < 8) {
+        return { success: false, error: "Password must be at least 8 characters." };
+    }
+
+    const record = await consumeSetupToken(token);
+    if (!record) {
+        return { success: false, error: "Invalid or expired setup link." };
+    }
+
+    const hashedPassword = await hashPassword(password);
+
+    await prisma.$transaction([
+        prisma.betterAuthUser.update({
+            where: { id: record.userId },
+            data: {
+                name,
+                email: email.trim().toLowerCase(),
+                emailVerified: true,
+            },
+        }),
+        prisma.betterAuthAccount.updateMany({
+            where: {
+                userId: record.userId,
+                providerId: "credential",
+            },
+            data: { password: hashedPassword },
         }),
     ]);
 

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,16 +1,40 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { createAdminAccount } from "./actions";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createAdminAccount, validateProvisionToken, activateProvisionedAccount } from "./actions";
 import styles from "./setup.module.css";
 
-export default function SetupPage() {
+function SetupForm() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const token = searchParams.get("token");
+    const isCloudMode = !!token;
+
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
+    const [prefillEmail, setPrefillEmail] = useState("");
+    const [prefillName, setPrefillName] = useState("");
+    const [tokenValid, setTokenValid] = useState(!isCloudMode);
+    const [tokenChecked, setTokenChecked] = useState(!isCloudMode);
 
-    async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    useEffect(() => {
+        if (!isCloudMode) return;
+        let cancelled = false;
+        validateProvisionToken(token!).then((result) => {
+            if (cancelled) return;
+            if (result.valid && result.email) {
+                setPrefillEmail(result.email);
+                setPrefillName(result.name ?? "");
+                setTokenValid(true);
+            } else {
+                setError(result.error ?? "Invalid or expired setup link.");
+            }
+            setTokenChecked(true);
+        });
+    }, [token, isCloudMode]);
+
+    async function handleLocalSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
         setError("");
         setLoading(true);
@@ -26,70 +50,179 @@ export default function SetupPage() {
         }
     }
 
+    async function handleCloudSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        setError("");
+        setLoading(true);
+
+        const formData = new FormData(e.currentTarget);
+        const name = formData.get("name") as string;
+        const email = formData.get("email") as string;
+        const password = formData.get("password") as string;
+
+        const result = await activateProvisionedAccount(token!, name, email, password);
+
+        if (result.success) {
+            router.push("/login");
+        } else {
+            setError(result.error ?? "Activation failed.");
+            setLoading(false);
+        }
+    }
+
+    if (isCloudMode && !tokenChecked) {
+        return (
+            <div className={styles.container}>
+                <div className={styles.card}>
+                    <p className={styles.subtitle}>Validating setup link...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (isCloudMode && !tokenValid) {
+        return (
+            <div className={styles.container}>
+                <div className={styles.card}>
+                    <div className={styles.logo}>W</div>
+                    <h1 className={styles.title}>Invalid Setup Link</h1>
+                    <p className={styles.error}>{error || "This setup link is invalid or has expired."}</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (isCloudMode) {
+        return (
+            <div className={styles.container}>
+                <div className={styles.card}>
+                    <div className={styles.logo}>W</div>
+                    <h1 className={styles.title}>Activate Your Account</h1>
+                    <p className={styles.subtitle}>Set up your password to activate your WorldWideView account</p>
+                    <form onSubmit={handleCloudSubmit} className={styles.form}>
+                        <label className={styles.label} htmlFor="name">
+                            Display Name
+                            <input
+                                id="name"
+                                name="name"
+                                type="text"
+                                required
+                                className={styles.input}
+                                placeholder="Your name"
+                                defaultValue={prefillName}
+                            />
+                        </label>
+                        <label className={styles.label} htmlFor="email">
+                            Email
+                            <input
+                                id="email"
+                                name="email"
+                                type="email"
+                                required
+                                className={styles.input}
+                                value={prefillEmail}
+                                readOnly
+                            />
+                        </label>
+                        <label className={styles.label} htmlFor="password">
+                            Password
+                            <input
+                                id="password"
+                                name="password"
+                                type="password"
+                                required
+                                minLength={8}
+                                className={styles.input}
+                                placeholder="Min. 8 characters"
+                            />
+                        </label>
+                        <label className={styles.label} htmlFor="confirm">
+                            Confirm Password
+                            <input
+                                id="confirm"
+                                name="confirm"
+                                type="password"
+                                required
+                                minLength={8}
+                                className={styles.input}
+                            />
+                        </label>
+                        {error && <p className={styles.error}>{error}</p>}
+                        <button type="submit" disabled={loading} className={styles.button}>
+                            {loading ? "Activating..." : "Activate Account"}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        );
+    }
+
     return (
-      <div className={styles.container}>
-        <div className={styles.card}>
-          <div className={styles.logo}>W</div>
-          <h1 className={styles.title}>Welcome to WorldWideView</h1>
-          <p className={styles.subtitle}>Create your admin account to get started</p>
-
-          <form onSubmit={handleSubmit} className={styles.form}>
-            <label className={styles.label} htmlFor="name">
-              Display Name
-              <input
-                id="name"
-                name="name"
-                type="text"
-                required
-                className={styles.input}
-                placeholder="Admin"
-              />
-            </label>
-
-            <label className={styles.label} htmlFor="email">
-              Email
-              <input
-                id="email"
-                name="email"
-                type="email"
-                required
-                className={styles.input}
-                placeholder="admin@example.com"
-              />
-            </label>
-
-            <label className={styles.label} htmlFor="password">
-              Password
-              <input
-                id="password"
-                name="password"
-                type="password"
-                required
-                minLength={8}
-                className={styles.input}
-                placeholder="Min. 8 characters"
-              />
-            </label>
-
-            <label className={styles.label} htmlFor="confirm">
-              Confirm Password
-              <input
-                id="confirm"
-                name="confirm"
-                type="password"
-                required
-                minLength={8}
-                className={styles.input}
-              />
-            </label>
-
-            {error && <p className={styles.error}>{error}</p>}
-
-            <button type="submit" disabled={loading} className={styles.button}>
-              {loading ? "Creating..." : "Create Admin Account"}
-            </button>
-          </form>
+        <div className={styles.container}>
+            <div className={styles.card}>
+                <div className={styles.logo}>W</div>
+                <h1 className={styles.title}>Welcome to WorldWideView</h1>
+                <p className={styles.subtitle}>Create your admin account to get started</p>
+                <form onSubmit={handleLocalSubmit} className={styles.form}>
+                    <label className={styles.label} htmlFor="name">
+                        Display Name
+                        <input
+                            id="name"
+                            name="name"
+                            type="text"
+                            required
+                            className={styles.input}
+                            placeholder="Admin"
+                        />
+                    </label>
+                    <label className={styles.label} htmlFor="email">
+                        Email
+                        <input
+                            id="email"
+                            name="email"
+                            type="email"
+                            required
+                            className={styles.input}
+                            placeholder="admin@example.com"
+                        />
+                    </label>
+                    <label className={styles.label} htmlFor="password">
+                        Password
+                        <input
+                            id="password"
+                            name="password"
+                            type="password"
+                            required
+                            minLength={8}
+                            className={styles.input}
+                            placeholder="Min. 8 characters"
+                        />
+                    </label>
+                    <label className={styles.label} htmlFor="confirm">
+                        Confirm Password
+                        <input
+                            id="confirm"
+                            name="confirm"
+                            type="password"
+                            required
+                            minLength={8}
+                            className={styles.input}
+                        />
+                    </label>
+                    {error && <p className={styles.error}>{error}</p>}
+                    <button type="submit" disabled={loading} className={styles.button}>
+                        {loading ? "Creating..." : "Create Admin Account"}
+                    </button>
+                </form>
+            </div>
         </div>
-      </div>
+    );
+}
+
+export default function SetupPage() {
+    return (
+        <Suspense fallback={<div className={styles.container}><div className={styles.card}><p className={styles.subtitle}>Loading...</p></div></div>}>
+            <SetupForm />
+        </Suspense>
     );
 }

--- a/src/lib/setup-token.test.ts
+++ b/src/lib/setup-token.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import crypto from "node:crypto";
+
+const mockDb = {
+    setupToken: {
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        updateMany: vi.fn(),
+    },
+};
+
+vi.mock("@/lib/db", () => ({
+    prisma: mockDb,
+}));
+
+const TOKEN_HEX_LENGTH = 64;
+
+async function importModule() {
+    return import("./setup-token");
+}
+
+describe("generateSetupToken", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("produces a 64-char hex raw token and stores SHA-256 hash", async () => {
+        const mockRecord = {
+            id: "uuid-1",
+            tokenHash: "abc123",
+            userId: "user-1",
+            organizationId: null,
+            expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            usedAt: null,
+            createdAt: new Date(),
+        };
+        mockDb.setupToken.create.mockResolvedValue(mockRecord);
+
+        const { generateSetupToken } = await importModule();
+        const result = await generateSetupToken("user-1");
+
+        expect(result.rawToken).toHaveLength(TOKEN_HEX_LENGTH);
+        expect(result.rawToken).toMatch(/^[0-9a-f]+$/);
+
+        const expectedHash = crypto.createHash("sha256").update(result.rawToken, "utf8").digest("hex");
+        expect(mockDb.setupToken.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                tokenHash: expectedHash,
+                userId: "user-1",
+                organizationId: null,
+            }),
+        });
+        expect(result.record).toBe(mockRecord);
+    });
+
+    it("accepts optional organizationId", async () => {
+        const mockRecord = {
+            id: "uuid-2",
+            tokenHash: "def456",
+            userId: "user-1",
+            organizationId: "org-1",
+            expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+            usedAt: null,
+            createdAt: new Date(),
+        };
+        mockDb.setupToken.create.mockResolvedValue(mockRecord);
+
+        const { generateSetupToken } = await importModule();
+        const result = await generateSetupToken("user-1", "org-1");
+
+        expect(mockDb.setupToken.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                userId: "user-1",
+                organizationId: "org-1",
+            }),
+        });
+        expect(result.rawToken).toHaveLength(TOKEN_HEX_LENGTH);
+    });
+
+    it("sets expiry to 24 hours from now", async () => {
+        const before = Date.now();
+        mockDb.setupToken.create.mockResolvedValue({
+            id: "uuid-3",
+            tokenHash: "hash",
+            userId: "user-1",
+            organizationId: null,
+            expiresAt: new Date(before + 24 * 60 * 60 * 1000),
+            usedAt: null,
+            createdAt: new Date(),
+        });
+
+        const { generateSetupToken } = await importModule();
+        await generateSetupToken("user-1");
+
+        const call = mockDb.setupToken.create.mock.calls[0][0];
+        const expiresAt = call.data.expiresAt.getTime();
+        const after = Date.now();
+
+        expect(expiresAt).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000 - 1000);
+        expect(expiresAt).toBeLessThanOrEqual(after + 24 * 60 * 60 * 1000 + 1000);
+    });
+});
+
+describe("validateSetupToken", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns the record for a valid token", async () => {
+        const rawToken = crypto.randomBytes(32).toString("hex");
+        const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+        const futureExpiry = new Date(Date.now() + 60 * 60 * 1000);
+
+        mockDb.setupToken.findUnique.mockResolvedValue({
+            id: "uuid-1",
+            tokenHash,
+            userId: "user-1",
+            organizationId: "org-1",
+            expiresAt: futureExpiry,
+            usedAt: null,
+            createdAt: new Date(),
+        });
+
+        const { validateSetupToken } = await importModule();
+        const result = await validateSetupToken(rawToken);
+
+        expect(result).not.toBeNull();
+        expect(result!.id).toBe("uuid-1");
+        expect(result!.userId).toBe("user-1");
+        expect(mockDb.setupToken.findUnique).toHaveBeenCalledWith({
+            where: { tokenHash },
+        });
+    });
+
+    it("returns null for an invalid token", async () => {
+        mockDb.setupToken.findUnique.mockResolvedValue(null);
+
+        const { validateSetupToken } = await importModule();
+        const result = await validateSetupToken("nonexistent-token");
+
+        expect(result).toBeNull();
+    });
+
+    it("returns null for a used token", async () => {
+        const rawToken = crypto.randomBytes(32).toString("hex");
+        const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+
+        mockDb.setupToken.findUnique.mockResolvedValue({
+            id: "uuid-1",
+            tokenHash,
+            userId: "user-1",
+            organizationId: null,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            usedAt: new Date(),
+            createdAt: new Date(),
+        });
+
+        const { validateSetupToken } = await importModule();
+        const result = await validateSetupToken(rawToken);
+
+        expect(result).toBeNull();
+    });
+
+    it("returns null for an expired token", async () => {
+        const rawToken = crypto.randomBytes(32).toString("hex");
+        const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+
+        mockDb.setupToken.findUnique.mockResolvedValue({
+            id: "uuid-1",
+            tokenHash,
+            userId: "user-1",
+            organizationId: null,
+            expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+            usedAt: null,
+            createdAt: new Date(),
+        });
+
+        const { validateSetupToken } = await importModule();
+        const result = await validateSetupToken(rawToken);
+
+        expect(result).toBeNull();
+    });
+});
+
+describe("consumeSetupToken", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("atomically consumes a valid token", async () => {
+        const rawToken = crypto.randomBytes(32).toString("hex");
+        const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+        const now = new Date();
+        const consumedRecord = {
+            id: "uuid-1",
+            tokenHash,
+            userId: "user-1",
+            organizationId: null,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            usedAt: now,
+            createdAt: new Date(),
+        };
+
+        mockDb.setupToken.updateMany.mockResolvedValue({ count: 1 });
+        mockDb.setupToken.findUnique.mockResolvedValue(consumedRecord);
+
+        const { consumeSetupToken } = await importModule();
+        const result = await consumeSetupToken(rawToken);
+
+        expect(result).not.toBeNull();
+        expect(result!.id).toBe("uuid-1");
+        expect(mockDb.setupToken.updateMany).toHaveBeenCalledWith({
+            where: {
+                tokenHash,
+                usedAt: null,
+                expiresAt: { gt: expect.any(Date) },
+            },
+            data: { usedAt: expect.any(Date) },
+        });
+    });
+
+    it("returns null when consumed twice (second call)", async () => {
+        const rawToken = crypto.randomBytes(32).toString("hex");
+
+        mockDb.setupToken.updateMany.mockResolvedValue({ count: 0 });
+
+        const { consumeSetupToken } = await importModule();
+        const result = await consumeSetupToken(rawToken);
+
+        expect(result).toBeNull();
+    });
+
+    it("returns null for an expired token", async () => {
+        const rawToken = crypto.randomBytes(32).toString("hex");
+
+        mockDb.setupToken.updateMany.mockResolvedValue({ count: 0 });
+
+        const { consumeSetupToken } = await importModule();
+        const result = await consumeSetupToken(rawToken);
+
+        expect(result).toBeNull();
+    });
+
+    it("returns null for an invalid token", async () => {
+        mockDb.setupToken.updateMany.mockResolvedValue({ count: 0 });
+
+        const { consumeSetupToken } = await importModule();
+        const result = await consumeSetupToken("nonexistent-token");
+
+        expect(result).toBeNull();
+    });
+});

--- a/src/lib/setup-token.ts
+++ b/src/lib/setup-token.ts
@@ -1,0 +1,99 @@
+import crypto from "node:crypto";
+import { prisma } from "@/lib/db";
+
+/**
+ * Generate a raw setup token and store its SHA-256 hash.
+ *
+ * Returns the raw token (to be sent to the user) and the database record.
+ * The token expires after 24 hours.
+ */
+export async function generateSetupToken(
+    userId: string,
+    organizationId?: string,
+): Promise<{ rawToken: string; record: { id: string; tokenHash: string; userId: string; organizationId: string | null; expiresAt: Date; usedAt: Date | null; createdAt: Date } }> {
+    const rawToken = crypto.randomBytes(32).toString("hex");
+    const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    const record = await prisma.setupToken.create({
+        data: {
+            tokenHash,
+            userId,
+            organizationId: organizationId ?? null,
+            expiresAt,
+        },
+    });
+
+    return { rawToken, record };
+}
+
+/**
+ * Validate a raw setup token without consuming it.
+ *
+ * Looks up the token by SHA-256 hash. Returns the record if found and
+ * not yet used/expired, otherwise returns null.
+ */
+export async function validateSetupToken(rawToken: string): Promise<{
+    id: string;
+    tokenHash: string;
+    userId: string;
+    organizationId: string | null;
+    expiresAt: Date;
+    usedAt: Date | null;
+    createdAt: Date;
+} | null> {
+    const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+
+    const record = await prisma.setupToken.findUnique({
+        where: { tokenHash },
+    });
+
+    if (!record) return null;
+    if (record.usedAt) return null;
+    if (record.expiresAt < new Date()) return null;
+
+    return record;
+}
+
+/**
+ * Atomically consume a setup token.
+ *
+ * Uses updateMany with a WHERE clause that ensures the token has not been
+ * used and has not expired. Returns the updated record if consumed, or
+ * null if the token is invalid, already used, or expired.
+ */
+export async function consumeSetupToken(rawToken: string): Promise<{
+    id: string;
+    tokenHash: string;
+    userId: string;
+    organizationId: string | null;
+    expiresAt: Date;
+    usedAt: Date;
+    createdAt: Date;
+} | null> {
+    const tokenHash = crypto.createHash("sha256").update(rawToken, "utf8").digest("hex");
+
+    const now = new Date();
+    const result = await prisma.setupToken.updateMany({
+        where: {
+            tokenHash,
+            usedAt: null,
+            expiresAt: { gt: now },
+        },
+        data: { usedAt: now },
+    });
+
+    if (result.count === 0) return null;
+
+    return prisma.setupToken.findUnique({
+        where: { tokenHash },
+    }) as Promise<{
+        id: string;
+        tokenHash: string;
+        userId: string;
+        organizationId: string | null;
+        expiresAt: Date;
+        usedAt: Date;
+        createdAt: Date;
+    } | null>;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,6 +39,7 @@ const PUBLIC_API_PREFIXES = [
     "/api/build",
     "/api/dev",
     "/api/service",
+    "/api/provision",
 ];
 
 function isPublicApiPath(path: string): boolean {

--- a/tests/setup-flow.spec.ts
+++ b/tests/setup-flow.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from '@playwright/test';
+import { PrismaClient } from '../src/generated/prisma/index.js';
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { hashPassword } from 'better-auth/crypto';
+import crypto from 'node:crypto';
+
+const SETUP_TEST_EMAIL = 'setup-e2e-test@test.local';
+const SETUP_TEST_PASSWORD = 'SetupTestPassword123!';
+
+test.describe('Setup Flow', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let prisma: PrismaClient;
+  let pool: Pool;
+
+  test.beforeAll(async () => {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public" });
+    const adapter = new PrismaPg(pool);
+    prisma = new PrismaClient({ adapter });
+
+    await prisma.betterAuthUser.deleteMany({
+      where: { email: SETUP_TEST_EMAIL },
+    });
+    await prisma.betterAuthAccount.deleteMany({
+      where: { accountId: SETUP_TEST_EMAIL },
+    });
+  });
+
+  test.afterAll(async () => {
+    await prisma.betterAuthUser.deleteMany({
+      where: { email: SETUP_TEST_EMAIL },
+    });
+    await prisma.betterAuthAccount.deleteMany({
+      where: { accountId: SETUP_TEST_EMAIL },
+    });
+    await prisma.$disconnect();
+    await pool.end();
+  });
+
+  test('local mode shows admin creation form', async ({ page }) => {
+    test.skip(!!process.env.CI, 'Requires clean DB with no users');
+    await page.goto('/setup');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('h1')).toContainText('Welcome');
+    await expect(page.locator('input#name')).toBeVisible();
+    await expect(page.locator('input#email')).toBeVisible();
+    await expect(page.locator('input#password')).toBeVisible();
+    await expect(page.locator('input#confirm')).toBeVisible();
+  });
+
+  test('cloud mode with valid token shows activation form', async ({ page }) => {
+    const tokenEmail = `setup-token-${Date.now()}@test.local`;
+    const userId = crypto.randomUUID();
+
+    try {
+      await prisma.betterAuthUser.create({
+        data: {
+          id: userId,
+          email: tokenEmail,
+          name: 'Setup Token Test',
+          emailVerified: false,
+          role: 'user',
+        },
+      });
+
+      const rawToken = crypto.randomBytes(32).toString('hex');
+      const tokenHash = crypto.createHash('sha256').update(rawToken, 'utf8').digest('hex');
+
+      await prisma.setupToken.create({
+        data: {
+          tokenHash,
+          userId,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        },
+      });
+
+      await page.goto(`/setup?token=${rawToken}`);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h1')).toContainText('Activate Your Account');
+      const emailInput = page.locator('input#email');
+      await expect(emailInput).toHaveValue(tokenEmail);
+      await expect(page.locator('input#name')).toBeVisible();
+      await expect(page.locator('input#password')).toBeVisible();
+      await expect(page.locator('input#confirm')).toBeVisible();
+    } finally {
+      await prisma.setupToken.deleteMany({ where: { userId } });
+      await prisma.betterAuthUser.deleteMany({ where: { id: userId } });
+    }
+  });
+
+  test('cloud mode with invalid token shows error', async ({ page }) => {
+    await page.goto('/setup?token=invalid-token-value');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('h1')).toContainText('Invalid Setup Link');
+    await expect(page.locator('p')).toContainText('invalid or has expired');
+  });
+
+  test('cloud activation - full flow', async ({ page }) => {
+    const activateEmail = `activate-${Date.now()}@test.local`;
+    const userId = crypto.randomUUID();
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(rawToken, 'utf8').digest('hex');
+
+    try {
+      await prisma.betterAuthUser.create({
+        data: {
+          id: userId,
+          email: activateEmail,
+          name: 'Activate Test',
+          emailVerified: false,
+          role: 'user',
+        },
+      });
+
+      await prisma.betterAuthAccount.create({
+        data: {
+          id: crypto.randomUUID(),
+          accountId: activateEmail,
+          providerId: 'credential',
+          userId,
+          password: await hashPassword(crypto.randomBytes(32).toString('hex')),
+        },
+      });
+
+      await prisma.setupToken.create({
+        data: {
+          tokenHash,
+          userId,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        },
+      });
+
+      await page.goto(`/setup?token=${rawToken}`);
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('h1')).toContainText('Activate Your Account');
+
+      await page.fill('input#name', 'Activated User');
+      await page.fill('input#password', SETUP_TEST_PASSWORD);
+      await page.fill('input#confirm', SETUP_TEST_PASSWORD);
+      await page.click('button[type="submit"]');
+
+      await page.waitForURL('/login', { timeout: 15000 });
+
+      await page.fill('input#email', activateEmail);
+      await page.fill('input#password', SETUP_TEST_PASSWORD);
+      await page.click('button[type="submit"]');
+
+      // Wait for redirect to home after login
+      await page.waitForURL('/', { timeout: 30000 });
+      await expect(page.locator('[data-testid="app-ready"]')).toBeVisible({ timeout: 30000 });
+    } finally {
+      await prisma.setupToken.deleteMany({ where: { userId } });
+      await prisma.betterAuthAccount.deleteMany({ where: { userId } });
+      await prisma.betterAuthUser.deleteMany({ where: { id: userId } });
+    }
+  });
+
+  test('provision endpoint rejects request without HMAC signature', async ({ page }) => {
+    const response = await page.request.post('/api/provision', {
+      data: { email: 'test@test.local', name: 'Test', hubUserId: 'hub-1' },
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test('provision endpoint rejects request with invalid HMAC', async ({ page }) => {
+    const response = await page.request.post('/api/provision', {
+      data: { email: 'test@test.local', name: 'Test', hubUserId: 'hub-1' },
+      headers: { 'X-Service-Signature': 't=0,n=invalid,sig=0000' },
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test('provision endpoint returns 400 for invalid body', async () => {
+    const secret = process.env.CROSS_SERVICE_SECRET || 'test-secret';
+    const body = 'not-json';
+    const timestamp = Date.now();
+    const nonce = crypto.randomUUID();
+    const bodyHash = crypto.createHash('sha256').update(body, 'utf8').digest('hex');
+    const canon = `POST\n/api/provision\n${timestamp}\n${bodyHash}`;
+    const sig = crypto.createHmac('sha256', secret).update(canon, 'utf8').digest('hex');
+
+    const response = await fetch('http://localhost:3001/api/provision', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Service-Signature': `t=${timestamp},n=${nonce},sig=${sig}`,
+      },
+      body,
+    });
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the globe side of the provisioning flow for Phase 2. The hub calls `/api/provision` via HMAC to create a new org and setup token for a new cloud user. The user then visits `/setup?token=xxx` to activate their account.

## What Changed

### New Files
- `prisma/migrations/20260702121851_add_setup_token/` — Prisma migration for SetupToken model
- `src/lib/setup-token.ts` — Library: `generateSetupToken`, `validateSetupToken`, `consumeSetupToken`
- `src/lib/setup-token.test.ts` — 11 unit tests covering token generation, validation, consumption, and expiry
- `src/app/api/provision/route.ts` — HMAC-protected POST endpoint for hub provisioning
- `tests/setup-flow.spec.ts` — 6 Playwright E2E tests for setup page and provision endpoint

### Modified Files
- `prisma/schema.prisma` — Added SetupToken model with relation to BetterAuthUser
- `src/app/setup/actions.ts` — Added `validateProvisionToken` and `activateProvisionedAccount` server actions
- `src/app/setup/page.tsx` — Dual-mode setup page (local admin creation + cloud token activation)
- `src/proxy.ts` — Added `/api/provision` to PUBLIC_API_PREFIXES
- `package.json` — Bumped 2.55.0 → 2.56.0

### Key Design Decisions
- Custom SetupToken model (not Better Auth oneTimeToken plugin — requires existing session)
- Atomic consumption via `updateMany` with WHERE guard
- Org + member created directly via Prisma (auth.api.createOrganization requires session headers)
- Token stored as SHA-256 hash, raw token returned to caller (24h expiry)
- After cloud setup, user redirected to /login for manual login (no auto-login/SSO)

## Test Results
- Lint: PASS (0 errors, only pre-existing warnings)
- Typecheck: PASS
- Unit tests: 114/115 files pass, 1118/1118 tests pass (1 pre-existing fail in wwv-plugin-sdk)
- SetupToken tests: 11/11 pass