### PR TITLE
fix: pin opencode action to v1.17.13 and bypass OIDC exchange

### DIFF
--- a/.github/workflows/opencode-fix.yml
+++ b/.github/workflows/opencode-fix.yml
@@ -71,8 +71,9 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@v1.17.13
         env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Problem
The `opencode-fix.yml` workflow fails with `Failed to parse JSON` because `anomalyco/opencode/github@latest` resolves to a stale tag (`github-v1.2.9`, Jan 2026). The old action code tries an OIDC token exchange with `api.opencode.ai` that fails when the OpenCode GitHub App isn't installed on the repo.

## Fix
- Pin the action to `anomalyco/opencode/github@v1.17.13` (current release)
- Add `TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the env block to use the GITHUB_TOKEN directly, bypassing the broken OIDC exchange

## Testing
Once merged, re-test by commenting `/opencode` on issue #304.