### PR TITLE
feat: add /api/instance endpoint (list + create workspaces)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.57.1",
+  "version": "2.58.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/src/app/api/instance/instance.test.ts
+++ b/src/app/api/instance/instance.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET, POST } from "./route";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        workspaceMember: {
+            findMany: vi.fn(),
+            create: vi.fn(),
+        },
+        workspace: {
+            findUnique: vi.fn(),
+            create: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/cross-service/verify", () => ({
+    verifyCrossServiceSignature: vi.fn().mockReturnValue({ valid: true }),
+}));
+
+function mockServiceRequest(url: string): Request {
+    return new Request(url, {
+        headers: {
+            "X-Service-Signature": "t=1234567890,n=test-nonce,sig=valid",
+            "X-Service-Timestamp": "1234567890",
+            "X-Service-Nonce": "test-nonce",
+        },
+    });
+}
+
+function mockPostRequest(body: unknown): Request {
+    return new Request("http://localhost/api/instance", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-Service-Signature": "t=1234567890,n=test-nonce,sig=valid",
+            "X-Service-Timestamp": "1234567890",
+            "X-Service-Nonce": "test-nonce",
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("GET /api/instance", () => {
+    it("returns 401 without cross-service auth", async () => {
+        const req = new Request("http://localhost/api/instance?userId=u1&email=a@b.com");
+        const res = await GET(req);
+        expect(res.status).toBe(401);
+    });
+
+    it("returns workspaces for a user", async () => {
+        const mockMemberships = [
+            {
+                workspaceId: "ws-1",
+                role: "owner",
+                workspace: {
+                    id: "ws-1",
+                    name: "Test Workspace",
+                    subdomain: "test-ws",
+                    status: "active",
+                    plan: "basic",
+                    createdAt: new Date("2026-01-01"),
+                },
+            },
+        ];
+        vi.mocked(prisma.workspaceMember.findMany).mockResolvedValue(mockMemberships as never);
+
+        const req = mockServiceRequest("http://localhost/api/instance?userId=u1&email=a@b.com");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.instances).toHaveLength(1);
+        expect(data.instances[0]).toMatchObject({
+            id: "ws-1",
+            name: "Test Workspace",
+            subdomain: "test-ws",
+            status: "active",
+        });
+    });
+
+    it("returns empty instances array when user has no workspaces", async () => {
+        vi.mocked(prisma.workspaceMember.findMany).mockResolvedValue([] as never);
+
+        const req = mockServiceRequest("http://localhost/api/instance?userId=u1&email=a@b.com");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.instances).toEqual([]);
+    });
+
+    it("returns 400 when userId is missing", async () => {
+        const req = mockServiceRequest("http://localhost/api/instance?email=a@b.com");
+        const res = await GET(req);
+        expect(res.status).toBe(400);
+    });
+});
+
+describe("POST /api/instance", () => {
+    it("returns 401 without cross-service auth", async () => {
+        const req = new Request("http://localhost/api/instance", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ subdomain: "test", name: "Test", userId: "u1", email: "a@b.com" }),
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when subdomain is missing", async () => {
+        const req = mockPostRequest({ name: "Test", userId: "u1", email: "a@b.com" });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when userId is missing", async () => {
+        const req = mockPostRequest({ subdomain: "test", name: "Test", email: "a@b.com" });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when subdomain format is invalid", async () => {
+        const req = mockPostRequest({ subdomain: "ab", name: "Test", userId: "u1", email: "a@b.com" });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 409 when subdomain already exists", async () => {
+        vi.mocked(prisma.workspace.findUnique).mockResolvedValue({
+            id: "existing", name: "Existing", subdomain: "test", status: "active", plan: "basic",
+            ownerId: null, trialEndsAt: null, createdAt: new Date(), updatedAt: new Date(),
+        } as never);
+
+        const req = mockPostRequest({ subdomain: "test", name: "Test", userId: "u1", email: "a@b.com" });
+        const res = await POST(req);
+        expect(res.status).toBe(409);
+    });
+
+    it("creates workspace and workspace member", async () => {
+        vi.mocked(prisma.workspace.findUnique).mockResolvedValue(null);
+        vi.mocked(prisma.workspace.create).mockResolvedValue({
+            id: "new-ws", name: "Test Workspace", subdomain: "test-ws",
+            status: "active", plan: "basic", ownerId: "u1",
+            trialEndsAt: null, createdAt: new Date(), updatedAt: new Date(),
+        } as never);
+
+        const req = mockPostRequest({
+            subdomain: "test-ws", name: "Test Workspace",
+            userId: "u1", email: "a@b.com",
+        });
+        const res = await POST(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.id).toBe("new-ws");
+        expect(data.subdomain).toBe("test-ws");
+        expect(prisma.workspace.create).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                subdomain: "test-ws",
+                name: "Test Workspace",
+                ownerId: "u1",
+            }),
+        }));
+        expect(prisma.workspaceMember.create).toHaveBeenCalled();
+    });
+});

