### PR TITLE
feat: add DELETE endpoint for instance/[id]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "worldwideview",
-    "version": "2.61.0",
+    "version": "2.62.0",
     "private": true,
     "license": "EL-2.0",
     "type": "module",

--- a/src/app/api/instance/[id]/route.ts
+++ b/src/app/api/instance/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { crossServiceAuth } from "@/lib/cross-service/middleware";
+
+export async function DELETE(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const authError = await crossServiceAuth(request);
+    if (authError) return authError;
+
+    const { id } = await params;
+
+    const workspace = await prisma.workspace.findUnique({ where: { id } });
+    if (!workspace) {
+        return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+    }
+
+    await prisma.workspace.delete({
+        where: { id },
+    });
+
+    return NextResponse.json({ success: true, id });
+}


### PR DESCRIPTION
Adds DELETE /api/instance/[id] so the hub can proxy instance deletion requests. Without this, the delete button in the hub UI returns 500 and freezes.