### PR TITLE
docs: add fresh worktree bootstrap guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ pnpm test         # Vitest
 pnpm db:reset     # Wipe + re-migrate DB (destructive)
 ```
 
+**Fresh worktree bootstrap**: a `git-wt` worktree starts with no `node_modules` and no env files. Run `pnpm install`, then copy `.env.local` from the main checkout (or a sibling worktree) if missing. `pnpm dev` auto-runs `prisma db push` + `copy-cesium` via `predev`. The main checkout is read-only and often stale: always read `origin/main` or work in a worktree.
+
 See `.agents/context/` → [deployment and testing details in `.agents/rules/deployment-and-testing.md`] for Docker architecture, Coolify rules, and CSP headers.
 
 ---


### PR DESCRIPTION
## Problem

Fresh worktrees hit the same recurring bootstrap gaps:

- no `node_modules/` (gitignored, never cloned)
- no `.env.local` / `.env` (gitignored)
- missing Cesium assets (`public/cesium`) until copy-cesium runs

## Fix

Added a fresh-worktree bootstrap paragraph to `AGENTS.md` documenting the sequence:

1. `pnpm install`
2. `pnpm dev` — the `predev` script auto-runs `prisma db push` (via `safe-db-push.mjs`, behind a local-DB guard) + `copy-cesium.mjs` + Prisma generate
3. copy the gitignored `.env.local` pair from a sibling worktree

Verified against the actual `predev` chain in `package.json`: `node scripts/boot-db.mjs && npx dotenv-cli -c -- node scripts/safe-db-push.mjs && npx prisma generate && node scripts/copy-cesium.mjs && node scripts/sync-local-plugins.mjs`.

## Files

- `AGENTS.md` (single file, no version bump)
