### PR TITLE
fix: correct GITHUB_TOKEN env var and enable use_github_token

### DIFF
--- a/.github/workflows/opencode-fix.yml
+++ b/.github/workflows/opencode-fix.yml
@@ -73,13 +73,11 @@ jobs:
       - name: Run OpenCode
         uses: anomalyco/opencode/github@v1.17.13
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: deepseek/deepseek-v4-flash
-          agent: build
+          use_github_token: true
           share: false
           prompt: ${{ steps.issue.outputs.prompt }}
 


### PR DESCRIPTION
## Problem
The `opencode-fix.yml` workflow fails with `undefined is not an object (evaluating 'p.rest')` because:

1. **Wrong env var name**: handler reads `process.env["GITHUB_TOKEN"]`, not `process.env["TOKEN"]` -- our token was silently ignored
2. **Missing `use_github_token: true`: defaults to `false`, forcing the broken OIDC token exchange path

## Fix
- Rename `TOKEN` to `GITHUB_TOKEN` in the env block
- Add `use_github_token: true` to skip OIDC entirely
- Remove unused `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` env vars
- Remove `agent: build` (silently ignored at v1.17.13 per issue #21730)

## Testing
Once merged, re-test by commenting `/opencode` on issue #304.

Refs: anomalyco/opencode#21730, anomalyco/opencode#19865