### PR TITLE
chore: CI cleanup - remove unused arm64 builds, add OCI labels, condition Firefox/WebKit tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,6 +33,30 @@ area:auth:
           - src/app/login/**/*
           - src/app/setup/**/*
 
+needs-firefox:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/core/globe/**/*
+          - src/**/*.css
+          - src/lib/auth/**/*
+          - src/app/api/auth/**/*
+          - playwright.config.ts
+          - .github/workflows/playwright.yml
+          - tests/**/*
+          - prisma/**/*
+
+needs-webkit:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/core/globe/**/*
+          - src/**/*.css
+          - src/lib/auth/**/*
+          - src/app/api/auth/**/*
+          - playwright.config.ts
+          - .github/workflows/playwright.yml
+          - tests/**/*
+          - prisma/**/*
+
 area:ci:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.description=Real-time geospatial intelligence engine — visualize live global events, conflicts, and satellite data on an interactive 3D globe
+            org.opencontainers.image.url=https://worldwideview.dev
+            org.opencontainers.image.vendor=WorldWideView
 
       - name: Build and push by digest
         id: build
@@ -102,104 +106,12 @@ jobs:
           cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
   # --------------------------------------------------
-  # Production image -- linux/arm64
-  # --------------------------------------------------
-  build-production-arm64:
-    name: Production (arm64)
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-      security-events: write
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NEXT_PUBLIC_WWV_EDITION=${{ vars.NEXT_PUBLIC_WWV_EDITION || 'local' }}
-            NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
-            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-            NEXT_PUBLIC_BING_MAPS_KEY=${{ secrets.NEXT_PUBLIC_BING_MAPS_KEY }}
-            NEXT_PUBLIC_WS_ENGINE_URL=${{ vars.NEXT_PUBLIC_WS_ENGINE_URL }}
-            NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL=${{ vars.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL }}
-            NEXT_PUBLIC_ADSENSE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_ADSENSE_CLIENT_ID }}
-            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          cache-from: type=gha,scope=prod-arm64
-          cache-to: type=gha,scope=prod-arm64,mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
-          format: sarif
-          output: trivy-results.sarif
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: os,library
-          severity: CRITICAL,HIGH
-        continue-on-error: true
-
-      - name: Upload Trivy results to GitHub Security
-        if: always()
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
-
-      - name: Attest build provenance
-        continue-on-error: true
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3.8.1
-
-      - name: Sign image with Cosign
-        continue-on-error: true
-        env:
-          COSIGN_EXPERIMENTAL: "1"
-        run: |
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
-
-  # --------------------------------------------------
-  # Merge production manifests
+  # Merge production manifest
   # --------------------------------------------------
   merge-production:
     name: Merge production manifest
     if: github.event_name != 'pull_request'
-    needs: [build-production-amd64, build-production-arm64]
+    needs: [build-production-amd64]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -216,13 +128,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push multi-arch manifest
+      - name: Create and push manifest
         run: |
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-production-amd64.outputs.digest }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-production-arm64.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-production-amd64.outputs.digest }}
 
       - name: Trigger Coolify deploy
         env:
@@ -267,6 +178,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.description=Real-time geospatial intelligence engine — visualize live global events, conflicts, and satellite data on an interactive 3D globe
+            org.opencontainers.image.url=https://worldwideview.dev
+            org.opencontainers.image.vendor=WorldWideView
 
       - name: Build and push by digest
         id: build
@@ -315,92 +230,12 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
 
   # --------------------------------------------------
-  # Demo image -- linux/arm64
-  # --------------------------------------------------
-  build-demo-arm64:
-    name: Demo (arm64)
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-      security-events: write
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NEXT_PUBLIC_WWV_EDITION=demo
-            NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS=iranwarlive,satellite,gps-jamming
-            NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
-            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-            NEXT_PUBLIC_BING_MAPS_KEY=${{ secrets.NEXT_PUBLIC_BING_MAPS_KEY }}
-            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          cache-from: type=gha,scope=demo-arm64
-          cache-to: type=gha,scope=demo-arm64,mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
-          format: sarif
-          output: trivy-results.sarif
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: os,library
-          severity: CRITICAL,HIGH
-        continue-on-error: true
-
-      - name: Upload Trivy results to GitHub Security
-        if: always()
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
-
-      - name: Attest build provenance
-        continue-on-error: true
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-
-  # --------------------------------------------------
-  # Merge demo manifests
+  # Merge demo manifest
   # --------------------------------------------------
   merge-demo:
     name: Merge demo manifest
     if: github.event_name != 'pull_request'
