### PR TITLE
revert: use GITHUB_TOKEN for OpenCode action, not GREMLIN_PAT

### DIFF
--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -139,15 +139,11 @@ jobs:
            git config user.name "Gremlin"
            git config user.email "gremlin@users.noreply.github.com"
 
-      - name: Configure git auth with PAT
-        run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GREMLIN_PAT }}@github.com/${{ github.repository }}.git
-
       - name: Run OpenCode
         uses: anomalyco/opencode/github@v1.17.13
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GREMLIN_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: deepseek/deepseek-v4-flash
           use_github_token: true


### PR DESCRIPTION
Reverts the GITHUB_TOKEN env var in the Run OpenCode step back to secrets.GITHUB_TOKEN.

The PAT cannot fix the workflow file push issue because OpenCode hardcodes \x-access-token:\ prefix in git credentials. GitHub treats this as App token format regardless of the actual token type.

Removes the unnecessary 'Configure git auth with PAT' step (OpenCode uses its own bundled git, so system git config has no effect).

GH_TOKEN at the top level stays as GREMLIN_PAT for gh CLI operations.