### PR TITLE
fix: remove paths filter from docker-publish trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,16 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: ["main"]
-    paths:
-      - "src/**"
-      - "prisma/**"
-      - "packages/**"
-      - "scripts/**"
-      - "Dockerfile"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "next.config.ts"
-      - ".github/workflows/docker-publish.yml"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
**Root cause:** The `paths:` filter under `on: push:` causes GitHub Actions' YAML parser to silently fail on this repository. The workflow produces 0 jobs and the API returns the file path as the workflow name instead of the YAML `name:` field.

**Fix:** Removed the `paths:` filter block from the trigger section. The workflow will now run on every push to main instead of filtering by changed paths.

**Verification:** Confirmed via binary search testing — creating a workflow file with `paths:` removed immediately showed the correct name in the API, while identical files with `paths:` showed the file path.