### PR TITLE
fix: Places API env var fallback + local engine blocklist

### DIFF
--- a/src/app/api/places/details/route.ts
+++ b/src/app/api/places/details/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
     // Use user-provided key if present in header AND looks valid, otherwise fall back to .env
     const userKey = request.headers.get("X-User-Google-Key");
     const isValidUserKey = userKey && userKey.length >= 20;
-    const apiKey = isValidUserKey ? userKey : process.env.GOOGLE_MAPS_API_KEY;
+    const apiKey = isValidUserKey ? userKey : (process.env.GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY);
     if (!apiKey) {
         console.error("GOOGLE_MAPS_API_KEY is not defined and no user key provided");
         return NextResponse.json({ error: "Server configuration error" }, { status: 500 });

--- a/src/app/api/places/search/route.ts
+++ b/src/app/api/places/search/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
     // Use user-provided key if present in header AND looks valid, otherwise fall back to .env
     const userKey = request.headers.get("X-User-Google-Key");
     const isValidUserKey = userKey && userKey.length >= 20;
-    const apiKey = isValidUserKey ? userKey : process.env.GOOGLE_MAPS_API_KEY;
+    const apiKey = isValidUserKey ? userKey : (process.env.GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY);
     if (!apiKey) {
         console.error("GOOGLE_MAPS_API_KEY is not defined and no user key provided");
         return NextResponse.json({ error: "Server configuration error" }, { status: 500 });

--- a/src/core/data/DataUtils.test.ts
+++ b/src/core/data/DataUtils.test.ts
@@ -3,7 +3,7 @@ import {
  describe, it, expect, vi, beforeEach
 } from "vitest";
 import { pluginManager } from "@/core/plugins/PluginManager";
-import { fetchLocalEngineManifest, localEngineHasPlugin, resetManifestCache } from "./engineManifest";
+import { fetchLocalEngineManifest, localEngineHasPlugin, isPluginBlocklisted, resetManifestCache } from "./engineManifest";
 import { resolveEngineUrl } from "./resolveEngineUrl";
 
 // Mock PluginManager
@@ -49,6 +49,39 @@ describe("EngineManifest", () => {
   });
 });
 
