### PR TITLE
fix: restore WWV_DATA_ENGINE_URL read in getEngineUrl (health probe)

### DIFF
--- a/deploy/INFRA-CHECKLIST.md
+++ b/deploy/INFRA-CHECKLIST.md
@@ -48,21 +48,26 @@ are unenforceable.
   This is the HTTP base (scheme + host + port). Do NOT include the `/stream` path:
   ```
   # Correct: REST base only
-  WWV_DATA_ENGINE_URL=http://<engine-host-ip>:5002
+  WWV_DATA_ENGINE_URL=https://dataenginev2.worldwideview.dev
 
   # Wrong: do not include /stream
-  # WWV_DATA_ENGINE_URL=http://<engine-host-ip>:5002/stream
+  # WWV_DATA_ENGINE_URL=https://dataenginev2.worldwideview.dev/stream
   ```
-  The engine's published REST port is **5002** (maps to internal port 5000 in
-  `deploy/production/docker-compose.engine.yml`).
+  The engine listens on internal port 5000 (`PORT=5000` in
+  `deploy/production/docker-compose.engine.yml`) and publishes ports 5000/5001 on the
+  host. The public URL `https://dataenginev2.worldwideview.dev` is reverse-proxied and
+  needs no port. The code reads `WWV_DATA_ENGINE_URL` first in `getEngineUrl()`
+  (`src/lib/data-query/service.ts`) and falls back to
+  `http://localhost:5001` when it is unset.
   Replace `<engine-host-ip>` with the actual engine host IP or hostname visible from
   the `wwv` container.
 - [ ] If the app and engine containers share a Docker network, use the service name:
   ```
   WWV_DATA_ENGINE_URL=http://wwv-data-engine:5000
   ```
-- [ ] Verify reachability: `GET /api/health` should return `"engine": "ok"`.
-  A value of `"degraded"` means the URL is wrong or the engine is not running.
+- [ ] Verify reachability: `GET /api/health` should return `checks.engine: true`.
+  A status of `"degraded"` with `checks.engine: false` means the URL is wrong or the
+  engine is not running.
 
 **What breaks without this:** All MCP data query tools (e.g. `query_plugin_data`)
 report "engine unreachable" and return no data.
@@ -105,8 +110,8 @@ Configure your uptime monitor or Coolify health check against `GET /api/health`.
 | Response | Meaning | Action required |
 |---|---|---|
 | `503` | Database or required config broken | Page on-call immediately |
-| `200` with any `"degraded"` field | Redis or engine unreachable | Investigate; MCP features are impaired but core app is up |
-| `200` all `"ok"` | Fully healthy | No action |
+| `200` with `status: "degraded"` | Redis or engine unreachable (`checks.redis`/`checks.engine` false) | Investigate; MCP features are impaired but core app is up |
+| `200` with `status: "healthy"` (all checks `true`) | Fully healthy | No action |
 
 Recommended alert rule: alert on any `503` immediately; alert on `200` degraded
 after 5 consecutive checks (transient restarts are normal).
@@ -117,7 +122,7 @@ after 5 consecutive checks (transient restarts are normal).
 
 Run these checks in order after applying all settings:
 
-1. `GET /api/health` returns `200` with all fields `"ok"`.
+1. `GET /api/health` returns `200` with `status: "healthy"` and all checks `true`.
 2. Sign in as an admin user, generate an MCP API key, and confirm the key is issued
    (cloud/demo: requires `API_KEY_HMAC_SECRET`).
 3. Run `geocode_location({ query: "Paris" })` via the MCP endpoint and confirm

--- a/deploy/cloud/docker-compose.yml
+++ b/deploy/cloud/docker-compose.yml
@@ -55,8 +55,10 @@ services:
       REDIS_URL: "redis://:${REDIS_PASSWORD}@wwv-redis:6379"
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       # REST base URL for server-side MCP data queries (NOT the WebSocket /stream path).
+      # The engine publishes ports 5000/5001 on the host; the public URL
+      # https://dataenginev2.worldwideview.dev is reverse-proxied and needs no port.
       # Set to the actual engine host IP/hostname visible from this container.
