### PR TITLE
docs: document self-hosting on any domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,12 @@ BETTER_AUTH_SECRET=
 # addresses. In local edition, the incoming request origin is trusted
 # automatically; this var covers cloud/demo or explicit overrides.
 # Example: BETTER_AUTH_TRUSTED_ORIGINS=http://wwv.local,http://10.0.0.5:3000
+# Example behind a reverse proxy: BETTER_AUTH_TRUSTED_ORIGINS=https://myglobe.com,https://globe.example.org
 BETTER_AUTH_TRUSTED_ORIGINS=
+
+# Dev-only origin allowed by next.config.ts allowedDevOrigins (dev server only).
+# Ignored in production builds. Set to the origin you browse the dev server from.
+# ALLOWED_DEV_ORIGIN=http://192.168.1.50:3000
 
 # Encryption Master Key (REQUIRED — generate with: openssl rand -hex 16)
 # Must be exactly 32 characters. Used to derive the AES-256-GCM key for credentials at rest.

--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,9 @@ BETTER_AUTH_SECRET=
 # Example behind a reverse proxy: BETTER_AUTH_TRUSTED_ORIGINS=https://myglobe.com,https://globe.example.org
 BETTER_AUTH_TRUSTED_ORIGINS=
 
-# Dev-only origin allowed by next.config.ts allowedDevOrigins (dev server only).
-# Ignored in production builds. Set to the origin you browse the dev server from.
-# ALLOWED_DEV_ORIGIN=http://192.168.1.50:3000
+# Dev-only origins allowed by next.config.ts allowedDevOrigins (dev server only).
+# Ignored in production builds. Comma-separated; set to the origin(s) you browse the dev server from.
+# ALLOWED_DEV_ORIGIN=http://192.168.1.50:3000,http://10.0.0.5:3000
 
 # Encryption Master Key (REQUIRED — generate with: openssl rand -hex 16)
 # Must be exactly 32 characters. Used to derive the AES-256-GCM key for credentials at rest.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/silvertakana/worldwidev
 
 ### Run on your own domain
 
-The self-hosted globe runs on any domain, LAN IP, or hostname you choose - localhost, a private network address, a custom domain, or behind a reverse proxy. There is no allowlist to update and nothing restricts which origin you open the instance on: the local edition automatically trusts the incoming origin, so login and CSRF cookie handling work on any address. Behind a reverse proxy, set `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated) to the public origins your users will access. For local dev servers, set `ALLOWED_DEV_ORIGIN` to the dev origin you browse from.
+The self-hosted globe runs on any domain, LAN IP, or hostname you choose - localhost, a private network address, a custom domain, or behind a reverse proxy. There is no allowlist to update and nothing restricts which origin you open the instance on: the local edition automatically trusts the incoming origin, so login and CSRF cookie handling work on any address. Behind a reverse proxy, set `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated) to the public origins your users will access. For local dev servers, set `ALLOWED_DEV_ORIGIN` (comma-separated) to the dev origin(s) you browse from.
 
 ## Quick Start (Local Development)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/silvertakana/worldwidev
 > [!NOTE]
 > Ensure you connect a PostgreSQL database via the `DATABASE_URL` environment variable for production deployments.
 
+### Run on your own domain
+
+The self-hosted globe runs on any domain, LAN IP, or hostname you choose - localhost, a private network address, a custom domain, or behind a reverse proxy. There is no allowlist to update and nothing restricts which origin you open the instance on: the local edition automatically trusts the incoming origin, so login and CSRF cookie handling work on any address. Behind a reverse proxy, set `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated) to the public origins your users will access. For local dev servers, set `ALLOWED_DEV_ORIGIN` to the dev origin you browse from.
+
 ## Quick Start (Local Development)
 
 To run the source code locally for contributing or developing:

--- a/docs/architecture/decisions/adr-0007-globe-local-auth-with-cloud-provisioning.md
+++ b/docs/architecture/decisions/adr-0007-globe-local-auth-with-cloud-provisioning.md
@@ -135,7 +135,7 @@ This guarantee covers login, cookies, and CSRF handling:
 - **No login/CSRF allowlist may be hardcoded to Sparvii-owned domains.** Every origin a self-hoster can use must be configurable, never implicit.
 - The operator-facing configuration keys are:
   - `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated) - production and reverse-proxy setups; adds extra trusted origins for CSRF/cookie writes
