### PR TITLE
fix: ignore cross-app billing specs in Playwright config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.17",
+  "version": "2.65.18",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
   // marketplace-from-instance.spec.ts uses playwright.marketplace.config.ts; full-flow requires marketplace repo
   // marketplace-redirect-handshake.spec.ts and marketplace-sign-out.spec.ts require marketplace.wwv.local:3002
   //   — use playwright.cross-app.config.ts for these cross-origin handshake tests
+  // billing-flow.spec.ts / billing-no-org.spec.ts target the web hub billing stack (seeded globe user, hub, Supabase, Stripe)
+  //   — use the web repo's playwright.billing.config.ts (billing is web-owned, ADR-0009)
   testIgnore: [
     '**/pact/**',
     '**/ci/**',
@@ -29,6 +31,8 @@ export default defineConfig({
     '**/marketplace-from-instance.spec.ts',
     '**/marketplace-redirect-handshake.spec.ts',
     '**/marketplace-sign-out.spec.ts',
+    '**/billing-flow.spec.ts',
+    '**/billing-no-org.spec.ts',
   ],
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
## Summary
The globe's "Playwright Tests" CI is red on main: `tests/billing-flow.spec.ts` and `tests/billing-no-org.spec.ts` were accidentally merged via #416 (commit `fd20fbd7`) and get auto-discovered by the default `playwright.config.ts`. They run without the billing stack they require (seeded globe user, hub, Supabase, Stripe) and fail in CI.

This PR excludes both specs via `testIgnore`, matching the existing pattern already used for the web-auth and marketplace cross-app specs.

## Why this is safe
Billing E2E is **web-owned** (ADR-0009). The suite remains covered by the web repo's `billing-e2e.yml` workflow, which is green and brings up the full billing stack (Docker Compose + local Supabase + Stripe).

## Test plan
- [x] `playwright test --list` — 78 tests in 10 files collected; billing specs no longer listed (26 tests in 10 files per project, x3 browsers)
- [x] Non-billing specs still present