### PR TITLE
fix: replace secrets-in-if with env-based pattern

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -211,10 +211,12 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-production-arm64.outputs.digest }}
 
       - name: Trigger Coolify deploy
-        if: ${{ secrets.COOLIFY_API_TOKEN != '' }}
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         run: |
+          [ -z "$COOLIFY_TOKEN" ] && exit 0
           curl -s -X POST "https://coolify.serv.wwv.io/api/v1/deploy" \
-            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
+            -H "Authorization: Bearer $COOLIFY_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"force": false}'
 

--- a/.github/workflows/shared-docker.yml
+++ b/.github/workflows/shared-docker.yml
@@ -112,9 +112,12 @@ jobs:
         continue-on-error: ${{ inputs.is-preview }}
 
       - name: Trigger Coolify deploy
-        if: ${{ secrets.COOLIFY_API_TOKEN != '' && !inputs.is-preview }}
+        if: ${{ !inputs.is-preview }}
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
         run: |
+          [ -z "$COOLIFY_TOKEN" ] && exit 0
           curl -s -X POST "https://coolify.serv.wwv.io/api/v1/deploy" \
-            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
+            -H "Authorization: Bearer $COOLIFY_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"force": false}'


### PR DESCRIPTION
**Root cause of the 3-week CI outage.**

GitHub Actions does not allow the `secrets` context in `if:` conditionals. Using `if: ${{ secrets.X != '' }}` causes the workflow validator to silently reject the entire workflow. The result: 0 jobs, no runner time, API shows the file path as the workflow name instead of the YAML `name:` field.

This affected three workflows:
- `docker-publish.yml` — had `if: ${{ secrets.COOLIFY_API_TOKEN != '' }}`
- `shared-docker.yml` — had `if: ${{ secrets.COOLIFY_API_TOKEN != '' && !inputs.is-preview }}`
- `pr-preview.yml` — cascaded failure (uses shared-docker.yml via `uses:`)

**Fix:** Replaced with the GitHub-recommended env-based pattern (assign secret to env var, check in shell). The `inputs.is-preview` check stays in `if:` since `inputs` IS an allowed context.

**Confirmed via test:** Exact copy of docker-publish.yml with only the `if: secrets` line removed parsed correctly and queued jobs immediately.