### PR TITLE
fix: configure git identity and persist credentials for OpenCode

### DIFF
--- a/.github/workflows/opencode-fix.yml
+++ b/.github/workflows/opencode-fix.yml
@@ -68,7 +68,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@v1.17.13


### PR DESCRIPTION
## Problem
OpenCode successfully analyzed the codebase, made changes, and attempted to commit -- but failed with `Author identity unknown` because the GitHub Actions runner has no git identity configured by default.

## Fix
- Add a `git config` step to set `github-actions[bot]` identity
- Change `persist-credentials` to `true` so OpenCode can push branches

## Progress
- v1: Fixed OIDC exchange (PR #305)
- v2: Fixed GITHUB_TOKEN env var name + use_github_token (PR #306)
- v3: This PR fixes git identity -- OpenCode was 90% working, just couldn't commit

## Testing
Once merged, re-test by commenting `/opencode` on issue #304.