### PR TITLE
feat: wire up GREMLIN_PAT for git push to workflow files

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.GREMLIN_PAT }}
 
 jobs:
   fix:
@@ -138,6 +138,10 @@ jobs:
         run: |
            git config user.name "Gremlin"
            git config user.email "gremlin@users.noreply.github.com"
+
+      - name: Configure git auth with PAT
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GREMLIN_PAT }}@github.com/${{ github.repository }}.git
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@v1.17.13


### PR DESCRIPTION
Adds a GREMLIN_PAT with `workflows: write` scope to enable Gremlin to push changes to `.github/workflows/` files.

- New step: configures git remote URL to use PAT for pushes
- GH_TOKEN now uses GREMLIN_PAT instead of GITHUB_TOKEN
- GITHUB_TOKEN stays in OpenCode action env for API calls
- This fixes issue #260 (Docker smoke test) and PR #328 (rebase of workflow changes)