### PR TITLE
chore: restore full opencode-fix workflow under v2 filename

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -1,7 +1,225 @@
-name: OpenCode Autonomous Fix v2
-on: workflow_dispatch
+name: OpenCode Autonomous Fix
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to fix
+        required: true
+        type: number
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: opencode-fix-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
-  test:
+  fix:
+    if: |
+      (github.event_name == 'issue_comment' && 
+       (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && 
+       github.event.label.name == 'agent-fix') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
     steps:
-      - run: echo "Workflow re-parse successful"
+      - name: Get issue details
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue?.number || 
+              context.payload.inputs?.issue_number;
+            
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+
+            // Add running label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['agent-fix-running']
+            });
+
+            // Check if this is a PR comment
+            const isPR = !!context.payload.issue?.pull_request;
+
+            // Extract instruction from comment body (strip /opencode or /oc prefix)
+            const commentBody = context.payload.comment?.body || '';
+            const instruction = commentBody
+              .replace(/^\/(opencode|oc)\s*/i, '')
+              .trim();
+
+            // Build prompt based on context
+            let prompt;
+            if (instruction) {
+              // User gave a specific instruction — pass it to OpenCode with context
+              const contextParts = [
+                `Repository: ${context.repo.owner}/${context.repo.repo}`,
+                isPR ? `This comment is on PR #${issueNumber}` : `Issue #${issueNumber}: ${issue.title}`,
+                '',
+                `## Description`,
+                issue.body || '(no description)',
+                '',
+                `## Instruction`,
+                instruction,
+              ];
+
+              if (isPR) {
+                contextParts.push(
+                  '',
+                  `The PR branch is already checked out. Review the changes, answer questions about them, or make any requested modifications.`
+                );
+              } else {
+                contextParts.push(
+                  '',
+                  `You have full access to the codebase. Use shell commands and read files as needed.`,
+                  `Run pnpm lint and pnpm test to verify any changes.`,
+                  `If changes are needed, commit and push to a new branch named fix/agent-issue-${issueNumber}`,
+                  ` and create a pull request.`
+                );
+              }
+
+              prompt = contextParts.join('\n');
+
+              // Add best practices suffix for custom instructions
+              prompt += `\n\n## Handoff\nWhen creating a PR for any changes:\n- Include "Fixes #${issueNumber}" in the description\n- Never modify or delete tests to make them pass\n- Only modify files necessary for the task\n- Run pnpm lint and pnpm test to verify\n- Max 3 retries per verification step, then restore and report failure`;
+            } else {
+              // No instruction — default to fix behavior
+              prompt = `Fix this issue in the repository.
+
+Issue #${issueNumber}: ${issue.title}
+
+Description:
+${issue.body}
+
+## Workflow
+1. REPRODUCE the issue - confirm it exists before making changes
+2. FIX with minimal, targeted changes
+3. VERIFY with lint + tests (up to 3 retries each)
+4. CHECK edge cases (empty states, null inputs, errors, boundaries)
+5. COMMIT and PR
+
+## Critical Rules
+- NEVER modify or delete tests to make them pass. If a test fails, fix your implementation.
+- Only modify files necessary to fix the issue. No refactoring unrelated code.
+- If you cannot reproduce the issue, report that in the PR description and STOP.
+- Run pnpm lint and pnpm test after changes. Max 3 retries per step.
+- After 3 failed retries, git restore all changes and abort.
+- Before committing, run git diff and check for debug code or accidental changes.
+
+## PR Requirements
+- Branch: fix/agent-issue-${issueNumber}
+- Commit format: fix: <description>
+- PR description must include: what the issue was, root cause, what changed, how verified
+- Include "Fixes #${issueNumber}" at the end of the PR description`;
+            }
+
+            core.setOutput('issue_number', issueNumber.toString());
+            core.setOutput('prompt', prompt);
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@v1.17.13
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: deepseek/deepseek-v4-flash
+          use_github_token: true
+          share: false
+          prompt: ${{ steps.issue.outputs.prompt }}
+
+      - name: On success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = ${{ steps.issue.outputs.issue_number }};
+            
+            // Remove running label
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name: 'agent-fix-running'
+            });
+
+            // Find the PR created by OpenCode
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'fix/agent-issue-' + issueNumber,
+              state: 'open'
+            });
+
+            let comment = '✅ OpenCode has finished working on this issue.';
+            if (prs.length > 0) {
+              comment += `\n\nPull Request: #${prs[0].number}`;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: comment
+            });
+
+      - name: On failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = ${{ steps.issue.outputs.issue_number }};
+            
+            // Remove running label
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'agent-fix-running'
+              });
+            } catch {}
+
+            // Add failed label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['agent-fix-failed']
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: '❌ OpenCode was unable to fix this issue automatically. The `agent-fix-failed` label has been added. Please review manually.'
+            });


### PR DESCRIPTION
Restores the full OpenCode Autonomous Fix workflow under the new filename (opencode-fix-v2.yml).

The old opencode-fix.yml was deleted and re-added but GitHub retained the stale cached definition. Deleting it and creating opencode-fix-v2.yml forces a fresh parse.

The new workflow ID 306533734 is properly parsed and accepts workflow_dispatch triggers (verified).