### PR TITLE
fix: add workflows: write permission to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      workflows: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Adds workflows: write to the permissions block so the GITHUB_TOKEN can push changes to .github/workflows/ files.

Without this, any /gremlin command that modifies workflow files fails at push time with: 'refusing to allow a GitHub App to create or update workflow ... without workflows permission'