### PR TITLE
fix: tenant-subdomain dev origins + corepack for node 26

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@ RUN find . -type f \! -name 'package.json' \! -name 'pnpm-workspace.yaml' \! -na
 
 # Stage 2: Install dependencies (cached layer)
 FROM node:26-alpine AS deps
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+RUN npm install -g corepack && corepack enable && corepack prepare pnpm@9.15.4 --activate
 WORKDIR /app
 COPY --from=extractor /app ./
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,13 @@ const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["@prisma/client", "prisma"],
   transpilePackages: ["@worldwideview/wwv-plugin-sdk", "resium", "react-player", "satellite.js", "@worldwideview/wwv-plugin-fortiguard", "@worldwideview/wwv-plugin-nz-traffic-cameras"],
-  allowedDevOrigins: process.env.ALLOWED_DEV_ORIGIN ? [process.env.ALLOWED_DEV_ORIGIN] : undefined,
+  allowedDevOrigins: [
+    "*.wwv.local",
+    "wwv.local",
+    "app.wwv.local",
+    "localhost",
+    ...(process.env.ALLOWED_DEV_ORIGIN ? process.env.ALLOWED_DEV_ORIGIN.split(",") : []),
+  ],
   experimental: {
     memoryBasedWorkersCount: true,
     cpus: 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.31",
+  "version": "2.65.32",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
Two dev-infrastructure fixes carried over from the billing-rehearsal worktree:

## (1) next.config.ts — `allowedDevOrigins` for tenant subdomains (dev-mode hydration fix)

Replaces the single-value `ALLOWED_DEV_ORIGIN` handling with a static allowlist covering the local dev stack's tenant subdomains:

```ts
allowedDevOrigins: [
  "*.wwv.local",
  "wwv.local",
  "app.wwv.local",
  "localhost",
  ...(process.env.ALLOWED_DEV_ORIGIN ? process.env.ALLOWED_DEV_ORIGIN.split(",") : []),
]
```

Before this change, dev mode logged `Blocked cross-origin request ... /_next/webpack-hmr from asdf.wwv.local` — the setup-link page never hydrated on tenant subdomains (stuck on "Validating..."). This is a dev-only key; production is unaffected.

## (2) Dockerfile.dev — explicit corepack install on node:26-alpine (billing-e2e CI fix)

`corepack` was removed from the base node:26-alpine image, so the plain `corepack enable` line failed with `/bin/sh: corepack: not found` (exit 127). The fix installs it explicitly:

```dockerfile
RUN npm install -g corepack && corepack enable && corepack prepare pnpm@9.15.4 --activate
```

**This resolves a cross-repo CI break:** the web repo's `billing-e2e` workflow checks out the globe at main and builds its `Dockerfile.dev`. Since the node 22→26 bump (f12e9879), every web-repo billing/provisioning PR has failed billing-e2e deterministically on the missing corepack. This PR is the fix for that recurring red check.