### PR TITLE
fix: prevent client-supplied role escalation and disable demo signup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.3",
+  "version": "2.65.4",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/lib/better-auth.ts
+++ b/src/lib/better-auth.ts
@@ -14,7 +14,7 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { prisma } from "@/lib/db";
-import { isLocal } from "@/core/edition";
+import { isLocal, isDemo } from "@/core/edition";
 import { organization, admin, jwt } from "better-auth/plugins";
 import { oneTimeToken } from "better-auth/plugins/one-time-token";
 import { apiKey } from "@better-auth/api-key";
@@ -90,6 +90,8 @@ export const auth = betterAuth({
     }),
     emailAndPassword: {
         enabled: true,
+        // Demo is public read-only; no self-registration (issue #400).
+        disableSignUp: isDemo,
         // Validate password strength at sign-up and password reset.
         // Rejects passwords scoring below MIN_PASSWORD_SCORE (2).
         passwordValidator: async (password: string) => {
@@ -109,6 +111,7 @@ export const auth = betterAuth({
                 type: "string",
                 required: true,
                 defaultValue: "user",
+                input: false, // never accept a client-supplied role (privilege-escalation guard)
             },
         },
     },


### PR DESCRIPTION
## Summary

Fixes **#400** — a critical pre-existing privilege-escalation vulnerability.

Better Auth's `role` additional field lacked `input: false`, so `parseInputData` stored client-supplied values verbatim. An attacker could `POST /api/ba/sign-up/email` with `{"role":"admin"}` and self-assign the admin role — gaining Better Auth admin-plugin powers (`setRole`, `impersonateUser`, `banUser`, `createApiKey`) and, since PR #399 made `isDemoAdmin` accept the `admin` role, full marketplace control on the public demo instance.

## Changes

- **`src/lib/better-auth.ts`**:
  - `role` additional field: added `input: false` — never accept a client-supplied role
  - `emailAndPassword`: `disableSignUp: isDemo` — the demo is public read-only with no self-registration (there is no signup UI in the app; signup was only reachable via the raw API endpoint)

## Verification

- `npx tsc --noEmit`: pass (0 errors)
- `npx eslint src/lib/better-auth.ts`: pass (0 problems)
- Unit tests: 40/40 pass (better-auth.test.ts + demoAdmin.test.ts)
- Production DB audit: only legitimate operator `titmitna@gmail.com` (role `admin`) — no attacker-injected admin rows

## Test plan

- [ ] On demo: `POST /api/ba/sign-up/email` returns a signup-disabled error
- [ ] `POST /api/ba/sign-up/email` with `{"role":"admin"}` does not grant admin
- [ ] Local/cloud signup still works (non-demo editions unaffected)

Closes #400