### PR TITLE
revert: remove workflows: write from permissions block

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
-      workflows: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Reverts the merge of PR #330 which added `workflows: write` to the workflow's permissions block.

`workflows` is NOT a valid permission in the workflow `permissions:` block -- it's a valid scope only for PATs and GitHub Apps. This made the workflow file unparseable, blocking all workflow_dispatch runs.

The real fix requires using a PAT with `workflows` scope (stored as a repository secret) for git push operations, not adding it to the permissions block.