--- a/src/app/api/instance/route.ts
+++ b/src/app/api/instance/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+import { prisma } from "@/lib/db";
+
+export async function GET(request: Request) {
+    const authError = await crossServiceAuth(request);
+    if (authError) return authError;
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+
+    if (!userId) {
+        return NextResponse.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    const memberships = await prisma.workspaceMember.findMany({
+        where: { userId },
+        include: {
+            workspace: true,
+        },
+        orderBy: {
+            joinedAt: "asc",
+        },
+    });
+
+    const instances = memberships.map((m) => ({
+        id: m.workspace.id,
+        name: m.workspace.name,
+        subdomain: m.workspace.subdomain,
+        status: m.workspace.status,
+        plan: m.workspace.plan,
+        createdAt: m.workspace.createdAt,
+        role: m.role,
+    }));
+
+    return NextResponse.json({ instances });
+}
+
+export async function POST(request: Request) {
+    const rawBody = await request.clone().text();
+    const authError = await crossServiceAuth(
+        new Request(request.url, {
+            method: request.method,
+            headers: request.headers,
+            body: rawBody,
+        }),
+    );
+    if (authError) return authError;
+
+    const body = JSON.parse(rawBody) as {
+        subdomain?: string;
+        name?: string;
+        userId?: string;
+        email?: string;
+    };
+
+    if (!body.subdomain) {
+        return NextResponse.json({ error: "subdomain is required" }, { status: 400 });
+    }
+    if (!body.userId) {
+        return NextResponse.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    const subdomain = body.subdomain.toLowerCase().trim();
+
+    if (!/^[a-z0-9]([a-z0-9-]{1,61}[a-z0-9])?$/.test(subdomain)) {
+        return NextResponse.json({ error: "Invalid subdomain format" }, { status: 400 });
+    }
+
+    const existing = await prisma.workspace.findUnique({
+        where: { subdomain },
+    });
+    if (existing) {
+        return NextResponse.json({ error: "Subdomain already taken" }, { status: 409 });
+    }
+
+    const workspace = await prisma.workspace.create({
+        data: {
+            name: body.name || subdomain,
+            subdomain,
+            ownerId: body.userId,
+            status: "active",
+            plan: "basic",
+        },
+    });
+
+    await prisma.workspaceMember.create({
+        data: {
+            workspaceId: workspace.id,
+            userId: body.userId,
+            role: "owner",
+        },
+    });
+
+    return NextResponse.json({
+        id: workspace.id,
+        name: workspace.name,
+        subdomain: workspace.subdomain,
+        status: workspace.status,
+        plan: workspace.plan,
+        createdAt: workspace.createdAt,
+    });
+}


### PR DESCRIPTION
Adds GET (list user workspaces) and POST (create workspace) endpoints with HMAC cross-service auth and full test coverage. Reuses existing Workspace + WorkspaceMember Prisma models.