### PR TITLE
feat: tier stamping at instance creation + workspace locking on downgrade

### DIFF
--- a/src/app/api/instance/[id]/tier/route.ts
+++ b/src/app/api/instance/[id]/tier/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+
+const TIER_RANK: Record<string, number> = {
+    free: 0,
+    beta_tester: 1,
+    early_access: 2,
+    pro: 3,
+    enterprise: 4,
+};
+
+export async function POST(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const authError = await crossServiceAuth(request);
+    if (authError) return authError;
+
+    const { id } = await params;
+
+    const body = (await request.json()) as { tier?: string };
+    const { tier } = body;
+
+    if (!tier || TIER_RANK[tier] === undefined) {
+        return NextResponse.json({ error: "Invalid tier" }, { status: 400 });
+    }
+
+    const workspace = await prisma.workspace.findUnique({ where: { id } });
+    if (!workspace) {
+        return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+    }
+
+    const currentRank = TIER_RANK[workspace.tier] ?? 0;
+    const newRank = TIER_RANK[tier] ?? 0;
+    const isDowngrade = newRank < currentRank;
+
+    const updated = await prisma.workspace.update({
+        where: { id },
+        data: {
+            tier,
+            tierStampedAt: new Date(),
+            locked: isDowngrade,
+            lockedReason: isDowngrade
+                ? `Tier changed from ${workspace.tier} to ${tier}. Re-upgrade to restore access.`
+                : null,
+            lockedAt: isDowngrade ? new Date() : null,
+        },
+    });
+
+    return NextResponse.json({
+        id: updated.id,
+        tier: updated.tier,
+        locked: updated.locked,
+        lockedReason: updated.lockedReason,
+    });
+}

--- a/src/app/api/instance/instance.test.ts
+++ b/src/app/api/instance/instance.test.ts
@@ -12,6 +12,10 @@ vi.mock("@/lib/db", () => ({
             findUnique: vi.fn(),
             create: vi.fn(),
         },
+        betterAuthUser: {
+            findUnique: vi.fn(),
+            create: vi.fn(),
+        },
     },
 }));
 
