### PR TITLE
feat(3a): Org tier tracking + feature gating

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -78,6 +78,9 @@ jobs:
         # Must match the value used by the Next.js app in the Docker Compose stack.
         # A non-empty string of sufficient length — not sensitive in test CI.
         BETTER_AUTH_SECRET: test-better-auth-secret-at-least-32-chars!
+        # Cross-service HMAC secret for hub <-> globe communication.
+        # Must match the value in playwright.config.ts webServer env.
+        CROSS_SERVICE_SECRET: test-cross-service-secret-for-e2e
       run: pnpm test:e2e --project=${{ matrix.browser }}
       
     - uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -89,6 +89,7 @@ export default defineConfig({
       env: {
         PORT: '3001',
         NEXT_PUBLIC_WWV_EDITION: 'local',
+        CROSS_SERVICE_SECRET: 'test-cross-service-secret-for-e2e',
         NEXT_PUBLIC_APP_URL: 'http://localhost:3001',
         NEXT_PUBLIC_MARKETPLACE_URL: 'http://localhost:3002',
       },

--- a/prisma/migrations/20260702140543_add_org_tier/migration.sql
+++ b/prisma/migrations/20260702140543_add_org_tier/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "org_tiers" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "tier" TEXT NOT NULL DEFAULT 'free',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "trialEndsAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "org_tiers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "org_tiers_organizationId_key" ON "org_tiers"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "org_tiers" ADD CONSTRAINT "org_tiers_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,8 +205,22 @@ model PluginOrganization {
   logo      String?
   metadata  String?
   createdAt DateTime @default(now())
+  orgTier   OrgTier?
 
   @@map("organization")
+}
+
+model OrgTier {
+  id             String             @id @default(uuid())
+  organizationId String             @unique
+  organization   PluginOrganization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  tier           String             @default("free")
+  status         String             @default("active")
+  trialEndsAt    DateTime?
+  updatedAt      DateTime           @updatedAt
+  createdAt      DateTime           @default(now())
+
+  @@map("org_tiers")
 }
 
 model PluginMember {

--- a/scripts/boot-db.mjs
+++ b/scripts/boot-db.mjs
@@ -29,7 +29,7 @@ const loadEnv = (file) => {
           // Remove quotes
           if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
           if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
-          process.env[key] = value;
+          if (value) process.env[key] = value;
         }
       });
     }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -24,7 +24,7 @@ const loadEnv = (file) => {
           let value = match[2] || '';
           if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
           if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
-          process.env[key] = value;
+          if (value) process.env[key] = value;
         }
       });
     }

--- a/src/app/api/service/tier-sync/route.ts
+++ b/src/app/api/service/tier-sync/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+import { resolveOrgIdByEmail, setOrgTier } from "@/lib/org-tier";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const authError = await crossServiceAuth(request);
+  if (authError) return authError;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const email = body.email;
+  const tier = body.tier;
+  const status = body.status;
+
+  if (!email || !tier) {
+    return NextResponse.json({ error: "Missing required fields: email, tier" }, { status: 400 });
+  }
+
+  if (typeof email !== "string" || typeof tier !== "string") {
+    return NextResponse.json({ error: "email and tier must be strings" }, { status: 400 });
+  }
+
+  const validTiers = ["free", "pro", "enterprise"];
+  if (!validTiers.includes(tier)) {
+    return NextResponse.json({ error: `Invalid tier: ${tier}. Must be one of: ${validTiers.join(", ")}` }, { status: 400 });
+  }
+
+  const validStatuses = ["active", "trialing", "past_due", "suspended"];
+  if (status && typeof status === "string" && !validStatuses.includes(status)) {
+    return NextResponse.json({ error: `Invalid status: ${status}. Must be one of: ${validStatuses.join(", ")}` }, { status: 400 });
+  }
+
+  let trialEndsAt: Date | undefined;
+  if (body.trialEndsAt) {
+    trialEndsAt = new Date(body.trialEndsAt as string);
+    if (isNaN(trialEndsAt.getTime())) {
+      return NextResponse.json({ error: "Invalid trialEndsAt date" }, { status: 400 });
+    }
+  }
+
+  const orgId = await resolveOrgIdByEmail(email);
+  if (!orgId) {
+    return NextResponse.json({ error: "Organization not found for email" }, { status: 404 });
+  }
+
+  try {
+    await setOrgTier(orgId, {
+      tier: tier as string,
+      status: (status as string) || "active",
+      trialEndsAt,
+    });
+  } catch (e) {
+    console.error("[tier-sync] Failed to upsert tier:", e);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    organizationId: orgId,
+    tier,
+    status: status || "active",
+  });
+}

--- a/src/app/api/service/tier/route.ts
+++ b/src/app/api/service/tier/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { crossServiceAuth } from "@/lib/cross-service/middleware";
 import { getActiveOrgId } from "@/lib/ba-org";
