### PR TITLE
feat: add /api/access-code endpoint (set org tier on redeem)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.57.1",
+  "version": "2.58.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",

--- a/src/app/api/access-code/route.test.ts
+++ b/src/app/api/access-code/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/lib/cross-service/middleware", () => ({
+    crossServiceAuth: vi.fn(),
+}));
+
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        betterAuthUser: { findUnique: vi.fn() },
+        pluginMember: { findFirst: vi.fn() },
+        orgTier: { upsert: vi.fn() },
+    },
+}));
+
+function mockPostRequest(body: unknown): Request {
+    return new Request("http://localhost/api/access-code", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-Service-Signature": "t=1234567890,n=test-nonce,sig=valid",
+            "X-Service-Timestamp": "1234567890",
+            "X-Service-Nonce": "test-nonce",
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("POST /api/access-code", () => {
+    it("returns 401 when cross-service auth fails", async () => {
+        vi.mocked(crossServiceAuth).mockResolvedValue(
+            new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+        );
+
+        const req = mockPostRequest({ code: "TEST1234", userId: "u1" });
+        const res = await POST(req);
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when code is missing", async () => {
+        vi.mocked(crossServiceAuth).mockResolvedValue(undefined as never);
+
+        const req = mockPostRequest({ userId: "u1" });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when userId is missing", async () => {
+        vi.mocked(crossServiceAuth).mockResolvedValue(undefined as never);
+
+        const req = mockPostRequest({ code: "TEST1234" });
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 404 when user is not found", async () => {
+        vi.mocked(crossServiceAuth).mockResolvedValue(undefined as never);
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue(null);
+
+        const req = mockPostRequest({ code: "TEST1234", userId: "nonexistent" });
+        const res = await POST(req);
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when user has no org membership", async () => {
+        vi.mocked(crossServiceAuth).mockResolvedValue(undefined as never);
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue({
+            id: "u1", name: "Test", email: "a@b.com",
+        } as never);
+        vi.mocked(prisma.pluginMember.findFirst).mockResolvedValue(null);
+
+        const req = mockPostRequest({ code: "TEST1234", userId: "u1" });
+        const res = await POST(req);
+        expect(res.status).toBe(404);
+    });
+
+    it("sets org tier to pro/trialing for 30 days", async () => {
+        vi.mocked(crossServiceAuth).mockResolvedValue(undefined as never);
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue({
+            id: "u1", name: "Test", email: "a@b.com",
+        } as never);
+        vi.mocked(prisma.pluginMember.findFirst).mockResolvedValue({
+            organizationId: "org-1",
+        } as never);
+        vi.mocked(prisma.orgTier.upsert).mockResolvedValue({
+            id: "tier-1", organizationId: "org-1", tier: "pro",
+            status: "trialing", trialEndsAt: new Date("2026-08-03"),
+            updatedAt: new Date(), createdAt: new Date(),
+        } as never);
+
+        const req = mockPostRequest({ code: "TEST1234", userId: "u1" });
+        const res = await POST(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.success).toBe(true);
+        expect(data.tier).toBe("pro");
+        expect(data.status).toBe("trialing");
+        expect(prisma.orgTier.upsert).toHaveBeenCalledWith(expect.objectContaining({
+            where: { organizationId: "org-1" },
+            create: expect.objectContaining({
+                organizationId: "org-1",
+                tier: "pro",
+                status: "trialing",
+            }),
+        }));
+    });
+});

--- a/src/app/api/access-code/route.ts
+++ b/src/app/api/access-code/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+import { prisma } from "@/lib/db";
+
+const TRIAL_DAYS = 30;
+
+export async function POST(request: Request) {
+    const rawBody = await request.clone().text();
+
+    const authError = await crossServiceAuth(
+        new Request(request.url, {
+            method: request.method,
+            headers: request.headers,
+            body: rawBody,
+        }),
+    );
+    if (authError) return authError;
+
+    let body: { code?: string; userId?: string };
+    try {
+        body = JSON.parse(rawBody) as { code?: string; userId?: string };
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    if (!body.code) {
+        return NextResponse.json({ error: "code is required" }, { status: 400 });
+    }
+    if (!body.userId) {
+        return NextResponse.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    const user = await prisma.betterAuthUser.findUnique({
+        where: { id: body.userId },
+        select: { id: true, email: true },
+    });
+    if (!user) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const membership = await prisma.pluginMember.findFirst({
+        where: { userId: body.userId },
+        select: { organizationId: true },
+        orderBy: { createdAt: "asc" },
+    });
+    if (!membership) {
+        return NextResponse.json({
+            error: "User has no organization. Create a workspace first.",
+            success: false,
+        }, { status: 404 });
+    }
+
+    const trialEndsAt = new Date();
+    trialEndsAt.setDate(trialEndsAt.getDate() + TRIAL_DAYS);
+
+    await prisma.orgTier.upsert({
+        where: { organizationId: membership.organizationId },
+        create: {
+            organizationId: membership.organizationId,
+            tier: "pro",
+            status: "trialing",
+            trialEndsAt,
+        },
+        update: {
+            tier: "pro",
+            status: "trialing",
+            trialEndsAt,
+        },
+    });
+
+    return NextResponse.json({
+        success: true,
+        tier: "pro",
+        status: "trialing",
+        trialEndsAt: trialEndsAt.toISOString(),
+    });
+}


### PR DESCRIPTION
Receives { code, userId } from hub redeem action. Validates user + org exist, then upserts OrgTier to pro/trialing for 30 days. Reuses existing OrgTier model.