### PR TITLE
fix: switch remaining AI workflows to OpenCode Go; guard Gremlin against bot-comment cancellation

### DIFF
--- a/.github/workflows/garbage-collector.yml
+++ b/.github/workflows/garbage-collector.yml
@@ -82,13 +82,13 @@ jobs:
       - name: Run Garbage Collector agent
         uses: anomalyco/opencode/github@v1.18.11
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Headless CI: pre-approve external_directory so the agent never hangs on an
           # unanswerable permission prompt (anomalyco/opencode#14473). CI-only, no repo config change.
           OPENCODE_PERMISSION: '{"external_directory": "allow"}'
         with:
-          model: deepseek/deepseek-v4-flash
+          model: opencode-go/deepseek-v4-flash
           use_github_token: true
           share: false
           prompt: |

--- a/.github/workflows/issue-classifier.yml
+++ b/.github/workflows/issue-classifier.yml
@@ -1,4 +1,4 @@
-# Auto-classifies new/edited issues by calling DeepSeek API to determine
+# Auto-classifies new/edited issues by calling the OpenCode Go API to determine
 # target repo and type, then applies labels and posts a routing comment.
 name: Issue Classifier
 
@@ -50,19 +50,19 @@ jobs:
             }
             return 'proceed';
 
-      - name: Classify via DeepSeek API
+      - name: Classify via OpenCode Go API
         id: classify
         if: steps.has-repo-label.outputs.result != 'skip'
         continue-on-error: true
         uses: actions/github-script@v7
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
           script: |
-            const apiKey = process.env.DEEPSEEK_API_KEY;
+            const apiKey = process.env.OPENCODE_API_KEY;
             if (!apiKey) {
               core.setOutput('api_failed', 'true');
-              core.setOutput('api_error', 'DEEPSEEK_API_KEY not set');
+              core.setOutput('api_error', 'OPENCODE_API_KEY not set');
               return;
             }
 
@@ -87,7 +87,7 @@ jobs:
               'confidence must be high, medium, or low.';
 
             const payload = {
-              model: 'deepseek-chat',
+              model: 'deepseek-v4-flash',
               messages: [
                 { role: 'system', content: systemPrompt },
                 { role: 'user', content: 'Title: ' + title + '\nBody: ' + body }
@@ -95,7 +95,7 @@ jobs:
             };
 
             try {
-              const response = await fetch('https://api.deepseek.com/v1/chat/completions', {
+              const response = await fetch('https://opencode.ai/zen/go/v1/chat/completions', {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
@@ -163,7 +163,7 @@ jobs:
             core.setOutput('repo', repo);
             core.setOutput('type', type);
             core.setOutput('confidence', confidence);
-            core.setOutput('reasoning', 'Keyword fallback (DeepSeek API unavailable)');
+            core.setOutput('reasoning', 'Keyword fallback (OpenCode Go API unavailable)');
 
       - name: Apply labels
         if: steps.has-repo-label.outputs.result != 'skip'
@@ -208,7 +208,7 @@ jobs:
             body += '| Reasoning | ' + (reasoning || 'N/A') + ' |\n';
 
             if (isFallback) {
-              body += '\n> Classification used keyword fallback (DeepSeek API was unavailable).\n';
+              body += '\n> Classification used keyword fallback (OpenCode Go API was unavailable).\n';
             }
             if (conf === 'low') {
               body += '\n> Low-confidence classification. A maintainer should verify and adjust labels as needed.';

--- a/.github/workflows/opencode-fix-v2.yml
+++ b/.github/workflows/opencode-fix-v2.yml
@@ -12,10 +12,6 @@ on:
   issues:
     types: [labeled]
 
-concurrency:
-  group: opencode-fix-${{ github.event.issue.number || github.event.inputs.issue_number }}
-  cancel-in-progress: true
-
 env:
   GH_TOKEN: ${{ secrets.GREMLIN_PAT }}
 
@@ -24,13 +20,18 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && 
        (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/gremlin')) &&
-       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association)) ||
+       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association) &&
+       github.event.comment.user.type != 'Bot') ||
       (github.event_name == 'issues' && github.event.action == 'labeled' && 
        github.event.label.name == 'agent-fix' &&
-       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.sender.author_association)) ||
+       contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.sender.author_association) &&
+       github.event.sender.type != 'Bot') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: opencode-fix-${{ github.event.issue.number || github.event.inputs.issue_number }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/opencode-mention.yml
+++ b/.github/workflows/opencode-mention.yml
@@ -10,32 +10,31 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  group: opencode-mention-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   opencode:
     if: |
       (github.event_name == 'issue_comment' &&
         (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@Claude') || contains(github.event.comment.body, '@opencode') || contains(github.event.comment.body, '@OpenCode')) &&
         contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association) &&
-        github.event.comment.user.login != 'github-actions[bot]') ||
+        github.event.comment.user.type != 'Bot') ||
       (github.event_name == 'pull_request_review_comment' &&
         (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@Claude') || contains(github.event.comment.body, '@opencode') || contains(github.event.comment.body, '@OpenCode')) &&
         contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.comment.author_association) &&
-        github.event.comment.user.login != 'github-actions[bot]') ||
+        github.event.comment.user.type != 'Bot') ||
       (github.event_name == 'pull_request_review' &&
         (contains(github.event.review.body, '@claude') || contains(github.event.review.body, '@Claude') || contains(github.event.review.body, '@opencode') || contains(github.event.review.body, '@OpenCode')) &&
         contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.sender.author_association) &&
