### PR TITLE
ci: add gitleaks secret scan

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,18 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Add Gitleaks secret scanning to CI so PRs that commit API keys, JWTs, or .env files fail. This repo previously had no secret scanner.

## Type of Change
- [x] CI / tooling

## Testing
- [x] gitleaks workflow file validated (YAML parses)