-    needs: [build-demo-amd64, build-demo-arm64]
+    needs: [build-demo-amd64]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -417,10 +252,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push multi-arch manifest
+      - name: Create and push manifest
         run: |
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:demo \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:demo-${{ github.sha }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-demo-amd64.outputs.digest }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-demo-arm64.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-demo-amd64.outputs.digest }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,10 @@
 name: Playwright Tests
 # Only run E2E tests when application code actually changes.
-# Doc/agent-rules/config-only changes skip the full 3-browser matrix.
+# Doc/agent-rules/config-only changes skip the full suite.
+# Chromium always runs. Firefox and WebKit run conditionally:
+#   - Always on push to main (full coverage before release)
+#   - On PRs when browser-impacting paths change (globe, CSS, auth, test files)
+#   - On PRs with explicit needs-firefox / needs-webkit labels
 # Skipped workflow runs satisfy GitHub required status checks (neutral pass).
 on:
   push:
@@ -34,17 +38,117 @@ concurrency:
 
 permissions:
   contents: read
+
 jobs:
-  test:
-    timeout-minutes: 60
+  # ── Detection: which non-Chromium browsers need to run? ──────────────
+  check:
+    name: Check Browser Need
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        browser: [chromium, firefox, webkit]
+    timeout-minutes: 5
+    outputs:
+      run-firefox: ${{ steps.check.outputs.run-firefox }}
+      run-webkit: ${{ steps.check.outputs.run-webkit }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            browser-impact:
+              - 'src/core/globe/**'
+              - 'src/**/*.css'
+              - 'src/lib/auth/**'
+              - 'src/app/api/auth/**'
+              - 'playwright.config.ts'
+              - '.github/workflows/playwright.yml'
+              - 'tests/**'
+              - 'prisma/**'
+
+      - name: Evaluate browser need
+        id: check
+        shell: bash
+        run: |
+          IS_PUSH="${{ github.event_name == 'push' }}"
+          HAS_IMPACT="${{ steps.filter.outputs.browser-impact }}"
+
+          # Label checks only apply to pull_request events
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            HAS_FF_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'needs-firefox') && 'true' || 'false' }}"
+            HAS_WK_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'needs-webkit') && 'true' || 'false' }}"
+          else
+            HAS_FF_LABEL="false"
+            HAS_WK_LABEL="false"
+          fi
+
+          # Firefox: push to main OR browser-impact paths changed OR needs-firefox label
+          if [ "$IS_PUSH" = "true" ] || [ "$HAS_IMPACT" = "true" ] || [ "$HAS_FF_LABEL" = "true" ]; then
+            echo "run-firefox=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-firefox=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # WebKit: push to main OR browser-impact paths changed OR needs-webkit label
+          if [ "$IS_PUSH" = "true" ] || [ "$HAS_IMPACT" = "true" ] || [ "$HAS_WK_LABEL" = "true" ]; then
+            echo "run-webkit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-webkit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Chromium — always runs ──────────────────────────────────────────
+  chromium:
+    name: Playwright (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v7
-    
+
+    - uses: pnpm/action-setup@v6
+      with:
+        version: 9.15.4
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 20
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+
+    - name: Run Project Setup
+      run: pnpm run setup
+
+    - name: Boot Database
+      run: |
+        docker network create coolify || true
+        pnpm run predev
+
+    - name: Run Playwright tests
+      env:
+        BETTER_AUTH_SECRET: test-better-auth-secret-at-least-32-chars!
+        CROSS_SERVICE_SECRET: test-cross-service-secret-for-e2e
+      run: pnpm test:e2e --project=chromium
+
+    - uses: actions/upload-artifact@v7
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report-chromium
+        path: playwright-report/
+        retention-days: 30
+
+  # ── Firefox — conditional ───────────────────────────────────────────
+  firefox:
+    name: Playwright (firefox)
+    if: needs.check.outputs.run-firefox == 'true'
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v7
+
     - uses: pnpm/action-setup@v6
       with:
         version: 9.15.4
@@ -73,19 +177,60 @@ jobs:
         # Prevent Firefox from loading the AT-SPI/MSAA accessibility bridge on
         # Linux CI — without this, Firefox hangs for ~20 min waiting for a bus
         # that doesn't exist on ubuntu-latest runners.
-        NO_AT_BRIDGE: ${{ matrix.browser == 'firefox' && '1' || '0' }}
-        # Better Auth secret for HMAC-SHA256 session cookie signing/validation.
-        # Must match the value used by the Next.js app in the Docker Compose stack.
-        # A non-empty string of sufficient length — not sensitive in test CI.
+        NO_AT_BRIDGE: '1'
         BETTER_AUTH_SECRET: test-better-auth-secret-at-least-32-chars!
-        # Cross-service HMAC secret for hub <-> globe communication.
-        # Must match the value in playwright.config.ts webServer env.
         CROSS_SERVICE_SECRET: test-cross-service-secret-for-e2e
-      run: pnpm test:e2e --project=${{ matrix.browser }}
-      
+      run: pnpm test:e2e --project=firefox
+
     - uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
-        name: playwright-report-${{ matrix.browser }}
+        name: playwright-report-firefox
+        path: playwright-report/
+        retention-days: 30
+
+  # ── WebKit — conditional ────────────────────────────────────────────
+  webkit:
+    name: Playwright (webkit)
+    if: needs.check.outputs.run-webkit == 'true'
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: pnpm/action-setup@v6
+      with:
+        version: 9.15.4
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 20
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+
+    - name: Run Project Setup
+      run: pnpm run setup
+
+    - name: Boot Database
+      run: |
+        docker network create coolify || true
+        pnpm run predev
+
+    - name: Run Playwright tests
+      env:
+        BETTER_AUTH_SECRET: test-better-auth-secret-at-least-32-chars!
+        CROSS_SERVICE_SECRET: test-cross-service-secret-for-e2e
+      run: pnpm test:e2e --project=webkit
+
+    - uses: actions/upload-artifact@v7
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report-webkit
         path: playwright-report/
         retention-days: 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,13 @@ COPY docker-entrypoint.sh ./docker-entrypoint.sh
 RUN sed -i 's/\r$//' ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
 
+LABEL org.opencontainers.image.title="WorldWideView"
+LABEL org.opencontainers.image.description="Real-time geospatial intelligence engine — visualize live global events, conflicts, and satellite data on an interactive 3D globe"
+LABEL org.opencontainers.image.url="https://worldwideview.dev"
+LABEL org.opencontainers.image.source="https://github.com/silvertakana/worldwideview"
+LABEL org.opencontainers.image.licenses="EL-2.0"
+LABEL org.opencontainers.image.vendor="WorldWideView"
+
 EXPOSE 3000 3001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "worldwideview",
     "version": "2.60.1",
     "private": true,
+    "license": "EL-2.0",
     "type": "module",
     "packageManager": "pnpm@9.15.4",
     "scripts": {


### PR DESCRIPTION
## Changes

### CI: Remove unused arm64 Docker builds (closes #347)
- Removed build-production-arm64 and build-demo-arm64 jobs
- Updated merge-production and merge-demo to depend only on amd64 builds
- Fixed copy-paste bug: build-demo-amd64 had platforms linux/arm64 -> now linux/amd64

### CI: Conditional Firefox/WebKit Playwright tests
- Chromium runs on every PR (always)
- Firefox/WebKit only run when push to main, browser paths change, or PR has needs-firefox/needs-webkit label
- Added check job using dorny/paths-filter for auto-detection
- Added needs-firefox and needs-webkit labels to labeler.yml

### Docker: OCI image labels
- Added description, url, vendor, title, source, licenses to all 3 Dockerfiles
- Overrode description in CI metadata-action so ghcr.io shows something useful
- Added license field to root package.json (EL-2.0)