### PR TITLE
fix: relocate preview secrets out of reusable workflow with block

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,6 +20,8 @@ permissions:
   contents: read
   packages: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-preview:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -31,13 +31,10 @@ jobs:
       build-args: |
         NEXT_PUBLIC_WWV_EDITION=demo
         NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS=iranwarlive,satellite,gps-jamming
-        NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
-        NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-        NEXT_PUBLIC_BING_MAPS_KEY=${{ secrets.NEXT_PUBLIC_BING_MAPS_KEY }}
         NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
-        NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       smoke-test-path: /api/health
       is-preview: true
+      include-preview-secrets: true
     secrets: inherit
 
   post-comment:

--- a/.github/workflows/shared-docker.yml
+++ b/.github/workflows/shared-docker.yml
@@ -18,6 +18,9 @@ on:
       is-preview:
         type: boolean
         default: false
+      include-preview-secrets:
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -57,7 +60,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build-args }}
+          build-args: |
+            ${{ inputs.build-args }}
+            ${{ inputs.include-preview-secrets && format('NEXT_PUBLIC_CESIUM_ION_TOKEN={0}', secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN) || '' }}
+            ${{ inputs.include-preview-secrets && format('NEXT_PUBLIC_GOOGLE_MAPS_API_KEY={0}', secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY) || '' }}
+            ${{ inputs.include-preview-secrets && format('NEXT_PUBLIC_BING_MAPS_KEY={0}', secrets.NEXT_PUBLIC_BING_MAPS_KEY) || '' }}
+            ${{ inputs.include-preview-secrets && format('NEXT_PUBLIC_SUPABASE_ANON_KEY={0}', secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/shared-docker.yml
+++ b/.github/workflows/shared-docker.yml
@@ -88,11 +88,11 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Generate SBOM
-        uses: anchore/syft-action@v0
+        uses: anchore/sbom-action@v0
         with:
           image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: spdx-json
-          output: sbom.spdx.json
+          output-file: sbom.spdx.json
 
       - name: Sign image with Cosign
         if: ${{ !inputs.is-preview }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.11",
+  "version": "2.65.12",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
pr-preview.yml has failed 100+ consecutive runs because `${{ secrets.* }}` is illegal inside a reusable workflow_call's `with:` (GitHub validation error: "context secrets is not allowed here"). Secrets moved into shared-docker.yml's build step behind an `include-preview-secrets` flag (default false, so marketplace/web consumers are unaffected). The caller already had `secrets: inherit`, so the secrets remain accessible where legal.