### PR TITLE
fix: make PR Preview on-demand via /preview comment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,14 +14,40 @@ permissions:
   pull-requests: write
 
 jobs:
+  resolve-ref:
+    if: |
+      contains(github.event.comment.body, '/preview') &&
+      github.event.issue.pull_request != null &&
+      contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+    steps:
+      - name: Resolve PR head commit SHA
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('head_sha', pr.head.sha);
+
   build-preview:
+    needs: resolve-ref
     if: |
       contains(github.event.comment.body, '/preview') &&
       github.event.issue.pull_request != null &&
       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association)
     uses: ./.github/workflows/shared-docker.yml
     with:
-      ref: refs/pull/${{ github.event.issue.number }}/merge
+      ref: ${{ needs.resolve-ref.outputs.head_sha }}
       platforms: linux/amd64
       tags: |
         type=raw,value=pr-${{ github.event.issue.number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,35 +1,30 @@
 name: PR Preview
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
-    paths:
-      - "src/**"
-      - "Dockerfile"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "next.config.ts"
-      - "docker-compose.yml"
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   packages: write
   pull-requests: write
-  id-token: write
-  attestations: write
 
 jobs:
   build-preview:
+    if: |
+      contains(github.event.comment.body, '/preview') &&
+      github.event.issue.pull_request != null &&
+      contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association)
     uses: ./.github/workflows/shared-docker.yml
     with:
+      ref: refs/pull/${{ github.event.issue.number }}/merge
+      platforms: linux/amd64
       tags: |
-        type=ref,event=pr
-        type=sha,prefix=sha-
+        type=raw,value=pr-${{ github.event.issue.number }}
       build-args: |
         NEXT_PUBLIC_WWV_EDITION=demo
         NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS=iranwarlive,satellite,gps-jamming
@@ -44,29 +39,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Resolve PR head commit
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('head_sha', pr.head.sha.slice(0, 7));
+
       - name: Find or create preview comment
         uses: peter-evans/find-comment@v4
         id: find
         with:
-          issue-number: ${{ github.event.number }}
+          issue-number: ${{ github.event.issue.number }}
           body-includes: "## PR Preview"
 
       - name: Post preview comment
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
+          issue-number: ${{ github.event.issue.number }}
           body: |
             ## PR Preview
 
             | Image | Pull Command |
             |-------|-------------|
-            | `ghcr.io/silvertakana/worldwideview:pr-${{ github.event.number }}` | `docker pull ghcr.io/silvertakana/worldwideview:pr-${{ github.event.number }}` |
+            | `ghcr.io/silvertakana/worldwideview:pr-${{ github.event.issue.number }}` | `docker pull ghcr.io/silvertakana/worldwideview:pr-${{ github.event.issue.number }}` |
 
             ### Run locally
             ```bash
-            docker run -p 3000:3000 ghcr.io/silvertakana/worldwideview:pr-${{ github.event.number }}
+            docker run -p 3000:3000 ghcr.io/silvertakana/worldwideview:pr-${{ github.event.issue.number }}
             ```
 
-            Edition: **demo** | Commit: `${{ github.sha }}`
+            Edition: **demo** | Commit: `${{ steps.pr.outputs.head_sha }}`
           edit-mode: replace

--- a/.github/workflows/shared-docker.yml
+++ b/.github/workflows/shared-docker.yml
@@ -25,6 +25,10 @@ on:
         type: string
         default: 'linux/amd64'
         description: 'Comma-separated build platforms. Default amd64-only; only the public globe app should pass linux/amd64,linux/arm64.'
+      ref:
+        type: string
+        default: ''
+        description: 'Git ref to check out (e.g. refs/pull/123/merge). Defaults to the triggering ref.'
 
 jobs:
   build:
@@ -37,6 +41,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/shared-docker.yml
+++ b/.github/workflows/shared-docker.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Untrusted-content trigger (issue_comment -> PR merge ref): never
+          # persist the GITHUB_TOKEN into the checkout, so checked-out code
+          # cannot exfiltrate it (CodeQL privileged-workflow hardening).
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.30",
+  "version": "2.65.31",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "worldwideview",
 <<<<<<< HEAD
+<<<<<<< HEAD
   "version": "2.65.29",
 =======
   "version": "2.65.29",
 >>>>>>> 5f4cf60c (fix: make PR Preview on-demand via /preview comment)
+=======
+  "version": "2.65.30",
+>>>>>>> 098259b9 (fix: least-privilege checkout for preview workflow (CodeQL))
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "worldwideview",
 <<<<<<< HEAD
 <<<<<<< HEAD
-  "version": "2.65.29",
+  "version": "2.65.30",
 =======
-  "version": "2.65.29",
+  "version": "2.65.30",
 >>>>>>> 5f4cf60c (fix: make PR Preview on-demand via /preview comment)
 =======
   "version": "2.65.30",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "worldwideview",
+<<<<<<< HEAD
   "version": "2.65.29",
+=======
+  "version": "2.65.29",
+>>>>>>> 5f4cf60c (fix: make PR Preview on-demand via /preview comment)
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,6 @@
 {
   "name": "worldwideview",
-<<<<<<< HEAD
-<<<<<<< HEAD
   "version": "2.65.30",
-=======
-  "version": "2.65.30",
->>>>>>> 5f4cf60c (fix: make PR Preview on-demand via /preview comment)
-=======
-  "version": "2.65.30",
->>>>>>> 098259b9 (fix: least-privilege checkout for preview workflow (CodeQL))
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
## What changed

**PR Preview is now on-demand.** Comment `/preview` on a pull request (from mobile or desktop) and the workflow builds the image; it no longer runs automatically on every PR push.

### `.github/workflows/pr-preview.yml`
- Trigger: `issue_comment: types: [created]` (was `pull_request: [opened, synchronize, reopened]` + paths filter — the explicit `/preview` command is now the filter)
- Job guard (mirrors the Gremlin `opencode-fix-v2.yml` security pattern):
  - comment body contains `/preview`
  - the comment is on a pull request (`issue.pull_request != null`)
  - author association is `OWNER`, `MEMBER`, or `COLLABORATOR`
- Concurrency keyed on the PR number (`cancel-in-progress: true`) — a re-`/preview` cancels a stale build for the same PR
- Builds the PR head via `refs/pull/<N>/merge` (passed through the new `ref` input on shared-docker.yml)
- Tag is `type=raw,value=pr-<N>` so `docker run -p 3000:3000 ghcr.io/silvertakana/worldwideview:pr-<N>` works unchanged
- Preview builds **single-arch (linux/amd64)** — roughly half the build time of the old multi-arch build
- `post-comment` resolves the PR head commit via the API instead of `github.sha` (which on `issue_comment` is main's head, not the PR's)

### `.github/workflows/shared-docker.yml`
- Added optional `ref` input (default empty → callers that omit it keep the triggering ref behavior). Only used by the preview caller.
- `platforms` input (default `linux/amd64`) already exists from PR #412 and is unchanged.

## Why

The old workflow ran on every PR push and took ~10 minutes (multi-arch build) even though the images are only ever pulled by the owner on their own machine. Now it only builds when the owner explicitly asks.

## Production multi-arch is preserved

The production publish path (`docker-publish.yml`) does **not** call `shared-docker.yml` — it is standalone with its own amd64 and arm64 jobs. It is untouched by this change.

## How to test

1. Comment `/preview` on this PR
2. The PR Preview workflow builds `ghcr.io/silvertakana/worldwideview:pr-<N>` (single-arch amd64)
3. The reply comment shows the exact command:
   ```bash
   docker run -p 3000:3000 ghcr.io/silvertakana/worldwideview:pr-<N>
   ```