-  - `ALLOWED_DEV_ORIGIN` - dev servers only; ignored in production builds
+  - `ALLOWED_DEV_ORIGIN` (comma-separated) - dev servers only; ignored in production builds
 - **Hardcoded host allowlists are permitted ONLY for narrow security fences that are not login gates** - for example, marketplace token/install redirect hosts that prevent open redirects. They must never gate login or cookie acceptance.
 
 ---

--- a/docs/architecture/decisions/adr-0007-globe-local-auth-with-cloud-provisioning.md
+++ b/docs/architecture/decisions/adr-0007-globe-local-auth-with-cloud-provisioning.md
@@ -125,6 +125,19 @@ Two UX rules follow from this architecture:
 1. **Authenticated users visiting `/login` or `/signup` are redirected to the dashboard.** This is standard best practice and prevents confusion when a user with an active session lands on the login page.
 2. **The setup page (`/setup`) is a dedicated route, separate from `/login` and `/signup`.** It is keyed on the setup token in the URL query parameter. Without a valid token, the page redirects to `/login`. This prevents the setup flow from being confused with the regular login flow.
 
+### ADR-007F: Domain Configurability Guarantee
+
+> **The Globe must function on any domain the operator chooses.** Localhost, a LAN IP, a custom domain, or a reverse-proxied domain - any address must work without a platform-operated allowlist.
+
+This guarantee covers login, cookies, and CSRF handling:
+
+- The **local edition auto-trusts the incoming request origin** (see `resolveTrustedOrigins` in `src/lib/better-auth.ts`). The operator is the sole user, so trusting whatever origin they open the instance on is deliberate by design, not a gap.
+- **No login/CSRF allowlist may be hardcoded to Sparvii-owned domains.** Every origin a self-hoster can use must be configurable, never implicit.
+- The operator-facing configuration keys are:
+  - `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated) - production and reverse-proxy setups; adds extra trusted origins for CSRF/cookie writes
+  - `ALLOWED_DEV_ORIGIN` - dev servers only; ignored in production builds
+- **Hardcoded host allowlists are permitted ONLY for narrow security fences that are not login gates** - for example, marketplace token/install redirect hosts that prevent open redirects. They must never gate login or cookie acceptance.
+
 ---
 
 ## Implementation Gap


### PR DESCRIPTION
Documents the guarantee that the self-hosted globe runs on any domain - localhost, LAN IP, custom domain, or behind a reverse proxy - with no allowlist to update. The local edition auto-trusts the incoming origin, so login and CSRF cookie handling work on any address the operator opens.

Three files changed:
- **README.md** - adds a "Run on your own domain" paragraph to the Self-Hosting quick start, covering the any-domain guarantee, the `BETTER_AUTH_TRUSTED_ORIGINS` reverse-proxy escape hatch, and `ALLOWED_DEV_ORIGIN` for dev servers.
- **.env.example** - adds a concrete reverse-proxy example next to `BETTER_AUTH_TRUSTED_ORIGINS` and documents `ALLOWED_DEV_ORIGIN` (dev only, ignored in production builds).
- **ADR-0007** - appends ADR-007F (Domain Configurability Guarantee): the globe must function on any operator-chosen domain, no login/CSRF allowlist may be hardcoded to Sparvii-owned domains, and hardcoded host allowlists are permitted only for narrow non-login security fences (e.g. open-redirect prevention).

Note: #437 also touches README.md (doc-accuracy). If it merges first, a trivial rebase may be needed.
