### PR TITLE
fix: garbage-collector review mechanism: closed-issue dedupe, report dedup, stale-bot, triage docs

### DIFF
--- a/.agents/agents/garbage-collector.md
+++ b/.agents/agents/garbage-collector.md
@@ -45,9 +45,22 @@ git branch -r --list 'origin/gc/*'
 
 # Open gc-bot Issues
 gh issue list --label gc-bot --state open --json number,title
+
+# CLOSED gc-bot Issues — a finding covered by a closed issue must RE-OPEN it, not duplicate it
+gh issue list --label gc-bot --state closed --json number,title --limit 100
 ```
 
-Build a mental map of already-handled concerns. For each finding, skip it if an open PR or Issue already covers the same file + pattern.
+Build a mental map of already-handled concerns. For each finding:
+
+1. Skip it if an open PR or open Issue already covers the same file + pattern.
+2. Skip it if a remote `gc/*` branch already covers the same patternId/type.
+3. If a **CLOSED** gc-bot Issue substantially covers the finding (same file + pattern, or same concern), **re-open that Issue** with a comment:
+   ```bash
+   gh issue reopen <number>
+   gh issue comment <number> --body "Re-opening: this finding resurfaced in the <scan-date> scan — <finding summary>"
+   ```
+   Do NOT create a new Issue.
+4. Only create a new Issue when neither an open nor a closed gc-bot Issue covers the finding.
 
 ## Step 5 — Tier A: Create draft PRs (max 3 per run)
 
@@ -191,6 +204,17 @@ No PRs or Issues were created (dry-run mode).
 EOF
 )"
 ```
+
+**Report-dedup rule (dry-run):** before posting, check the previous report comment on the tracking Issue and only post when the findings changed materially. To read the last comment:
+
+```bash
+# Last comment body on the tracking Issue (comments are returned oldest-first, so [-1] is the most recent)
+gh issue view <number> --comments --json comments --jq '.comments[-1].body'
+```
+
+- If the previous report's findings are identical to the current scan (same finding count, same file + type sets), post **nothing** — or at most a one-line "No changes since <previous-date>." but ONLY if the previous report comment is more than 7 days old.
+- If findings changed materially (new findings, resolved findings, or changed counts), post the full report above.
+- The **Monday full sweep** (DRY_RUN=false) always posts a full digest regardless, so the weekly state is always visible.
 
 ## Step 8 — Output summary
 

--- a/.agents/rules/garbage-collection.md
+++ b/.agents/rules/garbage-collection.md
@@ -64,11 +64,45 @@ When `DRY_RUN=true` (set in the workflow dispatch input):
 - **Do not create any PRs or Issues.**
 - Use dry-run for the first 3–5 days after deployment to validate finding quality before enabling normal mode.
 
+Report-dedup policy: only post a dry-run report when the findings **changed materially** since the
+previous report. Compare against the last comment on the tracking Issue (same finding count, same
+file + type sets = unchanged). If unchanged, post nothing — or at most a one-line "No changes since
+<date>" only when the previous report is more than 7 days old. The Monday full sweep always posts a
+full digest regardless. This keeps the tracking Issue from becoming a daily spam thread.
+
+## Human Triage Ritual (weekly, ~15 minutes)
+
+The GC bot files Issues — humans decide what happens to them. Once a week, review the open `gc-bot` backlog:
+
+1. Open the saved search: `https://github.com/silvertakana/worldwideview/issues?q=is%3Aopen+label%3Agc-bot`
+2. For each open `gc-bot` Issue, pick one of three actions:
+   - **Fix now** — small, clearly correct: fix it and close the Issue with a reference to the PR.
+   - **Park** — real but not urgent: leave it open and add a comment stating why it is parked (so the stale bot and future reviewers see intent).
+   - **Close** — stale, already addressed, or not worth doing: close it with a one-line reason. The closed-issue dedupe policy will re-open it if the finding resurfaces, so closing is not lossy.
+3. If an Issue is parked intentionally, add the `Not Stale` label so the stale lifecycle does not auto-close it.
+
+## Stale Lifecycle (gc-bot Issues only)
+
+`.github/workflows/gc-stale.yml` runs the stale lifecycle for `gc-bot` Issues only (`only-labels: gc-bot` —
+it never touches human Issues; PR handling is disabled):
+
+- After **30 days** of no activity, the Issue is labelled `stale` with a warning comment.
+- After **14 more days** (44 total) of no activity, it is closed automatically.
+- The `Not Stale` label exempts an Issue from this lifecycle.
+- The general stale bot (`stale.yml`) exempts `gc-bot` from its own lifecycle, so the two stale workflows never double-process the same Issue.
+
 ## Idempotency rules
 
 A finding is already handled if **either** of these is true:
 
 1. A remote branch matching `gc/<same-patternId-or-type>-*` exists (`git branch -r --list 'origin/gc/<type>-*'`).
 2. An open PR or Issue labelled `gc-bot` already covers the same file + concern.
+
+Closed-issue dedupe policy: before filing a new Tier B Issue, also check **closed** `gc-bot` Issues
+(`gh issue list --label gc-bot --state closed`). If a closed Issue substantially covers the finding
+(same file + pattern, or same concern), **re-open it** with a comment instead of creating a duplicate:
+`Re-opening: this finding resurfaced in the <scan-date> scan — <finding summary>`. Only create a new
+Issue when neither an open nor a closed `gc-bot` Issue covers it. This prevents the bot from re-filing
+issues it already filed and closed (the 08-10 sweep duplicated closed #182/#245 as #418/#419).
 
 Skip handled findings without error or noise.

--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -116,6 +116,17 @@ jobs:
             The comment body must list every finding with: tier, file, line, description.
             Include the run ID (${{ github.run_id }}) and timestamp at the top.
 
+            ## Report-dedup rule (dry-run):
+            Before posting, compare the current scan against the previous report comment on the tracking Issue.
+            Read the last comment with (comments are returned oldest-first, so [-1] is the most recent):
+              gh api repos/${{ github.repository }}/issues/<number>/comments?per_page=100 --jq '.[-1].body'
+            - If the previous report's findings are identical to the current scan (same finding count,
+              same file + type sets), post NOTHING — or at most a one-line "No changes since <previous-date>."
+              ONLY if the previous report comment is more than 7 days old.
+            - If findings changed materially (new findings, resolved findings, or changed counts), post the
+              full report.
+            - The Monday full sweep (DRY_RUN=false) always posts a full digest regardless.
+
             ## If DRY_RUN is "false":
             Execute the full sweep procedure described in `.agents/agents/garbage-collector.md`.
             Create Tier A draft PRs and Tier B Issues per the guard rails in `.agents/rules/garbage-collection.md`.

--- a/.github/workflows/gc-stale.yml
+++ b/.github/workflows/gc-stale.yml
@@ -1,0 +1,36 @@
+# GC stale lifecycle — marks untouched gc-bot issues stale after 30 days, then
+# closes after 14 more. ONLY touches gc-bot issues (only-labels) so it never
+# interferes with human issues. PR handling is disabled (the GC bot opens draft
+# PRs for humans to review — never auto-close those). The general stale bot
+# (stale.yml) exempts gc-bot, so the two workflows never double-process.
+name: GC Stale Bot
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # daily 07:00 UTC
+  workflow_dispatch: # manual trigger
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: 'gc-bot'
+          days-before-stale: 30
+          days-before-close: 14
+          stale-issue-message: >
+            This gc-bot issue has been inactive for 30 days. If there is no
+            further activity in the next 14 days it will be closed automatically.
+            Add the 'Not Stale' label if it should stay open.
+          close-issue-message: >
+            Closing this gc-bot issue due to 44 days of inactivity. The GC bot
+            will re-open it if the finding resurfaces in a future scan.
+          stale-issue-label: stale
+          exempt-issue-labels: 'Not Stale'
+          operations-per-run: 100
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.17",
+  "version": "2.65.18",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
GC bot review-mechanism upgrade (phase 1: review mechanism only, no auto-PR changes yet).

## Changes
- **Closed-issue dedupe** (`.agents/agents/garbage-collector.md`, `.agents/rules/garbage-collection.md`): before filing a Tier B issue, the bot now checks closed `gc-bot` issues and re-opens a matching closed issue with a comment instead of creating a duplicate (fixes the 08-10 sweep duplicating closed #182/#245 as #418/#419).
- **Report dedup** (`.agents/agents/garbage-collector.md` Step 7, `.github/workflows/garbage-collector.yml` DRY_RUN prompt): the daily dry-run only posts to tracking issue #178 when findings changed materially; otherwise posts nothing (or a one-liner after 7+ days of silence). Monday full sweep always posts the digest. Reads the latest comment via `gh issue view ... --jq '.comments[-1].body'` (comments are ascending by ID).
- **New stale-bot** (`.github/workflows/gc-stale.yml`): actions/stale@v9 for `gc-bot`-labeled issues only — stale after 30d inactivity, close after 14 more, `Not Stale` label exempts, PR handling disabled, `issues: write` only. The existing stale.yml exempts gc-bot, so no double-processing.
- **Triage docs** (`.agents/rules/garbage-collection.md`): new Human Triage Ritual (weekly review with saved search, Fix/Park/Close rules) and Stale Lifecycle sections.

## Verification
Verified before shipping: YAML parsed OK (PyYAML) for all workflows, logic reviewed by a verifier agent across two cycles (PASS; a real report-dedup bug was found in review and fixed), diff hygiene confirmed (exactly 4 intended files + semver bump). No tests/build needed — content is workflow YAML + agent prompt markdown.