### PR TITLE
docs: document known cosmetic CI failures in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,13 @@ See `.agents/context/INDEX.md` for the full navigation table. Key files:
 
 ---
 
+## 13. Known CI Caveats
+
+- **PR Preview can fail at startup (`startup_failure`, 0 jobs)**: GitHub silently rejects a whole reusable workflow when the `secrets` context appears inside its `if:`/`with:` values (see commit `28d6748`). The pattern regressed into `shared-docker.yml` build-args (PR #411); the fix is in-flight as PR #443. Until #443 merges, treat `startup_failure` on PR Preview as a workflow-registration issue, not a code/test failure — a re-run will not clear it.
+- Nothing else is currently known-red. Treat new failures as real until proven cosmetic.
+
+---
+
 ## Hard Rule
 
 > **Always interface-based, extensible, composable, modular. Never band-aids on band-aids.**


### PR DESCRIPTION
## docs: document known cosmetic CI failures in AGENTS.md

Adds a "Known CI Caveats" section to `AGENTS.md` so agents do not misclassify red CI as a regression in their own change.

**Why**: Red checks that are pre-existing and cosmetic (or being fixed separately) repeatedly get attributed to unrelated PRs. Agents should recognize them and move on.

**What**:
- Documents the **PR Preview / workflow startup_failure class**: GitHub silently rejects a reusable workflow whose `if:` or `with:` block references the `secrets` context, producing `startup_failure` with 0 jobs and no error text.
- Cites commit `28d6748` (the repo's own precedent commit documenting this behavior).
- Notes the regression introduced by PR #411 into `shared-docker.yml` (secrets context embedded in the build step's `build-args` `with:` block), which broke cross-repo consumers (marketplace/web `Docker Publish` workflows) while the globe's self-contained `Docker Image CI` stayed green.
- Notes the fix is in flight via PR #443.

**Note**: Update this section after PR #443 merges (the startup_failure class should become a resolved historical item, not a live caveat).