-import { getOrgTier, getEffectiveTier, resolveOrgIdByEmail } from "@/lib/org-tier";
+import { getOrgTier, resolveOrgIdByEmail } from "@/lib/org-tier";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const authError = await crossServiceAuth(request);
@@ -35,14 +35,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Unable to determine organization" }, { status: 400 });
   }
 
-  const [tierData, effectiveTier] = await Promise.all([
-    getOrgTier(orgId),
-    getEffectiveTier(orgId),
-  ]);
+  const tierData = await getOrgTier(orgId);
+  const isExpiredTrial = tierData.status === "trialing" && tierData.trialEndsAt && tierData.trialEndsAt < new Date();
+  const effectiveTier = isExpiredTrial ? "free" : tierData.tier;
+  const effectiveStatus = isExpiredTrial ? "expired" : tierData.status;
 
   return NextResponse.json({
     ...tierData,
-    effectiveTier: effectiveTier.tier,
-    effectiveStatus: effectiveTier.status,
+    effectiveTier,
+    effectiveStatus,
   });
 }

--- a/src/app/api/service/tier/route.ts
+++ b/src/app/api/service/tier/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+import { getActiveOrgId } from "@/lib/ba-org";
+import { getOrgTier, getEffectiveTier, resolveOrgIdByEmail } from "@/lib/org-tier";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authError = await crossServiceAuth(request);
+  const isServiceAuth = !authError;
+
+  if (!isServiceAuth) {
+    const sessionOrgId = await getActiveOrgId();
+    if (!sessionOrgId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const { searchParams } = new URL(request.url);
+  const orgIdParam = searchParams.get("organizationId");
+  const emailParam = searchParams.get("email");
+
+  let orgId: string | null = null;
+
+  if (orgIdParam) {
+    orgId = orgIdParam;
+  } else if (emailParam) {
+    orgId = await resolveOrgIdByEmail(emailParam);
+    if (!orgId) {
+      return NextResponse.json({ error: "Organization not found for email" }, { status: 404 });
+    }
+  } else {
+    orgId = await getActiveOrgId();
+  }
+
+  if (!orgId) {
+    return NextResponse.json({ error: "Unable to determine organization" }, { status: 400 });
+  }
+
+  const [tierData, effectiveTier] = await Promise.all([
+    getOrgTier(orgId),
+    getEffectiveTier(orgId),
+  ]);
+
+  return NextResponse.json({
+    ...tierData,
+    effectiveTier: effectiveTier.tier,
+    effectiveStatus: effectiveTier.status,
+  });
+}

--- a/src/lib/gating/planGating.test.ts
+++ b/src/lib/gating/planGating.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { hasMinimumPlan } from "./planGating";
+
+describe("hasMinimumPlan", () => {
+  it("free meets free minimum", () => {
+    expect(hasMinimumPlan("free", "free")).toBe(true);
+  });
+
+  it("free does not meet pro minimum", () => {
+    expect(hasMinimumPlan("free", "pro")).toBe(false);
+  });
+
+  it("free does not meet enterprise minimum", () => {
+    expect(hasMinimumPlan("free", "enterprise")).toBe(false);
+  });
+
+  it("pro meets free minimum", () => {
+    expect(hasMinimumPlan("pro", "free")).toBe(true);
+  });
+
+  it("pro meets pro minimum", () => {
+    expect(hasMinimumPlan("pro", "pro")).toBe(true);
+  });
+
+  it("pro does not meet enterprise minimum", () => {
+    expect(hasMinimumPlan("pro", "enterprise")).toBe(false);
+  });
+
+  it("enterprise meets all minimums", () => {
+    expect(hasMinimumPlan("enterprise", "free")).toBe(true);
+    expect(hasMinimumPlan("enterprise", "pro")).toBe(true);
+    expect(hasMinimumPlan("enterprise", "enterprise")).toBe(true);
+  });
+
+  it("handles unknown plan as rank 0", () => {
+    expect(hasMinimumPlan("unknown", "free")).toBe(true);
+    expect(hasMinimumPlan("free", "unknown")).toBe(true);
+  });
+});

--- a/src/lib/gating/planGating.ts
+++ b/src/lib/gating/planGating.ts
@@ -1,0 +1,11 @@
+export const PLAN_HIERARCHY: Record<string, number> = {
+  free: 0,
+  pro: 1,
+  enterprise: 2,
+};
+
+export function hasMinimumPlan(userPlan: string, minimum: string): boolean {
+  const userRank = PLAN_HIERARCHY[userPlan] ?? 0;
+  const minRank = PLAN_HIERARCHY[minimum] ?? 0;
+  return userRank >= minRank;
+}

--- a/src/lib/gating/requirePlan.test.ts
+++ b/src/lib/gating/requirePlan.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+const mockGetActiveOrgId = vi.hoisted(() => vi.fn());
+const mockGetEffectiveTier = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/ba-org", () => ({
+  getActiveOrgId: mockGetActiveOrgId,
+}));
+
+vi.mock("@/lib/org-tier", () => ({
+  getEffectiveTier: mockGetEffectiveTier,
+}));
+
+import { requirePlan } from "./requirePlan";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function getStatus(response: NextResponse | null): Promise<number | null> {
+  if (!response) return null;
+  return response.status;
+}
+
+describe("requirePlan", () => {
+  it("returns null when no org (local edition)", async () => {
+    mockGetActiveOrgId.mockResolvedValue(null);
+
+    const result = await requirePlan("pro");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when free meets free requirement", async () => {
+    mockGetActiveOrgId.mockResolvedValue("org-1");
+    mockGetEffectiveTier.mockResolvedValue({ tier: "free", status: "active" });
+
+    const result = await requirePlan("free");
+    expect(result).toBeNull();
+  });
+
+  it("blocks free user trying to access pro feature", async () => {
+    mockGetActiveOrgId.mockResolvedValue("org-1");
+    mockGetEffectiveTier.mockResolvedValue({ tier: "free", status: "active" });
+
+    const result = await requirePlan("pro");
+    expect(result).not.toBeNull();
+    expect(await getStatus(result)).toBe(402);
+    const body = await (result as NextResponse).json();
+    expect(body).toMatchObject({ error: "Upgrade required", required: "pro", current: "free" });
+  });
+
+  it("allows pro user to access pro feature", async () => {
+    mockGetActiveOrgId.mockResolvedValue("org-1");
+    mockGetEffectiveTier.mockResolvedValue({ tier: "pro", status: "active" });
+
+    const result = await requirePlan("pro");
+    expect(result).toBeNull();
+  });
+
+  it("blocks suspended subscription", async () => {
+    mockGetActiveOrgId.mockResolvedValue("org-1");
+    mockGetEffectiveTier.mockResolvedValue({ tier: "pro", status: "suspended" });
+
+    const result = await requirePlan("free");
+    expect(result).not.toBeNull();
+    expect(await getStatus(result)).toBe(402);
+    const body = await (result as NextResponse).json();
+    expect(body).toMatchObject({ error: "Subscription suspended" });
+  });
+});

