### PR TITLE
fix: remove workflows: write permission that broke workflow parsing

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
-      workflows: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Remove invalid `workflows: write` from permissions block.

This was silently breaking the entire workflow -- GitHub Actions parser rejects it with: `Invalid Argument - failed to parse workflow: Unexpected value 'workflows'`

Without this fix, no issue_comment or workflow_dispatch events are processed.