### PR TITLE
feat: add tier + lock columns to Workspace model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.58.3",
+  "version": "2.59.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",
@@ -29,7 +29,6 @@
   "dependencies": {
     "@better-auth/api-key": "^1.6.23",
     "@better-auth/prisma-adapter": "1.6.23",
-
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
@@ -62,7 +61,6 @@
     "react-player": "^3.4.0",
     "resium": "1.23.0",
     "satellite.js": "^7.0.1",
-
     "tslib": "^2.8.1",
     "undici": "^8.5.0",
     "ws": "^8.21.0",

--- a/prisma/migrations/20260704000000_add_workspace_tier_lock/migration.sql
+++ b/prisma/migrations/20260704000000_add_workspace_tier_lock/migration.sql
@@ -1,0 +1,6 @@
+-- Add tier and locking columns to workspaces table
+ALTER TABLE "workspaces" ADD COLUMN     "locked" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "lockedAt" TIMESTAMP(3),
+ADD COLUMN     "lockedReason" TEXT,
+ADD COLUMN     "tier" TEXT NOT NULL DEFAULT 'free',
+ADD COLUMN     "tierStampedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,16 +51,21 @@ model Setting {
 }
 
 model Workspace {
-  id          String            @id @default(uuid())
-  name        String
-  subdomain   String            @unique
-  ownerId     String?
-  status      String            @default("trialing")
-  plan        String            @default("basic")
-  trialEndsAt DateTime?
-  createdAt   DateTime          @default(now())
-  updatedAt   DateTime          @updatedAt
-  members     WorkspaceMember[]
+  id            String            @id @default(uuid())
+  name          String
+  subdomain     String            @unique
+  ownerId       String?
+  status        String            @default("trialing")
+  plan          String            @default("basic")
+  tier          String            @default("free")
+  locked        Boolean           @default(false)
+  lockedReason  String?
+  lockedAt      DateTime?
+  tierStampedAt DateTime?
+  trialEndsAt   DateTime?
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+  members       WorkspaceMember[]
 
   @@map("workspaces")
 }


### PR DESCRIPTION
Adds tier and locking columns to the Workspace model for subscription tier enforcement:

- `tier` (`String`, default `"free"`) — stamped by hub at instance creation
- `locked` (`Boolean`, default `false`) — set when tier downgraded
- `lockedReason` (`String?`) — human-readable reason for lock
- `lockedAt` (`DateTime?`) — when the lock was applied
- `tierStampedAt` (`DateTime?`) — when hub last stamped the tier (nullable, set explicitly)

Migration: `20260704000000_add_workspace_tier_lock` (additive only — ALTER TABLE ADD COLUMN)
No TypeScript changes. Schema drift verified: `prisma migrate diff --exit-code` = 0.