+describe("isPluginBlocklisted", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST;
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("should return false when blocklist env var is not set", () => {
+    expect(isPluginBlocklisted("maritime")).toBe(false);
+  });
+
+  it("should return true when plugin is in the blocklist", () => {
+    process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST = "maritime,some-other";
+    expect(isPluginBlocklisted("maritime")).toBe(true);
+  });
+
+  it("should return false when plugin is not in the blocklist", () => {
+    process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST = "some-other";
+    expect(isPluginBlocklisted("maritime")).toBe(false);
+  });
+
+  it("should handle whitespace in the blocklist", () => {
+    process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST = "maritime ,  spaced-plugin";
+    expect(isPluginBlocklisted("maritime")).toBe(true);
+    expect(isPluginBlocklisted("spaced-plugin")).toBe(true);
+  });
+});
+
 describe("resolveEngineUrl", () => {
   beforeEach(() => {
     resetManifestCache();
@@ -65,6 +98,43 @@ describe("resolveEngineUrl", () => {
 
     const url = resolveEngineUrl("plugin-local");
     expect(url).toContain("localhost:5000/stream");
+  });
+
+  it("should skip local engine for blocklisted plugin and fall back", async () => {
+    process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST = "plugin-local";
+    // Setup local manifest — plugin IS present locally
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ plugins: ["plugin-local"] }),
+    });
+    await fetchLocalEngineManifest();
+
+    // No plugin config or manifest configured, so should fall to default cloud
+    const url = resolveEngineUrl("plugin-local");
+    expect(url).toContain("worldwideview.dev/stream");
+    delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST;
+  });
+
+  it("should respect blocklist even when plugin has custom streamUrl", async () => {
+    process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST = "plugin-custom";
+    // Setup local manifest — plugin IS present locally
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ plugins: ["plugin-custom"] }),
+    });
+    await fetchLocalEngineManifest();
+
+    // Even though the plugin has a custom streamUrl, resolution goes through
+    // the normal chain — blocklist skips local engine, then falls to custom
+    (pluginManager.getPlugin as any).mockReturnValue({
+      plugin: {
+        getServerConfig: () => ({ streamUrl: "ws://custom-engine/stream" })
+      }
+    });
+
+    const url = resolveEngineUrl("plugin-custom");
+    expect(url).toBe("ws://custom-engine/stream");
+    delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST;
   });
 
   it("should fall back to plugin's custom streamUrl if not local", () => {

--- a/src/core/data/engineManifest.ts
+++ b/src/core/data/engineManifest.ts
@@ -66,6 +66,20 @@ export function localEngineHasPlugin(pluginId: string): boolean {
   return localManifest.includes(pluginId);
 }
 
+/**
+ * Check if a plugin is blocklisted from using the local engine.
+ *
+ * Reads NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST — a comma-separated list of
+ * plugin IDs that should always use the cloud engine instead. This lets
+ * operators bypass seeders that are registered but non-functional (e.g.,
+ * missing API keys) without code changes.
+ */
+export function isPluginBlocklisted(pluginId: string): boolean {
+  const blocklist = process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST || "";
+  if (!blocklist) return false;
+  return blocklist.split(",").map((s) => s.trim()).includes(pluginId);
+}
+
 /** Reset the cache (for testing or reconnection). */
 export function resetManifestCache(): void {
   localManifest = null;

--- a/src/core/data/resolveEngineUrl.ts
+++ b/src/core/data/resolveEngineUrl.ts
@@ -1,6 +1,6 @@
 // src/core/data/resolveEngineUrl.ts
 import { pluginManager } from "@/core/plugins/PluginManager";
-import { localEngineHasPlugin } from "./engineManifest";
+import { localEngineHasPlugin, isPluginBlocklisted } from "./engineManifest";
 
 const CLOUD_ENGINE_URL = "wss://dataenginev2.worldwideview.dev/stream"; // lint-url: allow (default fallback, env-overridable on next line)
 
@@ -28,7 +28,8 @@ function getLocalWsUrl() {
  * Resolves the WebSocket engine URL for a given plugin.
  *
  * Resolution order:
- * 1. Local engine (if running at localhost:5000 and has this plugin's seeder)
+ * 1. Local engine (if running at localhost:5000 and has this plugin's seeder,
+ *    AND the plugin is not in NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST)
  * 2. Plugin's ServerPluginConfig.streamUrl (code-based plugins)
  * 3. Plugin's PluginManifest.dataSource.streamUrl (manifest-based plugins)
  * 4. NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL env var
@@ -36,7 +37,9 @@ function getLocalWsUrl() {
  */
 export function resolveEngineUrl(pluginId: string): string {
   // 1. Local engine (split-routing) - PRIORITY #1
-  if (localEngineHasPlugin(pluginId)) {
+  // Skips blocklisted plugins so operators can bypass non-functional seeders
+  // (e.g., missing API keys) without code changes.
+  if (localEngineHasPlugin(pluginId) && !isPluginBlocklisted(pluginId)) {
     return getLocalWsUrl();
   }
 


### PR DESCRIPTION
Closes #374 and #376.

## #374 — Search broken in Docker deployments
**Root cause:** Server-side Places API routes read `process.env.GOOGLE_MAPS_API_KEY` but Docker only passes `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`. The env var names don't match, so search returns 500 in cloud/Docker deployments.

**Fix:** Added `|| process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` fallback to both `places/search` and `places/details` routes.

## #376 — Seeder blocks cloud engine fallback
**Root cause:** When a community seeder exists on disk but can't produce data (missing API key like `AISSTREAM_API_KEY`), the local engine still registers it in the manifest. The frontend routes data requests to the local engine instead of falling back to cloud, serving empty data.

**Fix:** Added `NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST` env var — a comma-separated list of plugin IDs that should skip the local engine and fall through to cloud URLs. Operators set `NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST=maritime` to work around non-functional seeders.