### PR TITLE
fix(globe): keyless-safe Google Maps 3D default and globe-hide guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,17 @@ NEXT_PUBLIC_CESIUM_ION_TOKEN=
 # Get your key at https://www.bingmapsportal.com/
 NEXT_PUBLIC_BING_MAPS_KEY=
 
+# Google Maps API Key (Optional, browser-side: enables the Google Photorealistic 3D globe layer)
+# Key must be at least 20 characters. Without a valid key the app defaults to
+# Bing Aerial and Google 3D stays disabled. Get a key at:
+# https://developers.google.com/maps/documentation/javascript/get-api-key
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
+
+# Google Maps API Key (Optional, server-side: Place search/details routes under /api/places/*)
+# Server-only; never prefix with NEXT_PUBLIC_. The places routes fall back to
+# the NEXT_PUBLIC_GOOGLE_MAPS_API_KEY above when this is unset.
+GOOGLE_MAPS_API_KEY=
+
 # Supabase Configuration (Optional — cloud-only features)
 # Found in your Supabase Project Settings > API
 NEXT_PUBLIC_SUPABASE_URL=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.33",
+  "version": "2.65.34",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/core/globe/useImageryManager.ts
+++ b/src/core/globe/useImageryManager.ts
@@ -69,6 +69,16 @@ export function useImageryManager(viewerInstance: CesiumViewer | null, viewerRea
                 }
             }
 
+            // A Google tileset only exists on keyed builds. Without one, never
+            // hide the globe surface or drop the imagery layer for a layer
+            // that cannot load; route through the existing fallback instead.
+            if (isGoogle3D && !foundTileset) {
+                if (fallbackLayerId !== "bing-aerial") {
+                    useStore.getState().updateMapConfig({ fallbackLayerId: "bing-aerial" });
+                }
+                return; // effect re-runs with the fallback layer; keep current imagery visible
+            }
+
             if (foundTileset) {
                 foundTileset.show = isGoogle3D;
             }

--- a/src/core/state/configSlice.ts
+++ b/src/core/state/configSlice.ts
@@ -6,6 +6,7 @@
 
 import type { StateCreator } from "zustand";
 import type { AppStore } from "./store";
+import { resolveDefaultBaseLayerId } from "./mapDefaults";
 
 // ─── Data Configuration ──────────────────────────────────────
 /**
@@ -109,7 +110,12 @@ export const createConfigSlice: StateCreator<AppStore, [], [], ConfigSlice> = (s
         maxScreenSpaceError: 32, // Increase from 16 to 32 to significantly reduce 3D tile network requests and costs
         shadowsEnabled: false,
         enableLighting: false,
-        baseLayerId: (typeof window !== "undefined" && window.localStorage && typeof window.localStorage.getItem === "function") ? (localStorage.getItem("wwv_map_layer") || "google-3d") : "google-3d",
+        baseLayerId: resolveDefaultBaseLayerId(
+            typeof window !== "undefined" && window.localStorage && typeof window.localStorage.getItem === "function"
+                ? localStorage.getItem("wwv_map_layer")
+                : null,
+            process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+        ),
         fallbackLayerId: null,
         sceneMode: 3,
         showOsmBuildings: true,

--- a/src/core/state/mapDefaults.test.ts
+++ b/src/core/state/mapDefaults.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { resolveDefaultBaseLayerId } from "./mapDefaults";
+
+describe("resolveDefaultBaseLayerId", () => {
+    it("defaults to google-3d with a valid browser key (>= 20 chars) and no stored choice", () => {
+        expect(resolveDefaultBaseLayerId(null, "a".repeat(20))).toBe("google-3d");
+    });
+
+    it("defaults to bing-aerial with no browser key and no stored choice", () => {
+        expect(resolveDefaultBaseLayerId(null, undefined)).toBe("bing-aerial");
+    });
+
+    it("defaults to bing-aerial with a short browser key (< 20 chars) and no stored choice", () => {
+        expect(resolveDefaultBaseLayerId(null, "a".repeat(19))).toBe("bing-aerial");
+        expect(resolveDefaultBaseLayerId(null, "")).toBe("bing-aerial");
+    });
+
+    it("keeps a stored osm choice regardless of key", () => {
+        expect(resolveDefaultBaseLayerId("osm", "a".repeat(20))).toBe("osm");
+        expect(resolveDefaultBaseLayerId("osm", undefined)).toBe("osm");
+    });
+
+    it("keeps a stored google-3d choice regardless of key", () => {
+        expect(resolveDefaultBaseLayerId("google-3d", undefined)).toBe("google-3d");
+        expect(resolveDefaultBaseLayerId("google-3d", "a".repeat(20))).toBe("google-3d");
+    });
+});

--- a/src/core/state/mapDefaults.ts
+++ b/src/core/state/mapDefaults.ts
@@ -1,0 +1,19 @@
+/**
+ * @file mapDefaults.ts
+ * @description Pure helpers for resolving default map configuration.
+ */
+
+/**
+ * Resolves the default base layer ID.
+ *
+ * A stored user preference always wins. Otherwise Google Photorealistic 3D is
+ * only offered as the default when a browser-side Google Maps API key of at
+ * least 20 characters exists: keyless builds must never default to a layer
+ * that cannot load, so they resolve to "bing-aerial".
+ */
+export function resolveDefaultBaseLayerId(stored: string | null, envKey: string | undefined): string {
+    if (stored !== null) {
+        return stored;
+    }
+    return envKey && envKey.length >= 20 ? "google-3d" : "bing-aerial";
+}


### PR DESCRIPTION
## Summary

Keyless deployments (demo + self-host with no `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`) no longer default to the unloadable `google-3d` layer, and selecting it can no longer black out the globe.

### Changes
- **`src/core/state/mapDefaults.ts` (new)** — pure `resolveDefaultBaseLayerId(stored, envKey)` helper: stored localStorage choice wins; otherwise `google-3d` only when a browser key of >= 20 chars exists, else `bing-aerial`.
- **`src/core/state/configSlice.ts`** — default `baseLayerId` now uses the helper instead of hardcoded `"google-3d"`.
- **`src/core/globe/useImageryManager.ts`** — when the active layer is `google-3d` but no Google tileset exists (keyless), set `fallbackLayerId: "bing-aerial"` and return early: the globe surface is never hidden and current imagery stays visible. Tileset-present behavior is unchanged.
- **`src/core/state/mapDefaults.test.ts` (new)** — 5 unit tests covering keyed/keyless/short-key/stored-override cases.
- **`.env.example`** — documents `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` (browser-side, enables Google Photorealistic 3D) and `GOOGLE_MAPS_API_KEY` (server-side, `/api/places/*`).

### Why
Investigation showed the demo runs keyless: Google 3D silently never loads, the app defaulted to that layer anyway (failed card + "Error: Missing API Key" for every visitor), and picking Google 3D without a key hid the globe surface entirely (black globe). The platform now treats keyless as the intended first-class experience.

### Test plan
- [x] `npx eslint` on touched files: 0 errors
- [x] `pnpm vitest run src/core/state/mapDefaults.test.ts`: 5/5 pass
- [x] `pnpm build` (production): passes
- [x] Independently verified by a fresh-context verifier agent: all 6 spec criteria PASS, only the 5 expected files changed