### PR TITLE
fix: recognize standard admin role as demo admin on demo edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.2",
+  "version": "2.65.3",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -123,3 +123,21 @@ describe("Header signout", () => {
         });
     });
 });
+
+describe("Header admin badge", () => {
+    it("renders ADMIN badge when the session user is a demo admin", async () => {
+        const mod = await import("@/core/edition");
+        const demoOriginal = mod.isDemo;
+        const adminOriginal = mod.isDemoAdmin;
+        Object.defineProperty(mod, "isDemo", { get: () => true });
+        Object.defineProperty(mod, "isDemoAdmin", { get: () => () => true });
+
+        render(<Header />);
+
+        const badges = screen.queryAllByText("ADMIN");
+        expect(badges.length).toBeGreaterThan(0);
+
+        Object.defineProperty(mod, "isDemo", { get: () => demoOriginal });
+        Object.defineProperty(mod, "isDemoAdmin", { get: () => adminOriginal });
+    });
+});

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -7,11 +7,19 @@ const mockSignOut = vi.fn();
 vi.mock("@/lib/auth-client", () => ({
     authClient: {
         signOut: (...args: unknown[]) => mockSignOut(...args),
+        useSession: () => ({
+            data: null,
+            isPending: false,
+            isRefetching: false,
+            error: null,
+            refetch: vi.fn(),
+        }),
     },
 }));
 
 vi.mock("@/core/edition", () => ({
     isDemo: false,
+    isDemoAdmin: () => false,
     DEMO_ADMIN_ROLE: "admin",
 }));
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,7 +15,8 @@ import {
  Globe, Key, Sun, Moon, Monitor, Crosshair, LogOut
 } from "lucide-react";
 import { trackEvent } from "@/lib/analytics";
-import { isDemo, DEMO_ADMIN_ROLE } from "@/core/edition";
+import { isDemo, isDemoAdmin as isDemoAdminSession } from "@/core/edition";
+import { useBetterAuth } from "@/hooks/useBetterAuth";
 
 import Image from "next/image";
 
@@ -67,7 +68,8 @@ export function Header() {
     const setTheme = useStore((s) => s.setTheme);
 
     const scrollContainerRef = useRef<HTMLDivElement>(null);
-    const [isDemoAdmin, setIsDemoAdmin] = useState(false);
+    const { data: session } = useBetterAuth();
+    const isDemoAdmin = isDemoAdminSession(session);
     const [showApiKeys, setShowApiKeys] = useState(false);
 
     const handleSignOut = async () => {
@@ -88,14 +90,6 @@ export function Header() {
     const [themeOpen, setThemeOpen] = useState(false);
     const themeButtonRef = useRef<HTMLButtonElement>(null);
     const [themePos, setThemePos] = useState({ top: 0, right: 0 });
-
-    useEffect(() => {
-        if (!isDemo) return;
-        fetch("/api/auth/session")
-            .then((r) => r.json())
-            .then((s) => setIsDemoAdmin(s?.user?.role === DEMO_ADMIN_ROLE))
-            .catch(() => {});
-    }, []);
 
     useEffect(() => {
         const el = scrollContainerRef.current;

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -10,7 +10,8 @@
 
 import React, { useState, useEffect } from "react";
 import { useStore } from "@/core/state/store";
-import { isHistoryEnabled as default_isHistoryEnabled, isDemo, DEMO_ADMIN_ROLE } from "@/core/edition";
+import { isHistoryEnabled as default_isHistoryEnabled, isDemoAdmin as isDemoAdminSession } from "@/core/edition";
+import { useBetterAuth } from "@/hooks/useBetterAuth";
 
 /**
  * @component Timeline
@@ -32,16 +33,12 @@ export function Timeline() {
     const timeRange = useStore((s) => s.timeRange);
 
     const [mounted, setMounted] = useState(false);
-    const [isDemoAdmin, setIsDemoAdmin] = useState(false);
+    const { data: session } = useBetterAuth();
+    const isDemoAdmin = isDemoAdminSession(session);
 
     useEffect(() => {
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setMounted(true);
-        if (!isDemo) return;
-        fetch("/api/auth/session")
-            .then((r) => r.json())
-            .then((s) => setIsDemoAdmin(s?.user?.role === DEMO_ADMIN_ROLE))
-            .catch(() => {});
     }, []);
 
     const isHistoryEnabled = default_isHistoryEnabled || isDemoAdmin;

--- a/src/core/demoAdmin.test.ts
+++ b/src/core/demoAdmin.test.ts
@@ -77,4 +77,10 @@ describe("isDemoAdmin", () => {
         const { isDemoAdmin, DEMO_ADMIN_ROLE } = await import("./edition");
         expect(isDemoAdmin({ user: { role: DEMO_ADMIN_ROLE } })).toBe(true);
     });
+
+    it("returns true on demo with the standard admin role", async () => {
+        vi.stubEnv("NEXT_PUBLIC_WWV_EDITION", "demo");
+        const { isDemoAdmin } = await import("./edition");
+        expect(isDemoAdmin({ user: { role: "admin" } })).toBe(true);
+    });
 });

--- a/src/core/edition.ts
+++ b/src/core/edition.ts
@@ -142,8 +142,13 @@ export function ticketAuthEnabledForPlugin(pluginId: string): boolean {
  * Returns `true` when the session belongs to the demo admin user.
  * Accepts any session-like object (uses runtime narrowing to avoid
  * type conflicts with Auth.js `Session` which doesn't declare `role`).
+ *
+ * An operator with the standard `admin` role is the demo admin;
+ * `demo-admin` is kept for legacy seeded accounts.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isDemoAdmin(session: any): boolean {
-    return isDemo && session?.user?.role === DEMO_ADMIN_ROLE;
+    if (!isDemo) return false;
+    const role = session?.user?.role;
+    return role === DEMO_ADMIN_ROLE || role === "admin";
 }


### PR DESCRIPTION
## Summary

Fixes the demo instance so a logged-in operator (role `admin`) actually controls the app — matching the intent that an admin is an admin regardless of edition.

### Root cause
1. `isDemoAdmin()` required the literal role `demo-admin`, but the real operator account has role `admin`. Every marketplace/plugin-control route gates on `isDemoAdmin`, so the logged-in admin got 403 on install/enable/disable/uninstall.
2. The client read the session from `/api/auth/session` — a route that does NOT exist after the Better Auth migration (the real endpoint is `/api/ba/get-session`). So the ADMIN badge and history unlock never activated even for a valid admin session.

### Changes
- **`src/core/edition.ts`**: `isDemoAdmin` now accepts `admin` OR legacy `demo-admin`. No role hierarchy exists in the app — roles are stored strings and this is the only role check — so this makes the standard admin role authoritative on demo.
- **`src/components/layout/Header.tsx`**: reads the session via `useBetterAuth()` (Better Auth SDK → `/api/ba/get-session`) instead of the dead `/api/auth/session` fetch. ADMIN badge now surfaces for real admin sessions.
- **`src/components/timeline/Timeline.tsx`**: same session fix; history unlock now activates for the demo admin.

### Verification
- `npx tsc --noEmit` passes (after `prisma generate` in the fresh worktree)
- `eslint` on all 3 changed files: 0 problems
- Production fact-check: the demo DB has `titmitna@gmail.com` with role `admin` in the live Better Auth `user` table — this fix makes that account the demo admin with zero data changes.

## Test plan
- [ ] Log into demo.worldwideview.dev as the operator → ADMIN badge shows, plugin install/enable/disable work
- [ ] Anonymous demo visitor → still sees the globe but cannot install/uninstall