### PR TITLE
fix: add workflows: write permission to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      workflows: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Adds `workflows: write` to the workflow permissions block.

Without this, any `/opencode` command that touches `.github/workflows/` files is rejected at push time:
`refusing to allow a GitHub App to create or update workflow ... without workflows permission`

Fixes issue #260 where the OpenCode agent successfully modified docker-publish.yml but couldn't push the changes.