### PR TITLE
fix: include instanceCount in service tier response

### DIFF
--- a/src/app/api/service/tier/route.test.ts
+++ b/src/app/api/service/tier/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        orgTier: {
+            findUnique: vi.fn(),
+        },
+        pluginMember: {
+            findMany: vi.fn(),
+            findFirst: vi.fn(),
+        },
+        betterAuthUser: {
+            findUnique: vi.fn(),
+        },
+        workspace: {
+            count: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/cross-service/verify", () => ({
+    verifyCrossServiceSignature: vi.fn().mockReturnValue({ valid: true }),
+}));
+
+function mockServiceRequest(url: string): NextRequest {
+    return new NextRequest(url, {
+        headers: {
+            "X-Service-Signature": "t=1234567890,n=test-nonce,sig=valid",
+            "X-Service-Timestamp": "1234567890",
+            "X-Service-Nonce": "test-nonce",
+        },
+    });
+}
+
+function mockOrgTier(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "tier-1",
+        organizationId: "org-1",
+        tier: "pro",
+        status: "active",
+        trialEndsAt: null,
+        updatedAt: new Date(),
+        createdAt: new Date(),
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("GET /api/service/tier", () => {
+    it("returns 401 without cross-service auth", async () => {
+        const req = new NextRequest("http://localhost/api/service/tier?organizationId=org-1");
+        const res = await GET(req);
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when email has no org membership", async () => {
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue(null);
+
+        const req = mockServiceRequest("http://localhost/api/service/tier?email=a@b.com");
+        const res = await GET(req);
+        expect(res.status).toBe(404);
+    });
+
+    it("returns instanceCount 0 when org has no owner memberships", async () => {
+        vi.mocked(prisma.orgTier.findUnique).mockResolvedValue(mockOrgTier() as never);
+        vi.mocked(prisma.pluginMember.findMany).mockResolvedValue([] as never);
+
+        const req = mockServiceRequest("http://localhost/api/service/tier?organizationId=org-1");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.instanceCount).toBe(0);
+        expect(prisma.pluginMember.findMany).toHaveBeenCalledWith({
+            where: { organizationId: "org-1", role: "owner" },
+            select: { userId: true },
+        });
+        expect(prisma.workspace.count).not.toHaveBeenCalled();
+    });
+
+    it("returns correct instanceCount for multi-owner org workspaces", async () => {
+        vi.mocked(prisma.orgTier.findUnique).mockResolvedValue(mockOrgTier() as never);
+        vi.mocked(prisma.pluginMember.findMany).mockResolvedValue([
+            { userId: "u1" },
+            { userId: "u2" },
+        ] as never);
+        vi.mocked(prisma.workspace.count).mockResolvedValue(3);
+
+        const req = mockServiceRequest("http://localhost/api/service/tier?organizationId=org-1");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.instanceCount).toBe(3);
+        expect(prisma.workspace.count).toHaveBeenCalledWith({
+            where: { ownerId: { in: ["u1", "u2"] } },
+        });
+    });
+
+    it("resolves org by email and returns instanceCount", async () => {
+        vi.mocked(prisma.betterAuthUser.findUnique).mockResolvedValue({ id: "u1" } as never);
+        vi.mocked(prisma.pluginMember.findFirst).mockResolvedValue({
+            organizationId: "org-email",
+        } as never);
+        vi.mocked(prisma.orgTier.findUnique).mockResolvedValue(
+            mockOrgTier({ organizationId: "org-email" }) as never,
+        );
+        vi.mocked(prisma.pluginMember.findMany).mockResolvedValue([{ userId: "u1" }] as never);
+        vi.mocked(prisma.workspace.count).mockResolvedValue(2);
+
+        const req = mockServiceRequest("http://localhost/api/service/tier?email=a@b.com");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data.instanceCount).toBe(2);
+        expect(prisma.pluginMember.findFirst).toHaveBeenCalled();
+        expect(prisma.workspace.count).toHaveBeenCalledWith({
+            where: { ownerId: { in: ["u1"] } },
+        });
+    });
+
+    it("keeps tier response shape and computes effective tier on expired trial", async () => {
+        const past = new Date(Date.now() - 86_400_000);
+        vi.mocked(prisma.orgTier.findUnique).mockResolvedValue(
+            mockOrgTier({ status: "trialing", trialEndsAt: past }) as never,
+        );
+        vi.mocked(prisma.pluginMember.findMany).mockResolvedValue([] as never);
+
+        const req = mockServiceRequest("http://localhost/api/service/tier?organizationId=org-1");
+        const res = await GET(req);
+        const data = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(data).toMatchObject({
+            tier: "pro",
+            status: "trialing",
+            effectiveTier: "free",
+            effectiveStatus: "expired",
+            instanceCount: 0,
+        });
+        expect(typeof data.trialEndsAt).toBe("string");
+    });
+});

--- a/src/app/api/service/tier/route.ts
+++ b/src/app/api/service/tier/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { crossServiceAuth } from "@/lib/cross-service/middleware";
 import { getActiveOrgId } from "@/lib/ba-org";
 import { getOrgTier, resolveOrgIdByEmail } from "@/lib/org-tier";
+import { prisma } from "@/lib/db";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const authError = await crossServiceAuth(request);
@@ -35,6 +36,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Unable to determine organization" }, { status: 400 });
   }
 
+  const ownerMembers = await prisma.pluginMember.findMany({
+    where: { organizationId: orgId, role: "owner" },
+    select: { userId: true },
+  });
+
+  const instanceCount =
+    ownerMembers.length > 0
+      ? await prisma.workspace.count({
+          where: { ownerId: { in: ownerMembers.map((m) => m.userId) } },
+        })
+      : 0;
+
   const tierData = await getOrgTier(orgId);
   const isExpiredTrial = tierData.status === "trialing" && tierData.trialEndsAt && tierData.trialEndsAt < new Date();
   const effectiveTier = isExpiredTrial ? "free" : tierData.tier;
@@ -44,5 +57,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     ...tierData,
     effectiveTier,
     effectiveStatus,
+    instanceCount,
   });
 }


### PR DESCRIPTION
## Summary

The globe tier GET endpoint (`/api/service/tier`) now returns `instanceCount` — the count of workspaces owned by the org's owner members — so the hub billing page shows the real instance count instead of a hardcoded "0 of Unlimited" and the zero-instance CTA disappears correctly.

- Adds owner-membership lookup + workspace count to the tier route
- Mirrors the owner-join pattern from `setOrgTier` in `src/lib/org-tier.ts`
- Adds 150-line route test suite (6 tests: auth, no-org, zero count, multi-owner count, email resolution, tier shape)

## Verification

- 1218 unit tests green
- tsc clean
- production build passes
- Rebased onto origin/main (2.65.20), package.json version kept at main's (no regression)

CI will run globe checks.