### PR TITLE
fix: persist unverified-plugin denials; debounce focus re-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.32",
+  "version": "2.65.33",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/core/hooks/useMarketplaceSync.ts
+++ b/src/core/hooks/useMarketplaceSync.ts
@@ -9,6 +9,8 @@ import type { PluginManifest } from "@/core/plugins/PluginManifest";
 import {
   getApprovedUnverifiedIds,
   approveUnverifiedPlugin,
+  getDeniedUnverifiedIds,
+  denyUnverifiedPlugin,
 } from "@/lib/marketplace/trustedPlugins";
 import { getDisabledPluginIds } from "@/core/plugins/pluginPreferences";
 import { isDemo } from "@/core/edition";
@@ -117,16 +119,20 @@ export function useMarketplaceSync(hostReady: boolean) {
 
             const { manifests } = json as { manifests: PluginManifest[] };
             const approved = getApprovedUnverifiedIds();
+            const denied = getDeniedUnverifiedIds();
             const newPending: PluginManifest[] = [];
 
             for (const manifest of manifests) {
                 if (!manifest.id) continue;
                 if (loadedIds.current.has(manifest.id)) continue;
 
-                // Unverified + not yet approved → collect for batch review
+                // Unverified + not yet approved → collect for batch review.
+                // Permanently denied plugins are skipped so re-syncs don't re-open the dialog.
                 // On demo, skip the gate — admin already approved by installing
                 if (!isDemo && manifest.trust === "unverified" && !approved.has(manifest.id)) {
-                    newPending.push(manifest);
+                    if (!denied.has(manifest.id)) {
+                        newPending.push(manifest);
+                    }
                     continue;
                 }
 
@@ -171,8 +177,12 @@ export function useMarketplaceSync(hostReady: boolean) {
 
     /** Called when user denies all pending unverified plugins. */
     const denyAll = useCallback(() => {
+        // Persist the denials so a later sync (e.g. window focus) doesn't re-pend them.
+        for (const manifest of pendingUnverified) {
+            denyUnverifiedPlugin(manifest.id);
+        }
         setPendingUnverified([]);
-    }, []);
+    }, [pendingUnverified]);
 
     const syncPlugins = useCallback(async () => {
         if (!hostReady) return;
@@ -187,7 +197,21 @@ export function useMarketplaceSync(hostReady: boolean) {
         // eslint-disable-next-line react-hooks/set-state-in-effect
         syncPlugins();
 
-        const handleFocus = () => { syncPlugins(); };
+        // Debounce focus-triggered re-syncs: rapid focus/blur pairs (e.g. from
+        // iframe or sibling-window activity) shouldn't each trigger a full sync.
+        const FOCUS_SYNC_DEBOUNCE_MS = 1500;
+        let lastSyncAt = Date.now();
+        let syncInFlight = false;
+
+        const handleFocus = () => {
+            if (syncInFlight) return;
+            if (Date.now() - lastSyncAt < FOCUS_SYNC_DEBOUNCE_MS) return;
+            syncInFlight = true;
+            lastSyncAt = Date.now();
+            syncPlugins().finally(() => {
+                syncInFlight = false;
+            });
+        };
         window.addEventListener("focus", handleFocus);
         return () => window.removeEventListener("focus", handleFocus);
     }, [syncPlugins, hostReady]);

--- a/src/lib/marketplace/trustedPlugins.ts
+++ b/src/lib/marketplace/trustedPlugins.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY = "wwv_approved_unverified_plugins";
+const DENIED_STORAGE_KEY = "wwv_denied_unverified_plugins";
 
 /** Get the set of plugin IDs the user has approved despite being unverified. */
 export function getApprovedUnverifiedIds(): Set<string> {
@@ -16,4 +17,28 @@ export function approveUnverifiedPlugin(pluginId: string): void {
   const approved = getApprovedUnverifiedIds();
   approved.add(pluginId);
   localStorage.setItem(STORAGE_KEY, JSON.stringify([...approved]));
+
+  // Approval wins over a prior permanent denial.
+  const denied = getDeniedUnverifiedIds();
+  if (denied.delete(pluginId)) {
+    localStorage.setItem(DENIED_STORAGE_KEY, JSON.stringify([...denied]));
+  }
+}
+
+/** Get the set of plugin IDs the user has permanently dismissed as unverified. */
+export function getDeniedUnverifiedIds(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = localStorage.getItem(DENIED_STORAGE_KEY);
+    return raw ? new Set<string>(JSON.parse(raw)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+/** Permanently dismiss an unverified plugin (won't show the warning again). */
+export function denyUnverifiedPlugin(pluginId: string): void {
+  const denied = getDeniedUnverifiedIds();
+  denied.add(pluginId);
+  localStorage.setItem(DENIED_STORAGE_KEY, JSON.stringify([...denied]));
 }


### PR DESCRIPTION
## What was broken

The "N plugins not verified by WorldWideView" dialog re-mounts on **every window focus**. Two mechanisms caused it:

1. `useMarketplaceSync` registers a `window` `focus` listener that calls `syncPlugins()` unconditionally. Each sync re-fetches `/api/marketplace/load`, and that route re-stamps every non-built-in plugin `unverified` on each call (with `registryClient` failing open to `[]` for verified IDs in sandboxed/E2E environments, there is no verifiedIds rescue).
2. `denyAll` only cleared the in-memory pending list — it never persisted the denial. The next sync re-pended the same plugins, so the dialog re-appeared.

With fully-parallel E2E workers, sibling browser activity fires focus/blur repeatedly, re-running the full sync and re-opening the dialog mid-test. The E2E specs currently patch around this with capture-phase focus/blur blockers; this fix makes those patches unnecessary over time.

## What changed

- **Persist denials** (`src/lib/marketplace/trustedPlugins.ts`): added `getDeniedUnverifiedIds()` / `denyUnverifiedPlugin()` backed by a new `wwv_denied_unverified_plugins` localStorage key, mirroring the existing approved-store style. `approveUnverifiedPlugin` also clears a prior denial so approval always wins.
- **Gate excludes denials** (`src/core/hooks/useMarketplaceSync.ts`): the unverified gate now skips permanently denied plugin IDs, so a re-sync never re-pends them.
- **`denyAll` persists** each pending plugin ID before clearing the list.
- **Debounce focus re-sync**: focus-triggered syncs are skipped if the last sync was <1500ms ago or a sync is in flight. Manual and timer sync paths are untouched.

## Why it matters

Removes flaky dialog interference in E2E runs and stops the dialog nagging users every time the window regains focus after they dismissed it. The approve flow is unchanged (already persisted).

## Verification

- `npx tsc --noEmit` — clean (exit 0)
- `pnpm lint` — 0 errors, 306 warnings (matches baseline; no warnings in changed files)
- No unit tests exist for `trustedPlugins.ts` / `useMarketplaceSync.ts`; E2E suite (CI) is the behavioral gate.

Semver: 2.65.32 -> 2.65.33 (patch).