### PR TITLE
fix: reorder workflow triggers to force re-parse

### DIFF
--- a/.github/workflows/opencode-fix.yml
+++ b/.github/workflows/opencode-fix.yml
@@ -1,16 +1,16 @@
 name: OpenCode Autonomous Fix
 
 on:
-  issue_comment:
-    types: [created]
-  issues:
-    types: [labeled]
   workflow_dispatch:
     inputs:
       issue_number:
         description: Issue number to fix
         required: true
         type: number
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled]
 
 concurrency:
   group: opencode-fix-${{ github.event.issue.number || github.event.inputs.issue_number }}


### PR DESCRIPTION
Forces GitHub Actions to re-parse the opencode-fix.yml workflow file by reordering the `on:` section triggers. The cached workflow definition doesn't recognize `workflow_dispatch` despite it being present in the YAML.