### PR TITLE
fix: restrict /opencode to collaborators and clean up agent-fix-failed label

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -22,12 +22,12 @@ env:
 jobs:
   fix:
     if: |
-      github.event_name == 'issue_comment' && (
-        contains(github.event.comment.body, '/opencode') ||
-        contains(github.event.comment.body, '/oc')
-      ) ||
-      github.event_name == 'issues' && github.event.action == 'labeled' &&
-        github.event.label.name == 'agent-fix' ||
+      (github.event_name == 'issue_comment' && 
+       (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc')) &&
+       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && 
+       github.event.label.name == 'agent-fix' &&
+       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.sender.author_association)) ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -157,12 +157,17 @@ jobs:
           script: |
             const issueNumber = ${{ steps.issue.outputs.issue_number }};
 
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              name: 'agent-fix-running'
-            });
+            // Remove status labels
+            for (const label of ['agent-fix-running', 'agent-fix-failed']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label
+                });
+              } catch {}
+            }
 
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,


### PR DESCRIPTION
## Changes
1. **Access control**: Only users with author_association of OWNER, MEMBER, or COLLABORATOR can invoke `/opencode`. Uses `contains()` with `github.event.comment.author_association` and `github.event.sender.author_association` for the two trigger paths.
2. **Label cleanup**: On success, remove both `agent-fix-running` and `agent-fix-failed` labels so stale failure labels don't persist.

## Why
Anyone could previously comment `/opencode` on any issue and consume DeepSeek API credits + create PRs. The label would also show `agent-fix-failed` even after a subsequent run succeeded.