-      WWV_DATA_ENGINE_URL: ${WWV_DATA_ENGINE_URL:-http://<engine-host-ip>:5002}
+      WWV_DATA_ENGINE_URL: ${WWV_DATA_ENGINE_URL:-http://<engine-host-ip>:5001}
     ports:
       - "3001:3000"
     labels:

--- a/deploy/production/docker-compose.app.yml
+++ b/deploy/production/docker-compose.app.yml
@@ -17,12 +17,12 @@ services:
       - "WWV_DEMO_ADMIN_SECRET=${WWV_DEMO_ADMIN_SECRET:-}"
       - "WWV_BRIDGE_TOKEN=${WWV_BRIDGE_TOKEN:-}"
       - "DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@db:5432/worldwideview?schema=public}"
-      # Provide the explicit public or host IP of the data engine for the frontend to use.
-      - "NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL=http://192.168.68.69:5002/stream"
+      # Provide the explicit public URL of the data engine for the frontend to use.
+      - "NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL=https://dataenginev2.worldwideview.dev/stream"
       # REST base URL for server-side MCP data queries (NOT the WebSocket /stream path).
-      # Default assumes the engine runs on the same host, published on port 5002.
-      # Operators using a separate engine host must override to http://<engine-host>:5002
-      - "WWV_DATA_ENGINE_URL=${WWV_DATA_ENGINE_URL:-http://192.168.68.69:5002}"
+      # getEngineUrl() reads this first and falls back to http://localhost:5001 when unset.
+      # The public URL is network-topology-independent (verified reachable from app containers).
+      - "WWV_DATA_ENGINE_URL=${WWV_DATA_ENGINE_URL:-https://dataenginev2.worldwideview.dev}"
       # Redis session/cache/rate-limit store.
       # Operators using a managed Redis (e.g. Upstash) should set REDIS_URL to their
       # rediss:// endpoint in .env and remove the wwv-redis service and depends_on below.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.18",
+  "version": "2.65.19",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.19",
+  "version": "2.65.20",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/lib/data-query/service.test.ts
+++ b/src/lib/data-query/service.test.ts
@@ -101,7 +101,7 @@ describe("getEngineUrl", () => {
     it("returns WWV_DATA_ENGINE_URL when set (overrides localhost default)", () => {
         process.env.WWV_DATA_ENGINE_URL = "https://dataenginev2.worldwideview.dev";
         delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
-        expect(getEngineUrl()).toBe("https://dataenginev2.worldwideview.dev");
+        expect(getEngineUrl()).toBe("https://dataenginev2.worldwideview.dev"); // lint-url: allow (test assertion)
     });
 
     it("uses NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT when WWV_DATA_ENGINE_URL is unset", () => {

--- a/src/lib/data-query/service.test.ts
+++ b/src/lib/data-query/service.test.ts
@@ -1,5 +1,5 @@
 import {
-    describe, it, expect, vi, beforeEach,
+    describe, it, expect, vi, beforeEach, afterEach,
 } from "vitest";
 import type { GeoEntity } from "@worldwideview/wwv-plugin-sdk";
 import type { PluginDataSnapshot } from "@/lib/data-query/types";
@@ -10,6 +10,7 @@ import {
     getPluginData,
     fetchPluginSnapshot,
     getAllPluginSnapshots,
+    getEngineUrl,
 } from "@/lib/data-query/service";
 
 // ---------------------------------------------------------------------------
@@ -69,6 +70,46 @@ function mockEngine404(): void {
         new Response(null, { status: 404 }),
     );
 }
+
+// ---------------------------------------------------------------------------
+// getEngineUrl — engine base-URL resolution (env-var contract)
+// ---------------------------------------------------------------------------
+
+describe("getEngineUrl", () => {
+    const ORIGINAL_ENGINE_URL = process.env.WWV_DATA_ENGINE_URL;
+    const ORIGINAL_ENGINE_PORT = process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+
+    afterEach(() => {
+        if (ORIGINAL_ENGINE_URL === undefined) {
+            delete process.env.WWV_DATA_ENGINE_URL;
+        } else {
+            process.env.WWV_DATA_ENGINE_URL = ORIGINAL_ENGINE_URL;
+        }
+        if (ORIGINAL_ENGINE_PORT === undefined) {
+            delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+        } else {
+            process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT = ORIGINAL_ENGINE_PORT;
+        }
+    });
+
+    it("returns localhost:5001 by default (no env vars set)", () => {
+        delete process.env.WWV_DATA_ENGINE_URL;
+        delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+        expect(getEngineUrl()).toBe("http://localhost:5001");
+    });
+
+    it("returns WWV_DATA_ENGINE_URL when set (overrides localhost default)", () => {
+        process.env.WWV_DATA_ENGINE_URL = "https://dataenginev2.worldwideview.dev";
+        delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+        expect(getEngineUrl()).toBe("https://dataenginev2.worldwideview.dev");
+    });
+
+    it("uses NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT when WWV_DATA_ENGINE_URL is unset", () => {
+        delete process.env.WWV_DATA_ENGINE_URL;
+        process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT = "5555";
+        expect(getEngineUrl()).toBe("http://localhost:5555");
+    });
+});
 
 // ---------------------------------------------------------------------------
 // QUERY-01 — searchEntities

--- a/src/lib/data-query/service.ts
+++ b/src/lib/data-query/service.ts
@@ -12,8 +12,7 @@ import type { FilterValue } from "@/core/plugins/PluginTypes";
 import { hasLocalSource, resolveLocalSnapshot, getLocalSourceIds } from "./localSources";
 
 export function getEngineUrl(): string {
-    const port = process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT || '5001';
-    return `http://localhost:${port}`;
+    return process.env.WWV_DATA_ENGINE_URL ?? `http://localhost:${process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT || '5001'}`;
 }
 
 function normalizeEntity(raw: unknown): GeoEntity | null {


### PR DESCRIPTION
## Summary

`getEngineUrl()` in `src/lib/data-query/service.ts` now reads the runtime env var `WWV_DATA_ENGINE_URL` first, falling back to `http://localhost:5001` only when unset. This restores correct engine probing on demo and production deployments, where `/api/health` was incorrectly reporting `engine: false` (regression from 2246a573).

## Changes

- `src/lib/data-query/service.ts` — `getEngineUrl()` prefers `process.env.WWV_DATA_ENGINE_URL`, falls back to localhost with `NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT` default 5001. Non-NEXT_PUBLIC runtime read means no rebuild needed for Coolify env changes.
- `src/lib/data-query/service.test.ts` — 3 new unit tests (default, env-var override, NEXT_PUBLIC port override) with env isolation.
- `deploy/INFRA-CHECKLIST.md`, `deploy/production/docker-compose.app.yml`, `deploy/cloud/docker-compose.yml` — corrected stale 5002-port references and documented the real health-check shape (`checks.engine` boolean, `status: "degraded"`).

## Verification

Independent review confirmed SHIP-READY: `pnpm test` 40/40, `pnpm build` passes, eslint passes on changed files. `curl https://dataenginev2.worldwideview.dev/manifest` returns HTTP 200 public, so `probeEngine()` returns true after this fix.