### PR TITLE
fix: prevent marketplace plugin double-registration on concurrent syncs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.34",
+  "version": "2.65.35",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/core/hooks/useMarketplaceSync.test.tsx
+++ b/src/core/hooks/useMarketplaceSync.test.tsx
@@ -1,0 +1,286 @@
+import {
+    describe, it, expect, beforeEach, afterEach, vi,
+} from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { PluginManifest } from "@/core/plugins/PluginManifest";
+import type { WorldPlugin } from "@/core/plugins/PluginTypes";
+import { pluginManager } from "@/core/plugins/PluginManager";
+import { useMarketplaceSync } from "./useMarketplaceSync";
+
+/**
+ * Regression tests for the marketplace sync double-registration race.
+ *
+ * useMarketplaceSync() runs a marketplace sync on mount AND on window focus
+ * (debounced 1500ms). On a cold/slow first load the mount pass can still be
+ * in flight when a focus event fires at t+1.5s, so two passes overlap and
+ * walk the manifest list concurrently. That used to make loadManifest()
+ * call pluginManager.loadFromManifest() twice for the same plugin id
+ * (check-then-act on loadedIds), producing "[PluginManager] Plugin X already
+ * registered" warnings and wasted registrations.
+ *
+ * Both tests hold the manifest fetch / plugin load behind controllable
+ * deferreds so the overlap is interleaved deterministically, then assert
+ * each plugin id is loaded exactly once and no duplicate-registration
+ * warning ever fires.
+ */
+
+const h = vi.hoisted(() => {
+    function makeDeferred<T>() {
+        let resolve!: (value: T) => void;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        let reject!: (reason?: unknown) => void;
+        const promise = new Promise<T>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return { promise, resolve };
+    }
+
+    function makePlugin(id: string): WorldPlugin {
+        return {
+            id,
+            name: `Plugin ${id}`,
+            description: "test plugin",
+            icon: "Box",
+            category: "custom",
+            version: "1.0.0",
+            initialize: async () => {},
+            destroy: () => {},
+            fetch: async () => [],
+            getPollingInterval: () => 0,
+            getLayerConfig: () => ({
+                color: "#fff",
+                clusterEnabled: false,
+                clusterDistance: 50,
+            }),
+            renderEntity: () => ({ type: "point" }),
+        };
+    }
+
+    const initLayer = vi.fn();
+    const useStore = Object.assign(
+        vi.fn((selector: (state: unknown) => unknown) => selector({ initLayer })),
+        {
+            getState: () => ({
+                dataConfig: { pluginSettings: {}, pollingIntervals: {} },
+                isPlaybackMode: false,
+                currentTime: new Date(),
+                showErrorToast: undefined,
+            }),
+            subscribe: () => () => {},
+        },
+    ) as unknown as {
+        (selector: (state: unknown) => unknown): unknown;
+        getState: () => unknown;
+        subscribe: () => () => void;
+    };
+
+    const gates: {
+        pluginGate: ReturnType<typeof makeDeferred<void>> | null;
+        loadGate: ReturnType<typeof makeDeferred<{ ok: boolean; json: () => Promise<unknown> }>> | null;
+    } = { pluginGate: null, loadGate: null };
+
+    const loadPluginFromManifest = vi.fn(async (manifest: PluginManifest) => {
+        if (gates.pluginGate) await gates.pluginGate.promise;
+        return makePlugin(manifest.id);
+    });
+
+    return { makeDeferred, makePlugin, initLayer, useStore, gates, loadPluginFromManifest };
+});
+
+vi.mock("@/core/state/store", () => ({ useStore: h.useStore }));
+vi.mock("@/lib/analytics", () => ({ trackEvent: () => {} }));
+vi.mock("@/core/data/resolveEngineUrl", () => ({
+    resolveEngineUrl: () => "wss://test.example/stream",
+}));
+vi.mock("@/core/data/engineManifest", () => ({
+    fetchLocalEngineManifest: async () => null,
+}));
+vi.mock("@/core/plugins/loadPluginFromManifest", () => ({
+    loadPluginFromManifest: h.loadPluginFromManifest,
+}));
+vi.mock("@/lib/marketplace/trustedPlugins", () => ({
+    getApprovedUnverifiedIds: () => new Set<string>(),
+    approveUnverifiedPlugin: vi.fn(),
+    getDeniedUnverifiedIds: () => new Set<string>(),
+    denyUnverifiedPlugin: vi.fn(),
+}));
+vi.mock("@/core/plugins/pluginPreferences", () => ({
+    getDisabledPluginIds: () => new Set<string>(),
+}));
+vi.mock("@/core/edition", () => ({ isDemo: false }));
+
+const MANIFESTS: PluginManifest[] = [
+    {
+        id: "alpha-1",
+        name: "Alpha",
+        version: "1.0.0",
+        type: "data-layer",
+        format: "bundle",
+        trust: "verified",
+        capabilities: ["data:own"],
+        category: "custom",
+        icon: "Box",
+        entry: "https://example.com/alpha.mjs",
+    },
+    {
+        id: "bravo-2",
+        name: "Bravo",
+        version: "1.0.0",
+        type: "data-layer",
+        format: "bundle",
+        trust: "verified",
+        capabilities: ["data:own"],
+        category: "custom",
+        icon: "Box",
+        entry: "https://example.com/bravo.mjs",
+    },
+    {
+        id: "charlie-3",
+        name: "Charlie",
+        version: "1.0.0",
+        type: "data-layer",
+        format: "bundle",
+        trust: "verified",
+        capabilities: ["data:own"],
+        category: "custom",
+        icon: "Box",
+        entry: "https://example.com/charlie.mjs",
+    },
+    {
+        id: "delta-4",
+        name: "Delta",
+        version: "1.0.0",
+        type: "data-layer",
+        format: "bundle",
+        trust: "verified",
+        capabilities: ["data:own"],
+        category: "custom",
+        icon: "Box",
+        entry: "https://example.com/delta.mjs",
+    },
+];
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeFetchStub() {
+    return vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/api/marketplace/load")) {
+            return h.gates.loadGate!.promise;
+        }
+        if (url.includes("/api/marketplace/disabled-builtins")) {
+            return { ok: true, json: async () => ({ disabledIds: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    h.gates.pluginGate = h.makeDeferred<void>();
+    h.gates.loadGate = h.makeDeferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    fetchMock = makeFetchStub();
+    vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+    // PluginManager is a module singleton; destroy() resets registrations so
+    // later tests in this file start from a clean slate (as PluginManager.test.ts does).
+    pluginManager.destroy();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+});
+
+function duplicateRegistrationWarnings(warnSpy: ReturnType<typeof vi.spyOn>) {
+    return warnSpy.mock.calls
+        .flat()
+        .filter((arg: unknown): arg is string => typeof arg === "string")
+        .filter((message: string) => message.includes("already registered"));
+}
+
+describe("useMarketplaceSync marketplace race", () => {
+    it("loads each plugin id exactly once when syncs overlap (TOCTOU)", async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const { result } = renderHook(() => useMarketplaceSync(true));
+
+        // Let the mount sync get past the manifest fetch; it then blocks
+        // inside loadPluginFromManifest on the held plugin gate.
+        await act(async () => {
+            h.gates.loadGate!.resolve({
+                ok: true,
+                json: async () => ({ manifests: MANIFESTS }),
+            });
+        });
+
+        // Two further syncs overlap with the in-flight mount sync — exactly
+        // like a focus event landing mid-sync on a cold start. They are fired
+        // without awaiting so the interleaving is visible; all must collapse
+        // into one walk of the manifest list.
+        act(() => {
+            result.current.syncPlugins();
+            result.current.syncPlugins();
+        });
+
+        // Let the overlapped syncs interleave before the load is released.
+        await act(async () => {});
+
+        // Release the plugin load; the single in-flight sync may finish.
+        await act(async () => {
+            h.gates.pluginGate!.resolve();
+        });
+
+        // Once per manifest id — never twice for the same id.
+        expect(h.loadPluginFromManifest).toHaveBeenCalledTimes(MANIFESTS.length);
+        expect(h.initLayer).toHaveBeenCalledTimes(MANIFESTS.length);
+        expect(pluginManager.getAllPlugins().map((managed) => managed.plugin.id).sort())
+            .toEqual([...MANIFESTS].map((manifest) => manifest.id).sort());
+        expect(duplicateRegistrationWarnings(warnSpy)).toEqual([]);
+
+        warnSpy.mockRestore();
+    });
+
+    it("skips a focus-triggered sync while the mount sync is in flight", async () => {
+        vi.useFakeTimers();
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        renderHook(() => useMarketplaceSync(true));
+
+        // Drain microtasks so the mount sync reaches the held manifest fetch
+        // and stays in flight across the debounce window.
+        await act(async () => {});
+
+        // Past the 1500ms focus debounce — this must NOT start a second sync.
+        act(() => {
+            vi.advanceTimersByTime(1600);
+        });
+        act(() => {
+            window.dispatchEvent(new Event("focus"));
+        });
+
+        // Release everything the in-flight sync is waiting on.
+        await act(async () => {
+            h.gates.loadGate!.resolve({
+                ok: true,
+                json: async () => ({ manifests: MANIFESTS }),
+            });
+        });
+        await act(async () => {
+            h.gates.pluginGate!.resolve();
+        });
+
+        // The focus trigger never started a second manifest fetch, so each
+        // plugin id was loaded exactly once and no duplicate-registration
+        // warning fired.
+        const loadFetchCalls = fetchMock.mock.calls.filter((call) =>
+            String(call[0]).includes("/api/marketplace/load"),
+        );
+        expect(loadFetchCalls).toHaveLength(1);
+        expect(h.loadPluginFromManifest).toHaveBeenCalledTimes(MANIFESTS.length);
+        expect(duplicateRegistrationWarnings(warnSpy)).toEqual([]);
+
+        warnSpy.mockRestore();
+    });
+});

--- a/src/core/hooks/useMarketplaceSync.ts
+++ b/src/core/hooks/useMarketplaceSync.ts
@@ -25,6 +25,8 @@ export function useMarketplaceSync(hostReady: boolean) {
     const initLayer = useStore((s) => s.initLayer);
     const loadedIds = useRef<Set<string>>(new Set());
     const initialDisabledIds = useRef<Set<string> | null>(null);
+    const syncInFlightRef = useRef(false);
+    const lastSyncAtRef = useRef(0);
     const [needsReload, setNeedsReload] = useState(false);
     const [pendingUnverified, setPendingUnverified] = useState<PluginManifest[]>([]);
 
@@ -76,6 +78,9 @@ export function useMarketplaceSync(hostReady: boolean) {
         }
 
         try {
+            // Reserve the id BEFORE the awaited load so a concurrent sync
+            // pass can never double-load this manifest.
+            loadedIds.current.add(manifest.id);
             console.log(`[MarketplaceSync] Loading manifest: ${manifest.id}`);
             await pluginManager.loadFromManifest(manifest);
 
@@ -95,9 +100,11 @@ export function useMarketplaceSync(hostReady: boolean) {
                 await pluginManager.enablePlugin(manifest.id);
             }
 
-            loadedIds.current.add(manifest.id);
             console.log(`[MarketplaceSync] Hot-loaded plugin "${manifest.id}"`);
         } catch (err) {
+            // Release the reservation so a failed load can be retried by a
+            // later sync.
+            loadedIds.current.delete(manifest.id);
             console.error(`[MarketplaceSync] Failed to load "${manifest.id}":`, err);
             const store = useStore.getState();
             if (store.showErrorToast) {
@@ -186,31 +193,34 @@ export function useMarketplaceSync(hostReady: boolean) {
 
     const syncPlugins = useCallback(async () => {
         if (!hostReady) return;
-        await captureInitialDisabled();
-        await syncMarketplacePlugins();
-        await checkBuiltinChanges();
+        if (syncInFlightRef.current) return;
+        syncInFlightRef.current = true;
+        try {
+            await captureInitialDisabled();
+            await syncMarketplacePlugins();
+            await checkBuiltinChanges();
+        } finally {
+            syncInFlightRef.current = false;
+        }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initLayer, hostReady]);
 
     useEffect(() => {
         if (!hostReady) return;
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         syncPlugins();
+        lastSyncAtRef.current = Date.now();
 
         // Debounce focus-triggered re-syncs: rapid focus/blur pairs (e.g. from
         // iframe or sibling-window activity) shouldn't each trigger a full sync.
         const FOCUS_SYNC_DEBOUNCE_MS = 1500;
-        let lastSyncAt = Date.now();
-        let syncInFlight = false;
 
         const handleFocus = () => {
-            if (syncInFlight) return;
-            if (Date.now() - lastSyncAt < FOCUS_SYNC_DEBOUNCE_MS) return;
-            syncInFlight = true;
-            lastSyncAt = Date.now();
-            syncPlugins().finally(() => {
-                syncInFlight = false;
-            });
+            if (Date.now() - lastSyncAtRef.current < FOCUS_SYNC_DEBOUNCE_MS) return;
+            lastSyncAtRef.current = Date.now();
+            // syncPlugins() itself is guarded: while the mount sync (or any
+            // other sync) is in flight, this trigger is skipped, so two passes
+            // can never walk the manifest list concurrently.
+            syncPlugins();
         };
         window.addEventListener("focus", handleFocus);
         return () => window.removeEventListener("focus", handleFocus);


### PR DESCRIPTION
## Problem

demo.worldwideview.dev browser console logs showed `[PluginManager] Plugin X already registered` warnings (data-centers, dams, and 20+ more under throttled network). API probes proved the manifest endpoint and DB are clean (54 unique plugins, 0 duplicates) — the duplicate was client-side.

## Root cause

`useMarketplaceSync` runs a marketplace sync on mount AND on window focus (1500ms debounce). On a slow/cold first load the mount pass takes >1.5s, so a focus event mid-pass started a second concurrent pass. Inside `loadManifest`, the `loadedIds` check then `await pluginManager.loadFromManifest()` is check-then-act (TOCTOU): the id was added to `loadedIds` only AFTER the await, so both passes loaded the same plugin and the second registration was rejected with a warning.

The existing partial fix (46d7539d) only guarded the focus handler with `syncInFlight`; the mount sync bypassed that guard entirely — reproduced live with CDP network throttling (800ms latency, 200KB/s) + focus events: 20+ `already registered` warnings.

## Fix

- `loadManifest` reserves the plugin id in `loadedIds` **before** the await and releases it on failure, making it idempotent under concurrency regardless of how many syncs overlap.
- Mount and focus syncs now share one in-flight guard (`syncInFlightRef`) with try/finally, so two passes can never walk the manifest list concurrently. Mount sync stays undebounced; focus keeps its 1500ms debounce.

## Verification

- New regression test `src/core/hooks/useMarketplaceSync.test.tsx` (2 tests, deterministic deferred-gate interleaving):
  - TOCTOU: 3 overlapping syncs -> each plugin id loads exactly once, zero `already registered` warnings. **Fails on pre-fix code (12 loads vs 4), passes post-fix.**
  - Focus guard: focus fired 1600ms into an in-flight mount sync -> exactly one manifest fetch.
- `pnpm exec vitest run`: 1191 tests pass. One pre-existing unrelated failure: `packages/wwv-lib-incidents` fails at import on clean origin/main too (CJS interop, no tests run) — not caused by this change.
- `tsc --noEmit`, eslint, and `pnpm build` all clean.
- Independent verifier subagent (fresh context): PASS on all 3 spec criteria.

Semver: 2.65.34 -> 2.65.35 (patch for fix).