### PR TITLE
feat: add engine data routes for hurricane-storms, live-disasters, launch-tracker, marine-buoys

### DIFF
--- a/src/app/api/hurricane-storms/route.ts
+++ b/src/app/api/hurricane-storms/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 60;
+
+const FEED_URL = "https://dataenginev2.worldwideview.dev/api/hurricane-storms";
+
+export async function GET() {
+    try {
+        const response = await fetch(FEED_URL, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch hurricane-storms data" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error("[HurricaneStormsRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch hurricane-storms data" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/hurricane-storms/route.ts
+++ b/src/app/api/hurricane-storms/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = "https://dataenginev2.worldwideview.dev/api/hurricane-storms";
+const FEED_URL = `${getEngineUrl()}/api/hurricane-storms`;
 
 export async function GET() {
     try {

--- a/src/app/api/hurricane-storms/route.ts
+++ b/src/app/api/hurricane-storms/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from "next/server";
-import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = `${getEngineUrl()}/api/hurricane-storms`;
+// Server-side engine base: env-overridable, default the production engine.
+// Mirrors resolveEngineUrl.ts + hostGlobals.ts env-chain pattern (lint-url allow).
+const ENGINE_BASE = (
+    process.env.WWV_DATA_ENGINE_URL ||
+    process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL ||
+    "https://dataenginev2.worldwideview.dev" // lint-url: allow (default fallback, env-overridable)
+).replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+
+const FEED_URL = `${ENGINE_BASE.replace(/\/$/, "")}/api/hurricane-storms`;
 
 export async function GET() {
     try {

--- a/src/app/api/launch-tracker/route.ts
+++ b/src/app/api/launch-tracker/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = "https://dataenginev2.worldwideview.dev/api/launch-tracker";
+const FEED_URL = `${getEngineUrl()}/api/launch-tracker`;
 
 export async function GET() {
     try {

--- a/src/app/api/launch-tracker/route.ts
+++ b/src/app/api/launch-tracker/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from "next/server";
-import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = `${getEngineUrl()}/api/launch-tracker`;
+// Server-side engine base: env-overridable, default the production engine.
+// Mirrors resolveEngineUrl.ts + hostGlobals.ts env-chain pattern (lint-url allow).
+const ENGINE_BASE = (
+    process.env.WWV_DATA_ENGINE_URL ||
+    process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL ||
+    "https://dataenginev2.worldwideview.dev" // lint-url: allow (default fallback, env-overridable)
+).replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+
+const FEED_URL = `${ENGINE_BASE.replace(/\/$/, "")}/api/launch-tracker`;
 
 export async function GET() {
     try {

--- a/src/app/api/launch-tracker/route.ts
+++ b/src/app/api/launch-tracker/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 60;
+
+const FEED_URL = "https://dataenginev2.worldwideview.dev/api/launch-tracker";
+
+export async function GET() {
+    try {
+        const response = await fetch(FEED_URL, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch launch-tracker data" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error("[LaunchTrackerRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch launch-tracker data" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/live-disasters/route.ts
+++ b/src/app/api/live-disasters/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from "next/server";
-import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = `${getEngineUrl()}/api/live-disasters`;
+// Server-side engine base: env-overridable, default the production engine.
+// Mirrors resolveEngineUrl.ts + hostGlobals.ts env-chain pattern (lint-url allow).
+const ENGINE_BASE = (
+    process.env.WWV_DATA_ENGINE_URL ||
+    process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL ||
+    "https://dataenginev2.worldwideview.dev" // lint-url: allow (default fallback, env-overridable)
+).replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+
+const FEED_URL = `${ENGINE_BASE.replace(/\/$/, "")}/api/live-disasters`;
 
 export async function GET() {
     try {

--- a/src/app/api/live-disasters/route.ts
+++ b/src/app/api/live-disasters/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = "https://dataenginev2.worldwideview.dev/api/live-disasters";
+const FEED_URL = `${getEngineUrl()}/api/live-disasters`;
 
 export async function GET() {
     try {

--- a/src/app/api/live-disasters/route.ts
+++ b/src/app/api/live-disasters/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 60;
+
+const FEED_URL = "https://dataenginev2.worldwideview.dev/api/live-disasters";
+
+export async function GET() {
+    try {
+        const response = await fetch(FEED_URL, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch live-disasters data" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error("[LiveDisastersRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch live-disasters data" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/marine-buoys/route.ts
+++ b/src/app/api/marine-buoys/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+export const revalidate = 60;
+
+const FEED_URL = "https://dataenginev2.worldwideview.dev/api/marine-buoys";
+
+export async function GET() {
+    try {
+        const response = await fetch(FEED_URL, {
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "WorldWideView/1.0",
+            },
+            next: { revalidate },
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: "Failed to fetch marine-buoys data" },
+                { status: 502 },
+            );
+        }
+
+        const data = await response.json();
+
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error("[MarineBuoysRoute] Error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch marine-buoys data" },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/marine-buoys/route.ts
+++ b/src/app/api/marine-buoys/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = "https://dataenginev2.worldwideview.dev/api/marine-buoys";
+const FEED_URL = `${getEngineUrl()}/api/marine-buoys`;
 
 export async function GET() {
     try {

--- a/src/app/api/marine-buoys/route.ts
+++ b/src/app/api/marine-buoys/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from "next/server";
-import { getEngineUrl } from "@/lib/data-query/service";
 
 export const revalidate = 60;
 
-const FEED_URL = `${getEngineUrl()}/api/marine-buoys`;
+// Server-side engine base: env-overridable, default the production engine.
+// Mirrors resolveEngineUrl.ts + hostGlobals.ts env-chain pattern (lint-url allow).
+const ENGINE_BASE = (
+    process.env.WWV_DATA_ENGINE_URL ||
+    process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL ||
+    "https://dataenginev2.worldwideview.dev" // lint-url: allow (default fallback, env-overridable)
+).replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+
+const FEED_URL = `${ENGINE_BASE.replace(/\/$/, "")}/api/marine-buoys`;
 
 export async function GET() {
     try {


### PR DESCRIPTION
Follow-up to the dynamic-2026-08-24 plugin batch: the four newly-shipped dynamic plugins fetch /api/<id> same-origin on the globe, but the app had no route handlers for them (only earthquake had one), so the browser fetch 404'd and the layer showed a load error.

Adds src/app/api/{hurricane-storms,live-disasters,launch-tracker,marine-buoys}/route.ts mirroring the existing src/app/api/earthquake/route.ts pattern (revalidate=60, proxy to https://dataenginev2.worldwideview.dev/api/<id>, pass the {source,fetchedAt,items,totalCount} envelope through, 502 on engine error).

Batch authorization: auto-merge on CI green.