-        github.event.review.user.login != 'github-actions[bot]') ||
+        github.event.review.user.type != 'Bot') ||
       (github.event_name == 'issues' &&
         ((contains(github.event.issue.body, '@claude') || contains(github.event.issue.body, '@Claude') || contains(github.event.issue.body, '@opencode') || contains(github.event.issue.body, '@OpenCode')) ||
          (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@opencode') || contains(github.event.issue.title, '@OpenCode'))) &&
         contains('["OWNER","MEMBER","COLLABORATOR"]', github.event.sender.author_association) &&
-        github.event.sender.login != 'github-actions[bot]')
+        github.event.sender.type != 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: opencode-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       actions: read
       contents: read
@@ -86,13 +85,13 @@ jobs:
       - name: Run OpenCode
         uses: anomalyco/opencode/github@v1.18.11
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Headless CI: pre-approve external_directory so the agent never hangs on an
           # unanswerable permission prompt (anomalyco/opencode#14473). CI-only, no repo config change.
           OPENCODE_PERMISSION: '{"external_directory": "allow"}'
         with:
-          model: deepseek/deepseek-v4-flash
+          model: opencode-go/deepseek-v4-flash
           use_github_token: true
           share: false
           prompt: ${{ steps.prompt.outputs.prompt }}


### PR DESCRIPTION
## What changed

Switch the remaining DeepSeek-direct AI workflows to the verified-working OpenCode Go endpoint, and fix a concurrency race that let bot comments cancel running Gremlin reviews.

### Per workflow

| File | Pattern | Change |
|---|---|---|
| `opencode-fix-v2.yml` (Gremlin) | action `anomalyco/opencode/github@v1.18.11` | Already on `opencode-go/deepseek-v4-flash` + `OPENCODE_API_KEY`. Added bot-comment guard + moved concurrency to job level (see below). |
| `opencode-mention.yml` | action | `model: deepseek/deepseek-v4-flash` → `opencode-go/deepseek-v4-flash`; env `DEEPSEEK_API_KEY` → `OPENCODE_API_KEY`. Bot guard upgraded from login-only (`github-actions[bot]`) to `user.type != 'Bot'` (covers codecov[bot], dependabot[bot], etc.). Concurrency moved to job level. |
| `garbage-collector.yml` | action | Same model/env swap. No trigger change (schedule + workflow_dispatch only, no comment exposure). |
| `issue-classifier.yml` | **raw fetch** | `api.deepseek.com/v1/chat/completions` + `model: 'deepseek-chat'` + `DEEPSEEK_API_KEY` → `opencode.ai/zen/go/v1/chat/completions` + `model: 'deepseek-v4-flash'` + Bearer `OPENCODE_API_KEY`. Fallback strings updated. |

### The bot-comment cancellation bug (opencode-fix-v2.yml + opencode-mention.yml)

Both had workflow-level `concurrency` with `cancel-in-progress: true`. Workflow-level concurrency cancels by **run creation** — before the job's `if:` is even evaluated. So a bot-authored comment (e.g. codecov) arriving mid-review created a run in the same group (same issue number), and that run cancelled the in-progress Gremlin run even though its job would have been skipped. Verified in production: run 31884613669 posted the review, then a codecov comment cancelled the run 8s later.

Fix, two parts:
1. **Guard**: `github.event.comment.user.type != 'Bot'` added to the comment trigger branches (plus `sender.type != 'Bot'` on the label-trigger branch) — bot comments can no longer **start** a run.
2. **Concurrency moved from workflow level to job level** — a run whose job is skipped (bot comment) no longer claims the concurrency group, so it can no longer **cancel** a running job. Only jobs that actually start (human OWNER/MEMBER/COLLABORATOR slash commands) participate.

## Why

- DeepSeek-direct (`api.deepseek.com` + `DEEPSEEK_API_KEY`) is a paid endpoint that frequently runs out of balance (the recurring "Insufficient Balance" 402s).
- OpenCode Go (`opencode-go` provider, base `https://opencode.ai/zen/go/v1`, secret `OPENCODE_API_KEY`) was live-verified working in PR #432 — same DeepSeek V4 Flash model, no balance problem.

## How to verify

- CI checks green on this PR (the workflow YAMLs parse; `actions/setup-node`/lint don't execute the workflows, but the PR triggers `ci.yml` + `playwright.yml` which must pass before merge).
- Grep check: no `deepseek/deepseek-v4-flash`, `DEEPSEEK_API_KEY`, `api.deepseek.com`, or `deepseek-chat` remain in any of the 4 touched workflows.
- Guard logic: no bot comment can start or cancel a Gremlin/mention run; only human OWNER/MEMBER/COLLABORATOR comments trigger.