### PR TITLE
fix: address GC triage findings - hardcoded engine URLs (#418), orphaned rule refs (#419), outdated-dep scanner markers (#186)

### DIFF
--- a/.agents/rules/cloud-auth-architecture.md
+++ b/.agents/rules/cloud-auth-architecture.md
@@ -179,11 +179,11 @@ Three thin adapter modules provide all edition-specific behaviour -- everything 
 
 | Adapter | Local | Cloud | Demo |
 |---|---|---|---|
-| `src/lib/auth.ts` | Auth.js `Credentials` (bcrypt + PostgreSQL) | Auth.js `@auth/supabase-adapter` | Disabled |
+| `src/lib/better-auth.ts` | Auth.js `Credentials` (bcrypt + PostgreSQL) | Auth.js `@auth/supabase-adapter` | Disabled |
 | Storage adapter (planned) | `fs.writeFile()` to `data/` | Supabase Storage SDK | Read-only |
 | Tenant adapter (planned) | No-op (single tenant) | Sets `app.tenant_id` for RLS | No-op |
 
-> The storage and tenant adapters listed above are planned for the Cloud edition build-out and are not yet implemented as separate files. Auth is fully implemented in `src/lib/auth.ts` and `src/lib/auth.config.ts`.
+> The storage and tenant adapters listed above are planned for the Cloud edition build-out and are not yet implemented as separate files. Auth is implemented in `src/lib/better-auth.ts` (server) and `src/lib/auth-client.ts` (client), with supporting modules under `src/lib/auth/`.
 
 ---
 

--- a/.agents/rules/data-engine-architecture.md
+++ b/.agents/rules/data-engine-architecture.md
@@ -30,7 +30,7 @@ In production, the `wwv-data-engine-v2` does NOT mount the local file system. In
 4. It then runs a single **workspace-aware `pnpm install --prod`**. This ensures all custom unbundled dependencies declared by the extracted plugins are downloaded directly into the container and properly linked together.
 ## 5. Namespace Separation Rule
 
-To prevent collisions and `404` or `ERR_MODULE_NOT_FOUND` errors, seeders **MUST NOT** exist simultaneously in both the community (`wwv-seeders`, cloned to a `local-seeders/community/` directory when developing locally) and private (`wwv-seeders-private`, cloned to `local-seeders/private/`) repositories. Namespace overlaps will cause module resolution failures when the V2 engine attempts to load them. Private seeders have priority.
+To prevent collisions and `404` or `ERR_MODULE_NOT_FOUND` errors, seeders **MUST NOT** exist simultaneously in both the community (`wwv-seeders`, cloned to a `local-seeders/community/` directory when developing locally; these are nested git clones created by worktree hooks, not tracked in the main repo) and private (`wwv-seeders-private`, cloned to `local-seeders/private/` the same way) repositories. Namespace overlaps will cause module resolution failures when the V2 engine attempts to load them. Private seeders have priority.
 
 ## 6. Plugin ID Contract — Single Source of Truth
 

--- a/.agents/rules/deployment-and-testing.md
+++ b/.agents/rules/deployment-and-testing.md
@@ -23,7 +23,7 @@ pnpm db:reset         # Reset and re-migrate the frontend database (destructive)
 pnpm start:backends   # Legacy command for standalone Fastify backends
 pnpm clean:backends   # Wipe all plugin database records
 pnpm run scaffold-osm-plugin <name>  # Generate a new plugin from scaffold
-pnpm dev:plugins      # File watcher for local-plugins/ directory (runs automatically in dev)
+pnpm dev:plugins      # File watcher for local-plugins/ (nested clone created by worktree hooks, not tracked in git; runs automatically in dev)
 node packages/wwv-cli/dist/index.js create <name> --local # Scaffold a new local plugin
 node packages/wwv-cli/dist/index.js link <name>           # Promote a local plugin to packages/
 ```

--- a/.agents/rules/monorepo-workflow.md
+++ b/.agents/rules/monorepo-workflow.md
@@ -14,8 +14,8 @@ Strict rules for operating within the `pnpm` monorepo workspace environment stru
 ## Directory Isolation
 
 - The Next.js frontend is located at root `.`.
-- Individual standalone plugins are located at `local-plugins/wwv-plugin-[name]` (a git clone of the `wwv-plugins` community repo).
-- For heavy plugin processing, data engine seeders are located in the separate `wwv-seeders` and `wwv-seeders-private` repositories. When developing locally, clone them into `local-seeders/community/` and `local-seeders/private/` respectively — `pnpm install` from the main repo does NOT pull seeder code. Run `git pull` inside each clone to get upstream changes.
+- Individual standalone plugins are located at `local-plugins/wwv-plugin-[name]` (a nested git clone of the `wwv-plugins` community repo created by worktree hooks; not tracked in the main repo).
+- For heavy plugin processing, data engine seeders are located in the separate `wwv-seeders` and `wwv-seeders-private` repositories. When developing locally, clone them into `local-seeders/community/` and `local-seeders/private/` respectively (nested git clones created by worktree hooks; not tracked in the main repo) — `pnpm install` from the main repo does NOT pull seeder code. Run `git pull` inside each clone to get upstream changes.
 
 ## Critical Workspace Rule
 

--- a/.agents/rules/plugin-architecture.md
+++ b/.agents/rules/plugin-architecture.md
@@ -462,7 +462,7 @@ To solve this friction and make third-party plugin hosting highly intuitive, the
 2. **Backend SDK:** They write simple `.ts` fetch scripts returning `GeoEntity[]` and drop them into a mounted `/seeders` volume.
 3. **Zero Configuration:** The Docker engine hot-reloads these seeders, handles the Redis caching, and exposes standardized REST or WebSocket endpoints automatically. The developer focuses only on fetching data, avoiding all backend infrastructure setup.
 
-The `data-engine-seeder-creation.md` skill was removed. Seeder implementation rules are documented inline in `.agents/rules/data-engine-architecture.md`. Seeders live in the separate `wwv-seeders` and `wwv-seeders-private` repositories (cloned to `local-seeders/community/` or `local-seeders/private/` when developing locally).
+The `data-engine-seeder-creation.md` skill was removed. Seeder implementation rules are documented inline in `.agents/rules/data-engine-architecture.md`. Seeders live in the separate `wwv-seeders` and `wwv-seeders-private` repositories (cloned to `local-seeders/community/` or `local-seeders/private/` — nested git clones created by worktree hooks, not tracked in the main repo — when developing locally).
 
 ---
 

--- a/packages/wwv-ci-probe/src/index.ts
+++ b/packages/wwv-ci-probe/src/index.ts
@@ -30,7 +30,7 @@ program
   .command("ws")
   .description("Connect to engine /stream and wait for a data payload for the given pluginId")
   .argument("<name>", "Canonical plugin id (kebab-case)")
-  .option("--url <url>", "WebSocket URL", "ws://localhost:5000/stream")
+  .option("--url <url>", "WebSocket URL (defaults to WWV_ENGINE_URL, then local engine)", process.env.WWV_ENGINE_URL ?? "ws://localhost:5000/stream")
   .option("--timeout <ms>", "Timeout in milliseconds", "30000")
   .action(async (name: string, opts: { url: string; timeout: string }) => {
     const ok = await probeWs({

--- a/packages/wwv-lib-incidents/src/index.test.ts
+++ b/packages/wwv-lib-incidents/src/index.test.ts
@@ -57,6 +57,8 @@ class MinimalIncidentPlugin extends BaseIncidentPlugin {
     getServerConfig(): ServerPluginConfig {
         return {
             apiBasePath: "/api/test-incident-plugin",
+            // Test fixture: the plugin DECLARES its own streamUrl (agnostic-frontend
+            // invariant). The literal is arbitrary — this suite never asserts on it.
             streamUrl: "ws://localhost:5001/stream",
             pollingIntervalMs: 0,
         };

--- a/scripts/gc-scan.mjs
+++ b/scripts/gc-scan.mjs
@@ -344,10 +344,17 @@ function detectOutdatedDeps() {
     } else {
       const cols = line.trim().split(/\s+/);
       if (cols.length < 3) continue;
+      // Guard against prose lines (e.g. "No dependencies need to be updated.") that
+      // pass the line filter: a real row has a version in the current or latest column.
+      if (!/^\d/.test(cols[1]) && !/^\d/.test(cols[2])) continue;
       [pkg, current, latest] = cols;
     }
     if (!pkg || !current || !latest || current === latest) continue;
-    const isMajor = current.replace(/^[^0-9]*/, '').split('.')[0] !== latest.replace(/^[^0-9]*/, '').split('.')[0];
+    // pnpm renders non-version status text in the Latest column (e.g. "Deprecated").
+    // Treat such markers as not-a-version: no major/minor comparison is possible.
+    const latestIsMarker = !/\d/.test(latest);
+    const isMajor = !latestIsMarker &&
+      current.replace(/^[^0-9]*/, '').split('.')[0] !== latest.replace(/^[^0-9]*/, '').split('.')[0];
     add({
       type: 'outdated-dep',
       tier: 'B',
@@ -355,7 +362,9 @@ function detectOutdatedDeps() {
       current,
       latest,
       isMajor,
-      description: `${pkg}: ${current} → ${latest}${isMajor ? ' ⚠ MAJOR bump — review breaking changes before upgrading' : ''}`,
+      description: latestIsMarker
+        ? `${pkg}: ${current} → ${latest}${latest === 'Deprecated' ? ' — package deprecated, find a replacement' : ' — Latest is a status marker, not a version'}`
+        : `${pkg}: ${current} → ${latest}${isMajor ? ' ⚠ MAJOR bump — review breaking changes before upgrading' : ''}`,
     });
   }
 }

--- a/src/core/data/DataUtils.test.ts
+++ b/src/core/data/DataUtils.test.ts
@@ -97,6 +97,8 @@ describe("resolveEngineUrl", () => {
     await fetchLocalEngineManifest();
 
     const url = resolveEngineUrl("plugin-local");
+    // 5000 is the local-engine default from NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT
+    // (getLocalWsUrl in resolveEngineUrl.ts) — this pins the default local routing.
     expect(url).toContain("localhost:5000/stream");
   });
 

--- a/src/core/data/engineManifest.ts
+++ b/src/core/data/engineManifest.ts
@@ -8,8 +8,9 @@ let manifestFetched = false;
 /**
  * Resolve the base URL of the local data engine.
  *
- * Always checks localhost:5000 — the port docker-compose.yml binds for
- * wwv-data-engine. NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL is intentionally
+ * Always checks the local engine at localhost on NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT
+ * (default 5000 — the port docker-compose.yml binds for wwv-data-engine).
+ * NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL is intentionally
  * NOT used here: that variable belongs to each plugin's own declared engine
  * URL (production, third-party, etc.) and must not poison local detection.
  * Mixing the two caused the production engine to be reported as "local".

--- a/src/core/data/resolveEngineUrl.ts
+++ b/src/core/data/resolveEngineUrl.ts
@@ -28,8 +28,9 @@ function getLocalWsUrl() {
  * Resolves the WebSocket engine URL for a given plugin.
  *
  * Resolution order:
- * 1. Local engine (if running at localhost:5000 and has this plugin's seeder,
- *    AND the plugin is not in NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST)
+ * 1. Local engine (if running on NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT — default
+ *    localhost:5000 — and has this plugin's seeder, AND the plugin is not in
+ *    NEXT_PUBLIC_WWV_LOCAL_ENGINE_BLOCKLIST)
  * 2. Plugin's ServerPluginConfig.streamUrl (code-based plugins)
  * 3. Plugin's PluginManifest.dataSource.streamUrl (manifest-based plugins)
  * 4. NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL env var

--- a/src/core/plugins/hostGlobals.ts
+++ b/src/core/plugins/hostGlobals.ts
@@ -70,8 +70,9 @@ export async function injectHostGlobals(): Promise<void> {
     };
 
     // REST Engine URL (Fallback)
-    // Note: Local Docker-based engine interception (localhost:5000) happens dynamically inside
-    // resolveEngineUrl.ts during plugin routing. These variables act as global fallbacks.
+    // Note: Local Docker-based engine interception (NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT, default
+    // localhost:5000) happens dynamically inside resolveEngineUrl.ts during plugin routing.
+    // These variables act as global fallbacks.
     const envDataEngine = process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
     if (envDataEngine) {
         (globalThis as Record<string, unknown>).__WWV_ENGINE_URL__ = envDataEngine;

--- a/src/core/plugins/loaders/DeclarativePlugin.test.ts
+++ b/src/core/plugins/loaders/DeclarativePlugin.test.ts
@@ -123,6 +123,8 @@ describe("DeclarativePlugin", () => {
             getCurrentTime: () => new Date(),
             env: {},
             edition: "local",
+            // Host-injected value (PluginContext.getEngineUrl) — arbitrary for this test;
+            // the plugin never consumes it. The address comes from the host, not the plugin.
             getEngineUrl: () => "http://localhost:5001",
         });
 


### PR DESCRIPTION
Ships the verified GC-triage fixes from the gc-triage-fixes worktree.

- **#418 hardcoded engine URLs**: `packages/wwv-ci-probe` `--url` default now reads `WWV_ENGINE_URL` (env-configurable); comment-only doc-drift fixes in `engineManifest.ts`, `resolveEngineUrl.ts`, `hostGlobals.ts`; 3 test fixtures keep literals with justification comments.
- **#419 orphaned rule refs**: 5 `.agents/rules/*.md` files updated — auth refs now point at the current `src/lib/better-auth.ts` / `src/lib/auth-client.ts` / `src/lib/auth/` layout; nested-clone convention clarified for local-seeders/local-plugins.
- **#186 scanner bug (partial)**: `scripts/gc-scan.mjs` `detectOutdatedDeps()` fixed — `latest: "Deprecated"` no longer misreported as a MAJOR bump; prose-row garbage skipped in the plain-format fallback. Addresses the outdated-dep scanner portion of #186; remaining parts stay parked.

Fixes #418, #419

Verification: vitest 4 files/33 tests pass, `pnpm --filter @worldwideview/wwv-ci-probe build` tsc clean, `node scripts/gc-scan.mjs` exit 0 with 11 well-formed findings.