@@ -134,6 +138,7 @@ describe("POST /api/instance", () => {
     it("returns 409 when subdomain already exists", async () => {
         vi.mocked(prisma.workspace.findUnique).mockResolvedValue({
             id: "existing", name: "Existing", subdomain: "test", status: "active", plan: "basic",
+            tier: "free", locked: false, lockedReason: null, lockedAt: null, tierStampedAt: null,
             ownerId: null, trialEndsAt: null, createdAt: new Date(), updatedAt: new Date(),
         } as never);
 
@@ -142,17 +147,21 @@ describe("POST /api/instance", () => {
         expect(res.status).toBe(409);
     });
 
-    it("creates workspace and workspace member", async () => {
+    it("creates workspace and workspace member with tier stamp", async () => {
         vi.mocked(prisma.workspace.findUnique).mockResolvedValue(null);
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue({
+            id: "u1", name: "a", email: "a@b.com", emailVerified: true,
+        } as never);
         vi.mocked(prisma.workspace.create).mockResolvedValue({
             id: "new-ws", name: "Test Workspace", subdomain: "test-ws",
-            status: "active", plan: "basic", ownerId: "u1",
+            status: "active", plan: "basic", tier: "pro", ownerId: "u1",
+            locked: false, lockedReason: null, lockedAt: null, tierStampedAt: new Date(),
             trialEndsAt: null, createdAt: new Date(), updatedAt: new Date(),
         } as never);
 
         const req = mockPostRequest({
             subdomain: "test-ws", name: "Test Workspace",
-            userId: "u1", email: "a@b.com",
+            userId: "u1", email: "a@b.com", tier: "pro",
         });
         const res = await POST(req);
         const data = await res.json();
@@ -160,13 +169,48 @@ describe("POST /api/instance", () => {
         expect(res.status).toBe(200);
         expect(data.id).toBe("new-ws");
         expect(data.subdomain).toBe("test-ws");
+        expect(data.tier).toBe("pro");
+        expect(prisma.betterAuthUser.findUnique).toHaveBeenCalledWith({ where: { id: "u1" } });
         expect(prisma.workspace.create).toHaveBeenCalledWith(expect.objectContaining({
             data: expect.objectContaining({
                 subdomain: "test-ws",
                 name: "Test Workspace",
                 ownerId: "u1",
+                tier: "pro",
             }),
         }));
         expect(prisma.workspaceMember.create).toHaveBeenCalled();
+    });
+
+    it("auto-creates user when not found", async () => {
+        vi.mocked(prisma.workspace.findUnique).mockResolvedValue(null);
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue(null);
+        vi.mocked(prisma.betterAuthUser.create).mockResolvedValue({
+            id: "u1-new", name: "a", email: "a@b.com", emailVerified: true,
+        } as never);
+        vi.mocked(prisma.workspace.create).mockResolvedValue({
+            id: "new-ws", name: "Test", subdomain: "test-ws",
+            status: "active", plan: "basic", tier: "free", ownerId: "u1",
+            locked: false, lockedReason: null, lockedAt: null, tierStampedAt: new Date(),
+            trialEndsAt: null, createdAt: new Date(), updatedAt: new Date(),
+        } as never);
+
+        const req = mockPostRequest({
+            subdomain: "test-ws", name: "Test",
+            userId: "u1-new", email: "a@b.com",
+        });
+        const res = await POST(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(prisma.betterAuthUser.create).toHaveBeenCalledWith({
+            data: {
+                id: "u1-new",
+                name: "a",
+                email: "a@b.com",
+                emailVerified: true,
+            },
+        });
+        expect(data.tier).toBe("free");
     });
 });

--- a/src/app/api/instance/route.ts
+++ b/src/app/api/instance/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: Request) {
         name?: string;
         userId?: string;
         email?: string;
+        tier?: string;
     };
 
     if (!body.subdomain) {
@@ -74,6 +75,19 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Subdomain already taken" }, { status: 409 });
     }
 
+    // Auto-create user if not found (hub has already verified)
+    let user = await prisma.betterAuthUser.findUnique({ where: { id: body.userId } });
+    if (!user && body.email) {
+        user = await prisma.betterAuthUser.create({
+            data: {
+                id: body.userId,
+                name: body.email.split("@")[0],
+                email: body.email,
+                emailVerified: true,
+            },
+        });
+    }
+
     const workspace = await prisma.workspace.create({
         data: {
             name: body.name || subdomain,
@@ -81,6 +95,8 @@ export async function POST(request: Request) {
             ownerId: body.userId,
             status: "active",
             plan: "basic",
+            tier: body.tier || "free",
+            tierStampedAt: new Date(),
         },
     });
 
@@ -98,6 +114,7 @@ export async function POST(request: Request) {
         subdomain: workspace.subdomain,
         status: workspace.status,
         plan: workspace.plan,
+        tier: workspace.tier,
         createdAt: workspace.createdAt,
     });
 }

--- a/src/app/api/internal/workspace/[subdomain]/route.ts
+++ b/src/app/api/internal/workspace/[subdomain]/route.ts
@@ -7,7 +7,7 @@ export async function GET(
     { params }: { params: Promise<{ subdomain: string }> }
 ) {
     if (!isCloud) {
-        return NextResponse.json({ status: "active", plan: "basic" });
+        return NextResponse.json({ status: "active", plan: "basic", tier: "free", locked: false, lockedReason: null });
     }
 
     // Await params as required in Next.js 15+
@@ -17,7 +17,7 @@ export async function GET(
     try {
         const workspace = await prisma.workspace.findUnique({
             where: { subdomain },
-            select: { status: true, plan: true }
+            select: { status: true, plan: true, tier: true, locked: true, lockedReason: true }
         });
 
         if (!workspace) {

--- a/src/app/locked/page.tsx
+++ b/src/app/locked/page.tsx
@@ -1,0 +1,27 @@
+export default function LockedPage({
+    searchParams,
+}: {
+    searchParams: { reason?: string };
+}) {
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: "100vh",
+                padding: "2rem",
+                textAlign: "center",
+            }}
+        >
+            <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>
+                Workspace Locked
+            </h1>
+            <p style={{ color: "#666", maxWidth: "400px" }}>
+                {searchParams.reason ||
+                    "This workspace is locked. Contact the workspace owner."}
+            </p>
+        </div>
+    );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from "next/server";
 import { isDemo } from "@/core/edition";
 import { hasBetterAuthCookie } from "@/lib/proxy-auth";
 
-const workspaceCache = new Map<string, { status: string; expiresAt: number }>();
+const workspaceCache = new Map<string, { status: string; plan: string; tier: string; locked: boolean; lockedReason: string | null; expiresAt: number }>();
 const CACHE_TTL = 60_000; // 60 seconds
 
 // Anchored static-asset allowlist. Only requests ending in a real asset
@@ -163,10 +163,21 @@ export default async function proxy(req: NextRequest) {
         if (workspaceInfo.status === "suspended" && !path.startsWith("/suspended")) {
             return NextResponse.redirect(new URL("/suspended", req.url));
         }
+        if (workspaceInfo.locked && !path.startsWith("/locked")) {
+            if (path.startsWith("/api/")) {
+                return new NextResponse(
+                    JSON.stringify({ error: "Workspace locked", reason: workspaceInfo.lockedReason }),
+                    { status: 403, headers: { "Content-Type": "application/json" } },
+                );
+            }
+            const lockUrl = new URL("/locked", req.url);
+            lockUrl.searchParams.set("reason", workspaceInfo.lockedReason || "This workspace is locked. Contact the workspace owner.");
+            return NextResponse.redirect(lockUrl);
+        }
     }
 
     // Auth pages: always accessible
-    if (path.startsWith("/setup") || path.startsWith("/login")) {
+    if (path.startsWith("/setup") || path.startsWith("/login") || path.startsWith("/locked")) {
         const res = NextResponse.next();
         if (tenantSubdomain) res.headers.set("x-tenant-subdomain", tenantSubdomain);
         return res;


### PR DESCRIPTION

## Summary
Implements globe-side tier stamping and workspace locking as architected in the stamping+locking decision (PR #342 added the schema).

## Changes

| File | What changed |
|------|-------------|
| `prisma/schema.prisma` | Added `tier`, `locked`, `lockedReason`, `lockedAt`, `tierStampedAt` to Workspace model |
| `prisma/migrations/20260704000000_add_workspace_tier_lock/` | New migration for the 5 columns |
| `src/app/api/instance/route.ts` | POST accepts `tier`, auto-creates BetterAuthUser if missing, stamps `tier` + `tierStampedAt`, returns `tier` in response |
| `src/app/api/instance/instance.test.ts` | Updated tests for tier stamping + auto-create user test |
| `src/app/api/instance/[id]/tier/route.ts` | **New** — POST endpoint for hub to push tier changes. Locks on downgrade with reason |
| `src/proxy.ts` | Lock check in tenant validation: APIs get 403 JSON, pages redirect to /locked. Cache type extended. /locked made public |
| `src/app/api/internal/workspace/[subdomain]/route.ts` | Returns `tier, locked, lockedReason` for proxy resolution |
| `src/app/locked/page.tsx` | **New** — simple locked page showing the reason |

## Instance POST Changes
- **Auto-create user**: if `betterAuthUser` not found and email provided, creates user (hub already verified)
- **Tier stamp**: `tier: body.tier || "free"`, `tierStampedAt: new Date()`
- **Response shape**: now includes `tier`

## Lock Check
- **Proxy.ts location**: tenant validation block, after suspended check (line ~163)
- **API response**: 403 JSON with `{ error, reason }`
- **Page response**: 302 redirect to `/locked?reason=...`
- **`/locked` page**: public (no auth required)

## Verification
- lint: PASS (0 errors)
- build: PASS
- tests: 11 passed (1 new for auto-create user)
