### PR TITLE
docs: document worktree removal gotchas in worktree-manager agent definition

### DIFF
--- a/.agents/agents/worktree-manager.md
+++ b/.agents/agents/worktree-manager.md
@@ -93,6 +93,34 @@ git -C "C:\dev\wwv\worldwideview" worktree list
 
 ---
 
+## Step 3a — Removal gotchas (Windows / Worktrunk)
+
+These three behaviors have caused slow worktree cleanups. Handle them in order — do NOT rediscover them from scratch.
+
+**1. yaml-language-server holds the directory handle (the big one).**
+OpenCode spawns a `yaml-language-server` LSP watcher whose **working directory is inside the worktree**. It holds an open handle on the directory, so Windows refuses deletion (`Device or resource busy`) even after `git-wt`'s background removal clears the contents. Command-line search for the path FAILS (the lock is the working directory, not the command line). `handle64.exe` finds it but is slow and can hang.
+
+Before removing the directory, kill the watcher first:
+```powershell
+Get-Process | Where-Object { $_.ProcessName -match 'yaml|language' } | Select-Object Id, ProcessName
+# Targeted kill only — never taskkill /F /IM node.exe
+Stop-Process -Id <PID> -Force
+```
+Only use `handle64.exe` as a fallback to find the holder, and run it backgrounded (it can take minutes).
+
+**2. Squash-merge leaves an "unmerged" branch behind.**
+After a squash-merged PR, the local branch commit is not an ancestor of main, so `git-wt remove` reports the branch unmerged and leaves it. Delete it explicitly:
+```powershell
+git branch -D <branch-name>
+```
+
+**3. `git-wt remove` backgrounds the deletion.**
+It unregisters the worktree synchronously but deletes contents in a background task (pre-remove hooks include `docker compose down -v`, which can take time). The directory may briefly linger with contents, then become an empty dir still held by the watcher. Don't fight it immediately — poll/wait for the background task, then clean the leftover empty dir (after killing the watcher per gotcha 1).
+
+Order that works: `git-wt remove --force --yes <branch>` → delete local branch if left (`-D`) → wait for background removal → kill yaml-language-server watcher if dir is held → `rm -rf` the empty dir.
+
+---
+
 ## Step 4 — Orphan recovery
 
 If a worktree was manually deleted and its Docker volume is now orphaned, run from the **main repo root**:

--- a/.agents/agents/worktree-manager.md
+++ b/.agents/agents/worktree-manager.md
@@ -97,6 +97,9 @@ git -C "C:\dev\wwv\worldwideview" worktree list
 
 These three behaviors have caused slow worktree cleanups. Handle them in order — do NOT rediscover them from scratch.
 
+**0. `wt` is Windows Terminal, NOT Worktrunk.**
+On Windows, the bare command `wt` resolves to the Windows Terminal executable, not a worktree command. NEVER invoke bare `wt` for worktree operations — it opens a terminal window or prints Windows Terminal help, and the command appears to "hang" or do nothing useful. ALWAYS use the full binary name `git-wt` (Worktrunk). Verify with `git-wt --version` before any operation (per the tool requirement at the top of this file).
+
 **1. yaml-language-server holds the directory handle (the big one).**
 OpenCode spawns a `yaml-language-server` LSP watcher whose **working directory is inside the worktree**. It holds an open handle on the directory, so Windows refuses deletion (`Device or resource busy`) even after `git-wt`'s background removal clears the contents. Command-line search for the path FAILS (the lock is the working directory, not the command line). `handle64.exe` finds it but is slow and can hang.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.14",
+  "version": "2.65.15",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.13",
+  "version": "2.65.14",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
Codifies three observed Windows/Worktrunk behaviors in the worktree-manager agent definition so future worktree cleanups start with the knowledge instead of rediscovering it:

1. yaml-language-server holds an open handle on the worktree directory (its working directory is inside it) — kill it with a targeted Stop-Process before deletion; command-line search misses it.
2. Squash-merged PRs leave an unmerged local branch behind — delete with git branch -D.
3. git-wt remove backgrounds the deletion and runs docker compose down -v — poll/wait instead of fighting it.

Docs-only change: `.agents/agents/worktree-manager.md` + package.json version bump 2.65.13 → 2.65.14.