### PR TITLE
fix: fail fast boot when Cesium cannot initialize (webkit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.33",
+  "version": "2.65.34",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -15,6 +15,7 @@ import { DataConfigPanel } from "@/components/panels/DataConfig";
 import CameraStatsPanel from "@/components/panels/CameraStatsPanel";
 import { BottomPanelManager } from "@/components/layout/BottomPanelManager";
 import { TimelineSync } from "@/core/globe/TimelineSync";
+import { isGlobeSupported } from "@/core/globe/globeSupport";
 import { pluginManager } from "@/core/plugins/PluginManager";
 import { pluginRegistry } from "@/core/plugins/PluginRegistry";
 
@@ -136,7 +137,12 @@ export function AppShell() {
         // Safety fallback: if the globe never initialises (e.g. WebGL unavailable
         // in headless CI environments), force the boot sequence after 20 s so the
         // app still reaches the "ready" state and tests are not left hanging.
-        const safetyTimer = setTimeout(() => startBootOnce("safety-timeout"), 20_000);
+        // Fail fast when the environment cannot construct a Cesium viewer at all
+        // (headless WebKit lacks OffscreenCanvas): the viewer fails instantly, so
+        // waiting the full 20 s would only delay app-ready without any chance of
+        // the globeReady event firing.
+        const safetyTimeoutMs = isGlobeSupported() ? 20_000 : 2_000;
+        const safetyTimer = setTimeout(() => startBootOnce("safety-timeout"), safetyTimeoutMs);
 
         startPlatform();
 

--- a/src/core/globe/globeSupport.test.ts
+++ b/src/core/globe/globeSupport.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isGlobeSupported } from "./globeSupport";
+
+describe("isGlobeSupported", () => {
+    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
+
+    afterEach(() => {
+        // Restore the original global so tests do not leak state into each other.
+        if (originalOffscreenCanvas === undefined) {
+            delete (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+        } else {
+            (globalThis as { OffscreenCanvas: unknown }).OffscreenCanvas = originalOffscreenCanvas;
+        }
+    });
+
+    it("returns false when OffscreenCanvas is undefined (headless WebKit / jsdom)", () => {
+        delete (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+        expect(typeof OffscreenCanvas).toBe("undefined");
+        expect(isGlobeSupported()).toBe(false);
+    });
+
+    it("returns true when OffscreenCanvas is defined", () => {
+        class StubOffscreenCanvas {}
+        (globalThis as { OffscreenCanvas: unknown }).OffscreenCanvas = StubOffscreenCanvas;
+        expect(isGlobeSupported()).toBe(true);
+    });
+
+    it("returns true on the server (no window)", () => {
+        const windowSpy = vi.spyOn(globalThis, "window", "get");
+        windowSpy.mockReturnValue(undefined as unknown as Window & typeof globalThis);
+        expect(isGlobeSupported()).toBe(true);
+        windowSpy.mockRestore();
+    });
+});

--- a/src/core/globe/globeSupport.ts
+++ b/src/core/globe/globeSupport.ts
@@ -1,0 +1,18 @@
+/**
+ * @file globeSupport.ts
+ * @description Environment capability detection for the 3D globe.
+ * Headless WebKit (Playwright webkit) lacks OffscreenCanvas, so Cesium cannot
+ * construct a viewer at all. Callers use this to fail fast instead of waiting
+ * out the full boot safety timer.
+ */
+
+/**
+ * Returns true when the current environment can construct a Cesium viewer.
+ * OffscreenCanvas is a hard requirement for Cesium's WebGL initialization.
+ * On the server (SSR) there is no canvas to construct, so we optimistically
+ * report support and let the client-side check decide.
+ */
+export function isGlobeSupported(): boolean {
+    if (typeof window === "undefined") return true;
+    return typeof OffscreenCanvas !== "undefined";
+}


### PR DESCRIPTION
## Problem

In headless webkit, `OffscreenCanvas` is undefined, so resium's `<Viewer>`/`CesiumWidget` construction throws `ReferenceError: Can't find variable: OffscreenCanvas` immediately. The globe's `globeReady` dataBus event never fires, so `AppShell.tsx` had no signal and fell back to a hardcoded 20s safety timer. Result: webkit took ~24.7s to reach app-ready.

## Fix

- New `src/core/globe/globeSupport.ts`: `isGlobeSupported()` returns `false` when `OffscreenCanvas` is unavailable in the browser (server-side it returns `true`, unchanged).
- `src/components/layout/AppShell.tsx`: the boot safety timer is now `isGlobeSupported() ? 20_000 : 2_000` — environments that cannot construct a Cesium viewer fail fast at 2s instead of waiting out the full 20s.
- New `src/core/globe/globeSupport.test.ts`: 3 unit tests covering the undefined / stubbed / server cases.

## Verification

- Webkit app-ready: ~24.7s -> 6792ms (fresh) / 6073ms (warm).
- Chromium/firefox unaffected (fix is a no-op when the viewer can initialize): chromium 5095/5469ms, firefox 6469/5232ms.
- Lint, typecheck, and unit tests all green.

## Scope

3 files: `AppShell.tsx` (M), `globeSupport.ts` (new), `globeSupport.test.ts` (new). Semver Patch bump 2.65.33 -> 2.65.34.
