### PR TITLE
chore: change workflow name to force GHA re-parse

### DIFF
--- a/.github/workflows/opencode-fix.yml
+++ b/.github/workflows/opencode-fix.yml
@@ -1,5 +1,4 @@
-# v2 - reparse
-name: OpenCode Autonomous Fix
+name: OpenCode Autonomous Fix v2
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Changes the workflow name from 'OpenCode Autonomous Fix' to 'OpenCode Autonomous Fix v2' to force GitHub Actions to re-parse the YAML definition.

The previous approach (adding a YAML comment) wasn't enough to trigger a cache refresh.