### PR TITLE
Disable scheduled garbage collector

### DIFF
--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -1,8 +1,6 @@
 name: Garbage Collector
 
 on:
-  schedule:
-    - cron: '0 6 * * *'   # 06:00 UTC daily
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary
- remove the daily cron trigger from the Garbage Collector workflow
- keep the manual workflow_dispatch inputs intact for an explicit on-demand run after credentials are fixed

## Why
The scheduled workflow has been failing daily because the Claude OAuth token used by anthropics/claude-code-action is revoked, creating recurring Actions noise and cost.

## Validation
- `git diff --check`
- Ruby YAML parse of `.github/workflows/garbage-collector.yml`
- confirmed `.github/workflows/garbage-collector.yml` still has `workflow_dispatch` and no `schedule`/`cron` trigger
- reviewed recent run `30078395731`, which failed with `401 OAuth access token has been revoked`

## Scope
Only `.github/workflows/garbage-collector.yml` changed. Other manual, production, CI, preview, publishing, stale-bot, and test workflows are untouched.