### PR TITLE
fix: revert altitude /10 workaround now that plugin altitude is correct

### DIFF
--- a/src/components/panels/EntityInfoCard.tsx
+++ b/src/components/panels/EntityInfoCard.tsx
@@ -71,7 +71,7 @@ export function EntityInfoCard() {
 
     // Format values
     const {altitude} = hoveredEntity;
-    const altitudeDisplay = altitude !== undefined ? `${(altitude / 10).toFixed(0)} m` : null;
+    const altitudeDisplay = altitude !== undefined ? `${altitude.toFixed(0)} m` : null;
 
     const {speed} = hoveredEntity;
     const speedDisplay = speed !== undefined ? `${speed.toFixed(0)} m/s` : null;


### PR DESCRIPTION
The aviation plugins in wwv-plugins had a `* 10` multiplier that caused aircraft altitude to display at 10x the actual value. A compensating `/ 10` was added in the frontend EntityInfoCard to mask it. With the plugins now fixed (the multiplier has been corrected at source), this workaround is no longer needed.

Closes #358