### PR TITLE
fix: use GREMLIN_PAT for OpenCode git pushes

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -147,7 +147,7 @@ jobs:
         uses: anomalyco/opencode/github@v1.17.13
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GREMLIN_PAT }}
         with:
           model: deepseek/deepseek-v4-flash
           use_github_token: true


### PR DESCRIPTION
OpenCode uses its own bundled git binary (not the system git), so the `git remote set-url` step had no effect.\n\nThe `GITHUB_TOKEN` env var in the action's step is what OpenCode actually uses for git push auth. Swapping it to `GREMLIN_PAT` gives it `workflows: write` scope, enabling pushes to `.github/workflows/` files.\n\nThis fixes issue #260 (Docker smoke test) and PR #328 (rebase of workflow changes).