### PR TITLE
fix: make shared docker workflow platforms configurable, default amd64

### DIFF
--- a/.github/workflows/shared-docker.yml
+++ b/.github/workflows/shared-docker.yml
@@ -21,6 +21,10 @@ on:
       include-preview-secrets:
         type: boolean
         default: false
+      platforms:
+        type: string
+        default: 'linux/amd64'
+        description: 'Comma-separated build platforms. Default amd64-only; only the public globe app should pass linux/amd64,linux/arm64.'
 
 jobs:
   build:
@@ -57,7 +61,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.12",
+  "version": "2.65.13",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
Only the public globe app needs arm64 Docker images. All other ecosystem apps (marketplace, web, data-engine) are self-hosted by the owner and are amd64-only.

`shared-docker.yml` now takes a `platforms` input defaulting to `linux/amd64`, so marketplace/web stop building unnecessary arm64 (QEMU) images and avoid the Prisma arm64 build failure.

The globe's own `docker-publish.yml` builds arm64 natively (PR #290) and is unaffected. `pr-preview.yml` stays on the amd64 default (preview, not production).

Marketplace and web call shared-docker.yml@main without a platforms input, so they inherit the new amd64 default automatically after merge.