### PR TITLE
ci: add Docker build smoke test for local edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,27 @@ jobs:
       - name: Verify migrations cover the schema
         run: npx prisma migrate diff --from-migrations prisma/migrations --to-schema prisma/schema.prisma --exit-code
       - run: pnpm build
+
+  docker-build:
+    name: Docker Build (local)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build local edition image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          build-args: |
+            NEXT_PUBLIC_WWV_EDITION=local
+            NEXT_PUBLIC_CESIUM_ION_TOKEN=
+            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
+            NEXT_PUBLIC_BING_MAPS_KEY=
+            NEXT_PUBLIC_WS_ENGINE_URL=
+            NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL=
+          cache-from: type=gha,scope=ci-docker-local
+          cache-to: type=gha,scope=ci-docker-local,mode=max


### PR DESCRIPTION
Adds a Docker build job to CI that builds the local edition image on every PR targeting main. Does not push the image -- just verifies the Dockerfile builds successfully.

This would have caught the 3-week CI outage where docker-publish.yml silently failed. Now Docker build breakages get caught on PRs, not on main after merge.