### PR TITLE
fix: add security-events: write permission for SARIF upload

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -106,6 +107,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -231,6 +233,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      security-events: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -307,6 +310,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      security-events: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:


### PR DESCRIPTION
The CodeQL upload-sarif step in docker-publish.yml requires `security-events: write` to push Trivy scan results to GitHub Security. Without it, all 4 build jobs fail at the upload step.