### PR TITLE
fix: rewrite opencode-fix workflow with YAML-safe indentation

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -22,10 +22,12 @@ env:
 jobs:
   fix:
     if: |
-      (github.event_name == 'issue_comment' && 
-       (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))) ||
-      (github.event_name == 'issues' && github.event.action == 'labeled' && 
-       github.event.label.name == 'agent-fix') ||
+      github.event_name == 'issue_comment' && (
+        contains(github.event.comment.body, '/opencode') ||
+        contains(github.event.comment.body, '/oc')
+      ) ||
+      github.event_name == 'issues' && github.event.action == 'labeled' &&
+        github.event.label.name == 'agent-fix' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -41,16 +43,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const issueNumber = context.payload.issue?.number || 
+            const issueNumber = context.payload.issue?.number ||
               context.payload.inputs?.issue_number;
-            
+
             const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber
             });
 
-            // Add running label
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,78 +59,70 @@ jobs:
               labels: ['agent-fix-running']
             });
 
-            // Check if this is a PR comment
             const isPR = !!context.payload.issue?.pull_request;
-
-            // Extract instruction from comment body (strip /opencode or /oc prefix)
             const commentBody = context.payload.comment?.body || '';
             const instruction = commentBody
               .replace(/^\/(opencode|oc)\s*/i, '')
               .trim();
 
-            // Build prompt based on context
             let prompt;
             if (instruction) {
-              // User gave a specific instruction — pass it to OpenCode with context
-              const contextParts = [
-                `Repository: ${context.repo.owner}/${context.repo.repo}`,
-                isPR ? `This comment is on PR #${issueNumber}` : `Issue #${issueNumber}: ${issue.title}`,
+              const parts = [
+                'Repository: ' + context.repo.owner + '/' + context.repo.repo,
+                isPR ? 'This comment is on PR #' + issueNumber : 'Issue #' + issueNumber + ': ' + issue.title,
                 '',
-                `## Description`,
+                '## Description',
                 issue.body || '(no description)',
                 '',
-                `## Instruction`,
+                '## Instruction',
                 instruction,
               ];
 
               if (isPR) {
-                contextParts.push(
+                parts.push(
                   '',
-                  `The PR branch is already checked out. Review the changes, answer questions about them, or make any requested modifications.`
+                  'The PR branch is already checked out. Review the changes, answer questions about them, or make any requested modifications.'
                 );
               } else {
-                contextParts.push(
+                parts.push(
                   '',
-                  `You have full access to the codebase. Use shell commands and read files as needed.`,
-                  `Run pnpm lint and pnpm test to verify any changes.`,
-                  `If changes are needed, commit and push to a new branch named fix/agent-issue-${issueNumber}`,
-                  ` and create a pull request.`
+                  'You have full access to the codebase. Use shell commands and read files as needed.',
+                  'Run pnpm lint and pnpm test to verify any changes.',
+                  'If changes are needed, commit and push to a new branch named fix/agent-issue-' + issueNumber + ' and create a pull request.'
                 );
               }
 
-              prompt = contextParts.join('\n');
+              prompt = parts.join('\n');
 
-              // Add best practices suffix for custom instructions
-              prompt += `\n\n## Handoff\nWhen creating a PR for any changes:\n- Include "Fixes #${issueNumber}" in the description\n- Never modify or delete tests to make them pass\n- Only modify files necessary for the task\n- Run pnpm lint and pnpm test to verify\n- Max 3 retries per verification step, then restore and report failure`;
+              prompt += '\n\n## Handoff\n' +
+                'When creating a PR for any changes:\n' +
+                '- Include "Fixes #' + issueNumber + '" in the description\n' +
+                '- Never modify or delete tests to make them pass\n' +
+                '- Only modify files necessary for the task\n' +
+                '- Run pnpm lint and pnpm test to verify\n' +
+                '- Max 3 retries per verification step, then restore and report failure';
             } else {
-              // No instruction — default to fix behavior
-              prompt = `Fix this issue in the repository.
-
-Issue #${issueNumber}: ${issue.title}
-
-Description:
-${issue.body}
-
-## Workflow
-1. REPRODUCE the issue - confirm it exists before making changes
-2. FIX with minimal, targeted changes
-3. VERIFY with lint + tests (up to 3 retries each)
-4. CHECK edge cases (empty states, null inputs, errors, boundaries)
-5. COMMIT and PR
-
-## Critical Rules
-- NEVER modify or delete tests to make them pass. If a test fails, fix your implementation.
-- Only modify files necessary to fix the issue. No refactoring unrelated code.
-- If you cannot reproduce the issue, report that in the PR description and STOP.
-- Run pnpm lint and pnpm test after changes. Max 3 retries per step.
-- After 3 failed retries, git restore all changes and abort.
-- Before committing, run git diff and check for debug code or accidental changes.
-
-## PR Requirements
-- Branch: fix/agent-issue-${issueNumber}
-- Commit format: fix: <description>
-- PR description must include: what the issue was, root cause, what changed, how verified
-- Include "Fixes #${issueNumber}" at the end of the PR description`;
+              prompt = 'Fix this issue in the repository.\n\n' +
+                'Issue #' + issueNumber + ': ' + issue.title + '\n\n' +
+                'Description:\n' + issue.body + '\n\n' +
+                '## Workflow\n' +
+                '1. REPRODUCE the issue - confirm it exists before making changes\n' +
+                '2. FIX with minimal, targeted changes\n' +
+                '3. VERIFY with lint + tests (up to 3 retries each)\n' +
+                '4. CHECK edge cases (empty states, null inputs, errors, boundaries)\n' +
+                '5. COMMIT and PR\n\n' +
+                '## Critical Rules\n' +
+                '- NEVER modify or delete tests to make them pass. If a test fails, fix your implementation.\n' +
+                '- Only modify files necessary to fix the issue. No refactoring unrelated code.\n' +
+                '- If you cannot reproduce the issue, report that in the PR description and STOP.\n' +
+                '- Run pnpm lint and pnpm test after changes. Max 3 retries per step.\n' +
+                '- After 3 failed retries, git restore all changes and abort.\n' +
+                '- Before committing, run git diff and check for debug code or accidental changes.\n\n' +
+                '## PR Requirements\n' +
+                '- Branch: fix/agent-issue-' + issueNumber + '\n' +
+                '- Commit format: fix: <description>\n' +
+                '- PR description must include: what the issue was, root cause, what changed, how verified\n' +
+                '- Include "Fixes #' + issueNumber + '" at the end of the PR description';
             }
 
             core.setOutput('issue_number', issueNumber.toString());
@@ -163,8 +156,7 @@ ${issue.body}
         with:
           script: |
             const issueNumber = ${{ steps.issue.outputs.issue_number }};
-            
-            // Remove running label
+
             await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -172,7 +164,6 @@ ${issue.body}
               name: 'agent-fix-running'
             });
 
-            // Find the PR created by OpenCode
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -180,9 +171,9 @@ ${issue.body}
               state: 'open'
             });
 