--- a/src/lib/gating/requirePlan.ts
+++ b/src/lib/gating/requirePlan.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getActiveOrgId } from "@/lib/ba-org";
+import { getEffectiveTier } from "@/lib/org-tier";
+import { hasMinimumPlan } from "./planGating";
+
+export async function requirePlan(minimum: "free" | "pro" | "enterprise"): Promise<NextResponse | null> {
+  const orgId = await getActiveOrgId();
+  if (!orgId) return null;
+
+  const { tier, status } = await getEffectiveTier(orgId);
+
+  if (status === "suspended") {
+    return NextResponse.json({ error: "Subscription suspended" }, { status: 402 });
+  }
+
+  if (!hasMinimumPlan(tier, minimum)) {
+    return NextResponse.json(
+      { error: "Upgrade required", required: minimum, current: tier },
+      { status: 402 }
+    );
+  }
+
+  return null;
+}

--- a/src/lib/org-tier.test.ts
+++ b/src/lib/org-tier.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindUnique = vi.hoisted(() => vi.fn());
+const mockUpsert = vi.hoisted(() => vi.fn());
+const mockBetterUserFindUnique = vi.hoisted(() => vi.fn());
+const mockMemberFindFirst = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    orgTier: {
+      findUnique: mockFindUnique,
+      upsert: mockUpsert,
+    },
+    betterAuthUser: {
+      findUnique: mockBetterUserFindUnique,
+    },
+    pluginMember: {
+      findFirst: mockMemberFindFirst,
+    },
+  },
+}));
+
+import { getOrgTier, setOrgTier, resolveOrgIdByEmail, getEffectiveTier } from "./org-tier";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getOrgTier", () => {
+  it("returns default free tier when no record exists", async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await getOrgTier("org-1");
+    expect(result).toEqual({ tier: "free", status: "active", trialEndsAt: null });
+  });
+
+  it("returns stored tier when record exists", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "tier-1",
+      organizationId: "org-1",
+      tier: "pro",
+      status: "active",
+      trialEndsAt: null,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const result = await getOrgTier("org-1");
+    expect(result).toEqual({ tier: "pro", status: "active", trialEndsAt: null });
+  });
+});
+
+describe("setOrgTier", () => {
+  it("upserts tier data", async () => {
+    mockUpsert.mockResolvedValue({});
+
+    await setOrgTier("org-1", { tier: "pro", status: "active" });
+
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { organizationId: "org-1" },
+      create: {
+        organizationId: "org-1",
+        tier: "pro",
+        status: "active",
+        trialEndsAt: null,
+      },
+      update: {
+        tier: "pro",
+        status: "active",
+        trialEndsAt: null,
+      },
+    });
+  });
+
+  it("includes trialEndsAt when provided", async () => {
+    mockUpsert.mockResolvedValue({});
+    const trialDate = new Date("2025-12-31");
+
+    await setOrgTier("org-1", { tier: "pro", status: "trialing", trialEndsAt: trialDate });
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ trialEndsAt: trialDate }),
+      }),
+    );
+  });
+});
+
+describe("resolveOrgIdByEmail", () => {
+  it("returns orgId when user and membership exist", async () => {
+    mockBetterUserFindUnique.mockResolvedValue({ id: "user-1" });
+    mockMemberFindFirst.mockResolvedValue({ organizationId: "org-1" });
+
+    const result = await resolveOrgIdByEmail("user@test.com");
+    expect(result).toBe("org-1");
+  });
+
+  it("returns null when user not found", async () => {
+    mockBetterUserFindUnique.mockResolvedValue(null);
+
+    const result = await resolveOrgIdByEmail("unknown@test.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user has no membership", async () => {
+    mockBetterUserFindUnique.mockResolvedValue({ id: "user-1" });
+    mockMemberFindFirst.mockResolvedValue(null);
+
+    const result = await resolveOrgIdByEmail("user@test.com");
+    expect(result).toBeNull();
+  });
+});
+
+describe("getEffectiveTier", () => {
+  it("returns stored tier and status when active", async () => {
+    mockFindUnique.mockResolvedValue({
+      id: "tier-1",
+      organizationId: "org-1",
+      tier: "pro",
+      status: "active",
+      trialEndsAt: null,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const result = await getEffectiveTier("org-1");
+    expect(result).toEqual({ tier: "pro", status: "active" });
+  });
+
+  it("returns expired when trial has ended", async () => {
+    const pastDate = new Date(Date.now() - 86400000);
+    mockFindUnique.mockResolvedValue({
+      id: "tier-1",
+      organizationId: "org-1",
+      tier: "pro",
+      status: "trialing",
+      trialEndsAt: pastDate,
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const result = await getEffectiveTier("org-1");
+    expect(result).toEqual({ tier: "free", status: "expired" });
+  });
+
+  it("returns default free when no record exists", async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await getEffectiveTier("org-1");
+    expect(result).toEqual({ tier: "free", status: "active" });
+  });
+});

--- a/src/lib/org-tier.ts
+++ b/src/lib/org-tier.ts
@@ -1,0 +1,73 @@
+import { prisma } from "@/lib/db";
+
+export interface OrgTierData {
+  tier: string;
+  status: string;
+  trialEndsAt: Date | null;
+}
+
+export interface TierInput {
+  tier: string;
+  status: string;
+  trialEndsAt?: Date | null;
+}
+
+export async function getOrgTier(orgId: string): Promise<OrgTierData> {
+  const record = await prisma.orgTier.findUnique({
+    where: { organizationId: orgId },
+  });
+
+  if (!record) {
+    return { tier: "free", status: "active", trialEndsAt: null };
+  }
+
+  return {
+    tier: record.tier,
+    status: record.status,
+    trialEndsAt: record.trialEndsAt,
+  };
+}
+
+export async function setOrgTier(orgId: string, data: TierInput): Promise<void> {
+  await prisma.orgTier.upsert({
+    where: { organizationId: orgId },
+    create: {
+      organizationId: orgId,
+      tier: data.tier,
+      status: data.status,
+      trialEndsAt: data.trialEndsAt ?? null,
+    },
+    update: {
+      tier: data.tier,
+      status: data.status,
+      trialEndsAt: data.trialEndsAt ?? null,
+    },
+  });
+}
+
+export async function resolveOrgIdByEmail(email: string): Promise<string | null> {
+  const user = await prisma.betterAuthUser.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+
+  if (!user) return null;
+
+  const membership = await prisma.pluginMember.findFirst({
+    where: { userId: user.id },
+    select: { organizationId: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return membership?.organizationId ?? null;
+}
+
+export async function getEffectiveTier(orgId: string): Promise<{ tier: string; status: string }> {
+  const { tier, status, trialEndsAt } = await getOrgTier(orgId);
+
+  if (status === "trialing" && trialEndsAt && trialEndsAt < new Date()) {
+    return { tier: "free", status: "expired" };
+  }
+
+  return { tier, status };
+}

--- a/tests/global.teardown.ts
+++ b/tests/global.teardown.ts
@@ -20,7 +20,7 @@ function loadEnv() {
           let value = match[2] || '';
           if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
           if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
-          process.env[key] = value;
+          if (value) process.env[key] = value;
         }
       });
     }

--- a/tests/tier-sync.spec.ts
+++ b/tests/tier-sync.spec.ts
@@ -1,126 +1,148 @@
 import { test, expect } from '@playwright/test';
 import { PrismaClient } from '../src/generated/prisma/index.js';
-import { PrismaPg } from "@prisma/adapter-pg";
-import { Pool } from "pg";
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
 import crypto from 'node:crypto';
-import { signCrossServiceRequest } from '../src/lib/cross-service/sign';
 
-const SYNC_EMAIL = `tier-sync-${Date.now()}@test.local`;
+const CROSS_SERVICE_SECRET = 'test-cross-service-secret-for-e2e';
+
+function signRequest(method: string, path: string, body?: Record<string, unknown>): string {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = crypto.randomUUID();
+  const bodyStr = body !== undefined ? JSON.stringify(body) : '';
+  const bodyHash = crypto.createHash('sha256').update(bodyStr, 'utf8').digest('hex');
+  const canon = `${method}\n${path}\n${timestamp}\n${bodyHash}`;
+  const sig = crypto.createHmac('sha256', CROSS_SERVICE_SECRET).update(canon, 'utf8').digest('hex');
+  return `t=${timestamp},n=${nonce},sig=${sig}`;
+}
 
 test.describe('Tier Sync API', () => {
   test.describe.configure({ mode: 'serial' });
 
+  const SYNC_EMAIL = `tier-sync-e2e-${Date.now()}@test.local`;
+  let testOrgId: string;
   let prisma: PrismaClient;
   let pool: Pool;
-  let orgId: string;
-  let userId: string;
 
   test.beforeAll(async () => {
-    process.env.CROSS_SERVICE_SECRET = 'test-cross-service-secret-for-e2e';
-    pool = new Pool({ connectionString: process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public" });
+    process.env.CROSS_SERVICE_SECRET = CROSS_SERVICE_SECRET;
+
+    pool = new Pool({
+      connectionString: process.env.DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public',
+    });
     const adapter = new PrismaPg(pool);
     prisma = new PrismaClient({ adapter });
 
-    userId = crypto.randomUUID();
-    orgId = crypto.randomUUID();
-
-    await prisma.betterAuthUser.create({
+    const org = await prisma.pluginOrganization.create({
       data: {
-        id: userId,
+        name: 'Tier Sync Test Org',
+        slug: `tier-sync-test-${Date.now()}`,
+      },
+    });
+    testOrgId = org.id;
+
+    const user = await prisma.betterAuthUser.create({
+      data: {
         email: SYNC_EMAIL,
-        name: 'Tier Sync Test',
-        emailVerified: true,
-        role: 'user',
+        name: 'Tier Sync Test User',
       },
     });
 
     await prisma.pluginMember.create({
       data: {
-        organizationId: orgId,
-        userId,
+        organizationId: testOrgId,
+        userId: user.id,
         role: 'admin',
-        createdAt: new Date(),
-      },
-    });
-
-    await prisma.pluginOrganization.create({
-      data: {
-        id: orgId,
-        name: 'Tier Sync Test Org',
-        slug: `tier-sync-${Date.now()}`,
       },
     });
   });
 
   test.afterAll(async () => {
-    await prisma.orgTier.deleteMany({ where: { organizationId: orgId } }).catch(() => {});
-    await prisma.pluginMember.deleteMany({ where: { userId } }).catch(() => {});
-    await prisma.pluginOrganization.deleteMany({ where: { id: orgId } }).catch(() => {});
-    await prisma.betterAuthUser.deleteMany({ where: { id: userId } }).catch(() => {});
+    await prisma.pluginMember.deleteMany({ where: { organizationId: testOrgId } });
+    await prisma.orgTier.deleteMany({ where: { organizationId: testOrgId } });
+    await prisma.betterAuthSession.deleteMany({
+      where: { user: { email: SYNC_EMAIL } },
+    });
+    await prisma.betterAuthAccount.deleteMany({
+      where: { user: { email: SYNC_EMAIL } },
+    });
+    await prisma.betterAuthUser.deleteMany({ where: { email: SYNC_EMAIL } });
+    await prisma.pluginOrganization.deleteMany({ where: { id: testOrgId } });
     await prisma.$disconnect();
     await pool.end();
   });
 
-  test('HMAC-signed tier-sync request returns 200 and updates tier', async ({ page }) => {
-    const body = { email: SYNC_EMAIL, tier: 'pro', status: 'active' };
-    const bodyStr = JSON.stringify(body);
-    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
-
+  test('unsigned tier-sync request returns 401', async ({ page }) => {
     const response = await page.request.post('/api/service/tier-sync', {
-      data: bodyStr,
-      headers: { ...headers, 'Content-Type': 'application/json' },
-    });
-
-    expect(response.status()).toBe(200);
-    const json = await response.json();
-    expect(json.success).toBe(true);
-    expect(json.organizationId).toBe(orgId);
-    expect(json.tier).toBe('pro');
-    expect(json.status).toBe('active');
-  });
-
-  test('unsigned request returns 401', async ({ page }) => {
-    const response = await page.request.post('/api/service/tier-sync', {
-      data: { email: SYNC_EMAIL, tier: 'pro', status: 'active' },
+      data: { email: 'test@example.com', tier: 'pro', status: 'active' },
     });
     expect(response.status()).toBe(401);
   });
 
-  test('invalid body returns 400', async ({ page }) => {
-    const body = {};
-    const bodyStr = JSON.stringify(body);
-    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
+  test('HMAC-signed tier-sync returns 200', async ({ page }) => {
+    const body = { email: SYNC_EMAIL, tier: 'pro', status: 'active' };
+    const sigHeader = signRequest('POST', '/api/service/tier-sync', body);
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: bodyStr,
-      headers: { ...headers, 'Content-Type': 'application/json' },
+      data: body,
+      headers: { 'X-Service-Signature': sigHeader },
     });
+
+    if (response.status() !== 200) {
+      const errBody = await response.text();
+      console.error(`[tier-sync] HMAC 200 test FAIL: status=${response.status()}, body=${errBody}`);
+    }
+    expect(response.status()).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+  });
+
+  test('HMAC-signed with missing required fields returns 400', async ({ page }) => {
+    const body = { email: 'test@test.com' };
+    const sigHeader = signRequest('POST', '/api/service/tier-sync', body);
+
+    const response = await page.request.post('/api/service/tier-sync', {
+      data: body,
+      headers: { 'X-Service-Signature': sigHeader },
+    });
+
     expect(response.status()).toBe(400);
   });
 
-  test('non-existent email returns 404', async ({ page }) => {
-    const body = { email: 'nonexistent@test.local', tier: 'free', status: 'active' };
-    const bodyStr = JSON.stringify(body);
-    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
+  test('HMAC-signed with non-existent email returns 404', async ({ page }) => {
+    const body = { email: `nonexistent-${Date.now()}@test.local`, tier: 'pro', status: 'active' };
+    const sigHeader = signRequest('POST', '/api/service/tier-sync', body);
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: bodyStr,
-      headers: { ...headers, 'Content-Type': 'application/json' },
+      data: body,
+      headers: { 'X-Service-Signature': sigHeader },
     });
+
     expect(response.status()).toBe(404);
   });
 
-  test('tier query returns updated tier after sync', async ({ page }) => {
-    const headers = signCrossServiceRequest({ method: 'GET', path: '/api/service/tier' });
+  test('tier query returns synced tier after HMAC-signed sync', async ({ page }) => {
+    const syncBody = { email: SYNC_EMAIL, tier: 'enterprise', status: 'active' };
+    const syncSig = signRequest('POST', '/api/service/tier-sync', syncBody);
 
-    const response = await page.request.get(`/api/service/tier?email=${encodeURIComponent(SYNC_EMAIL)}`, {
-      headers,
+    const syncResp = await page.request.post('/api/service/tier-sync', {
+      data: syncBody,
+      headers: { 'X-Service-Signature': syncSig },
     });
 
-    expect(response.status()).toBe(200);
-    const body = await response.json();
-    expect(body.tier).toBe('pro');
-    expect(body.status).toBe('active');
-    expect(body.effectiveTier).toBe('pro');
+    expect(syncResp.status()).toBe(200);
+
+    const querySig = signRequest('GET', '/api/service/tier');
+    const queryResp = await page.request.get(`/api/service/tier?email=${SYNC_EMAIL}`, {
+      headers: { 'X-Service-Signature': querySig },
+    });
+
+    if (queryResp.status() !== 200) {
+      const errBody = await queryResp.text();
+      console.error(`[tier-sync] Query test FAIL: status=${queryResp.status()}, body=${errBody}`);
+    }
+    expect(queryResp.status()).toBe(200);
+    const data = await queryResp.json();
+    expect(data.tier).toBe('enterprise');
   });
 });

--- a/tests/tier-sync.spec.ts
+++ b/tests/tier-sync.spec.ts
@@ -63,11 +63,12 @@ test.describe('Tier Sync API', () => {
 
   test('HMAC-signed tier-sync request returns 200 and updates tier', async ({ page }) => {
     const body = { email: SYNC_EMAIL, tier: 'pro', status: 'active' };
+    const bodyStr = JSON.stringify(body);
     const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: body,
-      headers,
+      data: bodyStr,
+      headers: { ...headers, 'Content-Type': 'application/json' },
     });
 
     expect(response.status()).toBe(200);
@@ -86,22 +87,25 @@ test.describe('Tier Sync API', () => {
   });
 
   test('invalid body returns 400', async ({ page }) => {
-    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body: {} });
+    const body = {};
+    const bodyStr = JSON.stringify(body);
+    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: {},
-      headers,
+      data: bodyStr,
+      headers: { ...headers, 'Content-Type': 'application/json' },
     });
     expect(response.status()).toBe(400);
   });
 
   test('non-existent email returns 404', async ({ page }) => {
     const body = { email: 'nonexistent@test.local', tier: 'free', status: 'active' };
+    const bodyStr = JSON.stringify(body);
     const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: body,
-      headers,
+      data: bodyStr,
+      headers: { ...headers, 'Content-Type': 'application/json' },
     });
     expect(response.status()).toBe(404);
   });

--- a/tests/tier-sync.spec.ts
+++ b/tests/tier-sync.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/test';
+import { PrismaClient } from '../src/generated/prisma/index.js';
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import crypto from 'node:crypto';
+
+const TEST_SECRET = 'test-cross-service-secret-for-e2e';
+const SYNC_EMAIL = `tier-sync-${Date.now()}@test.local`;
+
+function signRequest(method: string, path: string, body: unknown, secret: string) {
+  const nonce = crypto.randomUUID();
+  const timestamp = Math.floor(Date.now() / 1000);
+  const bodyStr = body !== undefined ? JSON.stringify(body) : '';
+  const bodyHash = crypto.createHash('sha256').update(bodyStr, 'utf8').digest('hex');
+  const canon = `${method}\n${path}\n${timestamp}\n${bodyHash}`;
+  const sig = crypto.createHmac('sha256', secret).update(canon, 'utf8').digest('hex');
+  return {
+    'X-Service-Signature': `t=${timestamp},n=${nonce},sig=${sig}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+test.describe('Tier Sync API', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let prisma: PrismaClient;
+  let pool: Pool;
+  let orgId: string;
+  let userId: string;
+
+  test.beforeAll(async () => {
+    process.env.CROSS_SERVICE_SECRET = TEST_SECRET;
+    pool = new Pool({ connectionString: process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public" });
+    const adapter = new PrismaPg(pool);
+    prisma = new PrismaClient({ adapter });
+
+    userId = crypto.randomUUID();
+    orgId = crypto.randomUUID();
+
+    await prisma.betterAuthUser.create({
+      data: {
+        id: userId,
+        email: SYNC_EMAIL,
+        name: 'Tier Sync Test',
+        emailVerified: true,
+        role: 'user',
+      },
+    });
+
+    await prisma.pluginMember.create({
+      data: {
+        organizationId: orgId,
+        userId,
+        role: 'admin',
+        createdAt: new Date(),
+      },
+    });
+
+    await prisma.pluginOrganization.create({
+      data: {
+        id: orgId,
+        name: 'Tier Sync Test Org',
+        slug: `tier-sync-${Date.now()}`,
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await prisma.orgTier.deleteMany({ where: { organizationId: orgId } }).catch(() => {});
+    await prisma.pluginMember.deleteMany({ where: { userId } }).catch(() => {});
+    await prisma.pluginOrganization.deleteMany({ where: { id: orgId } }).catch(() => {});
+    await prisma.betterAuthUser.deleteMany({ where: { id: userId } }).catch(() => {});
+    await prisma.$disconnect();
+    await pool.end();
+  });
+
+  test('HMAC-signed tier-sync request returns 200 and updates tier', async ({ page }) => {
+    const headers = signRequest('POST', '/api/service/tier-sync', {
+      email: SYNC_EMAIL,
+      tier: 'pro',
+      status: 'active',
+    }, TEST_SECRET);
+
+    const response = await page.request.post('/api/service/tier-sync', {
+      data: { email: SYNC_EMAIL, tier: 'pro', status: 'active' },
+      headers,
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.organizationId).toBe(orgId);
+    expect(body.tier).toBe('pro');
+    expect(body.status).toBe('active');
+  });
+
+  test('unsigned request returns 401', async ({ page }) => {
+    const response = await page.request.post('/api/service/tier-sync', {
+      data: { email: SYNC_EMAIL, tier: 'pro', status: 'active' },
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test('invalid body returns 400', async ({ page }) => {
+    const headers = signRequest('POST', '/api/service/tier-sync', {}, TEST_SECRET);
+
+    const response = await page.request.post('/api/service/tier-sync', {
+      data: {},
+      headers,
+    });
+    expect(response.status()).toBe(400);
+  });
+
+  test('non-existent email returns 404', async ({ page }) => {
+    const headers = signRequest('POST', '/api/service/tier-sync', {
+      email: 'nonexistent@test.local',
+      tier: 'free',
+      status: 'active',
+    }, TEST_SECRET);
+
+    const response = await page.request.post('/api/service/tier-sync', {
+      data: { email: 'nonexistent@test.local', tier: 'free', status: 'active' },
+      headers,
+    });
+    expect(response.status()).toBe(404);
+  });
+
+  test('tier query returns updated tier after sync', async ({ page }) => {
+    const headers = signRequest('GET', `/api/service/tier?email=${encodeURIComponent(SYNC_EMAIL)}`, undefined, TEST_SECRET);
+
+    const response = await page.request.get(`/api/service/tier?email=${encodeURIComponent(SYNC_EMAIL)}`, {
+      headers,
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.tier).toBe('pro');
+    expect(body.status).toBe('active');
+    expect(body.effectiveTier).toBe('pro');
+  });
+});

--- a/tests/tier-sync.spec.ts
+++ b/tests/tier-sync.spec.ts
@@ -3,22 +3,9 @@ import { PrismaClient } from '../src/generated/prisma/index.js';
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
 import crypto from 'node:crypto';
+import { signCrossServiceRequest } from '../src/lib/cross-service/sign';
 
-const TEST_SECRET = 'test-cross-service-secret-for-e2e';
 const SYNC_EMAIL = `tier-sync-${Date.now()}@test.local`;
-
-function signRequest(method: string, path: string, body: unknown, secret: string) {
-  const nonce = crypto.randomUUID();
-  const timestamp = Math.floor(Date.now() / 1000);
-  const bodyStr = body !== undefined ? JSON.stringify(body) : '';
-  const bodyHash = crypto.createHash('sha256').update(bodyStr, 'utf8').digest('hex');
-  const canon = `${method}\n${path}\n${timestamp}\n${bodyHash}`;
-  const sig = crypto.createHmac('sha256', secret).update(canon, 'utf8').digest('hex');
-  return {
-    'X-Service-Signature': `t=${timestamp},n=${nonce},sig=${sig}`,
-    'Content-Type': 'application/json',
-  };
-}
 
 test.describe('Tier Sync API', () => {
   test.describe.configure({ mode: 'serial' });
@@ -29,7 +16,7 @@ test.describe('Tier Sync API', () => {
   let userId: string;
 
   test.beforeAll(async () => {
-    process.env.CROSS_SERVICE_SECRET = TEST_SECRET;
+    process.env.CROSS_SERVICE_SECRET = 'test-cross-service-secret-for-e2e';
     pool = new Pool({ connectionString: process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:5432/worldwideview?schema=public" });
     const adapter = new PrismaPg(pool);
     prisma = new PrismaClient({ adapter });
@@ -75,23 +62,20 @@ test.describe('Tier Sync API', () => {
   });
 
   test('HMAC-signed tier-sync request returns 200 and updates tier', async ({ page }) => {
-    const headers = signRequest('POST', '/api/service/tier-sync', {
-      email: SYNC_EMAIL,
-      tier: 'pro',
-      status: 'active',
-    }, TEST_SECRET);
+    const body = { email: SYNC_EMAIL, tier: 'pro', status: 'active' };
+    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: { email: SYNC_EMAIL, tier: 'pro', status: 'active' },
+      data: body,
       headers,
     });
 
     expect(response.status()).toBe(200);
-    const body = await response.json();
-    expect(body.success).toBe(true);
-    expect(body.organizationId).toBe(orgId);
-    expect(body.tier).toBe('pro');
-    expect(body.status).toBe('active');
+    const json = await response.json();
+    expect(json.success).toBe(true);
+    expect(json.organizationId).toBe(orgId);
+    expect(json.tier).toBe('pro');
+    expect(json.status).toBe('active');
   });
 
   test('unsigned request returns 401', async ({ page }) => {
@@ -102,7 +86,7 @@ test.describe('Tier Sync API', () => {
   });
 
   test('invalid body returns 400', async ({ page }) => {
-    const headers = signRequest('POST', '/api/service/tier-sync', {}, TEST_SECRET);
+    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body: {} });
 
     const response = await page.request.post('/api/service/tier-sync', {
       data: {},
@@ -112,21 +96,18 @@ test.describe('Tier Sync API', () => {
   });
 
   test('non-existent email returns 404', async ({ page }) => {
-    const headers = signRequest('POST', '/api/service/tier-sync', {
-      email: 'nonexistent@test.local',
-      tier: 'free',
-      status: 'active',
-    }, TEST_SECRET);
+    const body = { email: 'nonexistent@test.local', tier: 'free', status: 'active' };
+    const headers = signCrossServiceRequest({ method: 'POST', path: '/api/service/tier-sync', body });
 
     const response = await page.request.post('/api/service/tier-sync', {
-      data: { email: 'nonexistent@test.local', tier: 'free', status: 'active' },
+      data: body,
       headers,
     });
     expect(response.status()).toBe(404);
   });
 
   test('tier query returns updated tier after sync', async ({ page }) => {
-    const headers = signRequest('GET', `/api/service/tier?email=${encodeURIComponent(SYNC_EMAIL)}`, undefined, TEST_SECRET);
+    const headers = signCrossServiceRequest({ method: 'GET', path: '/api/service/tier' });
 
     const response = await page.request.get(`/api/service/tier?email=${encodeURIComponent(SYNC_EMAIL)}`, {
       headers,


### PR DESCRIPTION
Phase 3a: Globe-side tier tracking infrastructure. Hub syncs subscription tier changes via HMAC-protected endpoint. Globe gates premium features based on tier.

## Changes
- OrgTier Prisma model (organizationId, tier, status, trialEndsAt)
- Tier-sync endpoint (POST /api/service/tier-sync, HMAC-protected)
- Tier query endpoint (GET /api/service/tier, HMAC or session)
- Feature gating library (requirePlan, planGating)
- 23 unit tests + 5 Playwright E2E tests

## Verification
- Lint: PASS
- Typecheck: PASS
- Unit tests: 23 new tests PASS
- Playwright: 5 E2E tests created