### PR TITLE
perf: reduce PM2 cluster instances to 4 and cap Node.js heap at 768MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN npm install -g prisma@7.5.0 pm2@latest
 
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
+ENV NODE_OPTIONS=--max-old-space-size=768
 ENV PORT=3000
 # DATABASE_URL must be provided via environment variable (no default)
 # Example: postgresql://user:pass@host:5432/dbname

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -96,4 +96,4 @@ if [ -f "./scripts/https-proxy.mjs" ]; then
   node ./scripts/https-proxy.mjs &
 fi
 
-exec pm2-runtime server.js -i max
+exec pm2-runtime server.js -i 4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.64.0",
+  "version": "2.64.1",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
## Problem

The PM2 cluster mode was set to `-i max`, which spawned 16 Node.js processes on the 16-core production server. Each process allocates memory overhead, and the unbounded heap size (`--max-old-space-size` unset) allowed individual processes to grow uncontrolled.

This caused the container to consume 2+ GiB RAM for 16 processes, contributing to overall server memory pressure.

## Changes

- **docker-entrypoint.sh**: Changed `pm2-runtime start -i max` to `-i 4` — limits to 4 cluster instances, matching the server's available memory budget
- **Dockerfile**: Added `ENV NODE_OPTIONS=--max-old-space-size=768` to cap the Node.js heap at 768MB per process

## Expected Impact

- Container RAM: ~2+ GiB → ~400-500 MiB
- Total server memory savings: ~1.5 GiB

## Related

- Same fix applied to worldwideview-web in PR #58