-            let comment = '✅ OpenCode has finished working on this issue.';
+            let comment = 'OpenCode has finished working on this issue.';
             if (prs.length > 0) {
-              comment += `\n\nPull Request: #${prs[0].number}`;
+              comment += '\n\nPull Request: #' + prs[0].number;
             }
 
             await github.rest.issues.createComment({
@@ -198,8 +189,7 @@ ${issue.body}
         with:
           script: |
             const issueNumber = ${{ steps.issue.outputs.issue_number }};
-            
-            // Remove running label
+
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
@@ -209,7 +199,6 @@ ${issue.body}
               });
             } catch {}
 
-            // Add failed label
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -221,5 +210,5 @@ ${issue.body}
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: '❌ OpenCode was unable to fix this issue automatically. The `agent-fix-failed` label has been added. Please review manually.'
+              body: 'OpenCode was unable to fix this issue automatically. The agent-fix-failed label has been added. Please review manually.'
             });


### PR DESCRIPTION
The original opencode-fix.yml YAML was never properly parsed by GitHub Actions because multi-line JavaScript template literals inside YAML '|' block scalars had lines with less indentation than the block scalar itself, causing premature termination of the block scalar and broken YAML parsing.

This rewrite:
1. Replaces template literals with string concatenation to avoid indentation issues in YAML block scalars
2. Uses a new filename (opencode-fix-v2.yml) to get a fresh workflow ID
3. All lines inside '|' block scalars are now properly indented