### PR TITLE
docs: correct auth, runtime, and CLI references in AGENTS.md and README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ WorldWideView is a **real-time geospatial intelligence engine** visualizing live
 | Event Bus | Custom typed `DataBus` (pub/sub singleton) |
 | Styling | Vanilla CSS — **no Tailwind** |
 | Database | PostgreSQL via Prisma 7 |
-| Auth | NextAuth v5 beta (Credentials provider, JWT sessions) |
+| Auth | better-auth (email/password, JWT sessions, API keys via @better-auth/api-key) |
 | Package Manager | pnpm (monorepo with `pnpm-workspace.yaml`) |
 | Testing | Vitest + jsdom + React Testing Library |
 | Deployment | Docker multi-stage build → Coolify |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ flowchart TD
 ## Prerequisites
 
 Before running the application, ensure you have the following installed:
-- [Node.js](https://nodejs.org/) (v18+)
+- [Node.js](https://nodejs.org/) (v20+)
 - [pnpm](https://pnpm.io/) (v9+)
 - [Docker](https://www.docker.com/) (for self-hosting or full local dev)
 - PostgreSQL (or rely on the `coolify-db` / local compose container)
@@ -107,7 +107,7 @@ To run the source code locally for contributing or developing:
 git clone https://github.com/silvertakana/worldwideview.git
 cd worldwideview
 pnpm install
-pnpm run setup   # generates .env.local with AUTH_SECRET
+pnpm run setup   # generates .env.local with BETTER_AUTH_SECRET + ENCRYPTION_MASTER_KEY
 pnpm run dev:all # boots the UI, cache layers, and the data engine
 ```
 Visit `http://localhost:3000` to see the live globe.
@@ -134,7 +134,7 @@ worldwideview/
 
 WorldWideView operates on an open-core philosophy. The platform itself is data-agnostic; all data sources are dynamically imported as plugins at runtime.
 
-- **[Plugin Quickstart Guide](docs/plugin-quickstart.md)**: Learn how to scaffold and link your first plugin using the `@worldwideview/cli`.
+- **[Plugin Quickstart Guide](docs/plugin-quickstart.md)**: Learn how to scaffold and link your first plugin using the `@worldwideview/wwv-cli`.
 - **[Advanced Plugin Guide](docs/plugin-advanced.md)**: Deep dive into microservice data seeders, WebSockets, complex 3D rendering, and Marketplace publishing.
 
 ## Repository Ecosystem


### PR DESCRIPTION
## Summary

Corrects stale and wrong documentation in the globe repo's AGENTS.md and README.

**Changes:**
- `AGENTS.md` auth row: "NextAuth v5 beta" → better-auth (the repo uses `better-auth`, `@better-auth/prisma-adapter`, `@better-auth/api-key`; zero `next-auth` anywhere in package.json).
- `README.md` runtime: Node v18+ → v20+ (matches `engines.node: ">=20.0.0"`).
- `README.md` setup note: `AUTH_SECRET` → `BETTER_AUTH_SECRET` + `ENCRYPTION_MASTER_KEY` (what `scripts/setup.mjs` actually generates).
- `README.md` CLI name: `@worldwideview/cli` → `@worldwideview/wwv-cli` (the real package name).

Each claim verified against package.json, setup scripts, and packages/wwv-cli before editing.

## Verification
Doc-only change; no code touched.
