### PR TITLE
fix(auth): complete v3.3 cleanup (phase 74 role + phase 75 criticals)

### DIFF
--- a/packages/wwv-plugin-sdk/dist/viteGlobals.d.ts
+++ b/packages/wwv-plugin-sdk/dist/viteGlobals.d.ts
@@ -1,0 +1,26 @@
+/**
+ * @file viteGlobals.ts
+ * @description Build-time utility for externalizing shared host dependencies.
+ * Provides a Vite plugin that maps 10 core libraries to globalThis.__WWV_HOST__,
+ * ensuring singleton stability for dynamically loaded plugin bundles:
+ *   react, react-dom, react/jsx-runtime, cesium, resium, zustand,
+ *   @worldwideview/wwv-plugin-sdk, @/core/state/store,
+ *   @/core/plugins/PluginManager, @/components/video/CameraStream
+ *
+ * Everything else (e.g. wwv-lib-aviation, wwv-lib-incidents, recharts) must be
+ * bundled per-plugin — the host does not provide small utility libs.
+ * @module @worldwideview/wwv-plugin-sdk
+ */
+/**
+ * @function wwvPluginGlobals
+ * @description Creates a Vite/Rollup plugin that resolves shared dependencies to
+ * the `globalThis.__WWV_HOST__` object.
+ *
+ * This ensures that dynamically loaded plugins inherit the exact library
+ * instances of the host application, preventing version mismatches and
+ * context errors.
+ *
+ * @returns {any} A Vite plugin object.
+ */
+export declare function wwvPluginGlobals(): any;
+//# sourceMappingURL=viteGlobals.d.ts.map

--- a/packages/wwv-plugin-sdk/dist/viteGlobals.d.ts.map
+++ b/packages/wwv-plugin-sdk/dist/viteGlobals.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"viteGlobals.d.ts","sourceRoot":"","sources":["../src/viteGlobals.ts"],"names":[],"mappings":"AAAA;;;;;;;;;;;;GAYG;AAMH;;;;;;;;;;GAUG;AACH,wBAAgB,gBAAgB,IAAI,GAAG,CA+FtC"}

--- a/packages/wwv-plugin-sdk/dist/viteGlobals.js
+++ b/packages/wwv-plugin-sdk/dist/viteGlobals.js
@@ -1,0 +1,121 @@
+"use strict";
+/**
+ * @file viteGlobals.ts
+ * @description Build-time utility for externalizing shared host dependencies.
+ * Provides a Vite plugin that maps 10 core libraries to globalThis.__WWV_HOST__,
+ * ensuring singleton stability for dynamically loaded plugin bundles:
+ *   react, react-dom, react/jsx-runtime, cesium, resium, zustand,
+ *   @worldwideview/wwv-plugin-sdk, @/core/state/store,
+ *   @/core/plugins/PluginManager, @/components/video/CameraStream
+ *
+ * Everything else (e.g. wwv-lib-aviation, wwv-lib-incidents, recharts) must be
+ * bundled per-plugin — the host does not provide small utility libs.
+ * @module @worldwideview/wwv-plugin-sdk
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.wwvPluginGlobals = wwvPluginGlobals;
+/**
+ * @function wwvPluginGlobals
+ * @description Creates a Vite/Rollup plugin that resolves shared dependencies to
+ * the `globalThis.__WWV_HOST__` object.
+ *
+ * This ensures that dynamically loaded plugins inherit the exact library
+ * instances of the host application, preventing version mismatches and
+ * context errors.
+ *
+ * @returns {any} A Vite plugin object.
+ */
+function wwvPluginGlobals() {
+    const HOST_MAPPINGS = {
+        "react": "React",
+        "react-dom": "ReactDOM",
+        "react/jsx-runtime": "jsxRuntime",
+        "cesium": "Cesium",
+        "resium": "Resium",
+        // zustand is handled in resolveId separately (not in HOST_MAPPINGS) — see load() below
+        "@worldwideview/wwv-plugin-sdk": "WWVPluginSDK",
+        "@/core/state/store": "useStore",
+        "@/core/plugins/PluginManager": "pluginManager",
+        "@/components/video/CameraStream": "CameraStream"
+    };
+    return {
+        name: "wwv-plugin-globals",
+        enforce: "pre",
+        resolveId(id) {
+            if (id in HOST_MAPPINGS || id === "zustand") {
+                // Ensure Rollup doesn't try to look for these modules in node_modules
+                return "\0" + id;
+            }
+            return null;
+        },
+        load(id) {
+            if (!id.startsWith("\0"))
+                return null;
+            const originalId = id.slice(1);
+            if (originalId === "react") {
+                return `
+                    const React = globalThis.__WWV_HOST__.React;
+                    export default React;
+                    export const { useState, useEffect, useRef, useMemo, useCallback, useContext, useReducer, useLayoutEffect, StrictMode, Suspense, createContext, createElement, cloneElement, isValidElement, Fragment, Children, Component, PureComponent, createRef, forwardRef, memo, lazy, startTransition, useTransition, useDeferredValue, useId, useSyncExternalStore, useInsertionEffect } = React;
+                `;
+            }
+            if (originalId === "react-dom") {
+                return `
+                    const ReactDOM = globalThis.__WWV_HOST__.ReactDOM;
+                    export default ReactDOM;
+                    export const { createPortal, flushSync } = ReactDOM;
+                `;
+            }
+            if (originalId === "react/jsx-runtime") {
+                return `
+                    const jsxRuntime = globalThis.__WWV_HOST__.jsxRuntime;
+                    export const jsx = jsxRuntime.jsx;
+                    export const jsxs = jsxRuntime.jsxs;
+                    export const Fragment = jsxRuntime.Fragment;
+                `;
+            }
+            if (originalId === "cesium") {
+                return `
+                    const Cesium = globalThis.__WWV_HOST__.Cesium;
+                    export default Cesium;
+                    // Export common bindings for direct destructuring
+                    export const { Viewer, Entity, Cartesian3, Cartesian2, Color, CallbackProperty, DistanceDisplayCondition, NearFarScalar, HeightReference, Resource, Rectangle, PolygonHierarchy, ClassificationType, ArcType, Math, JulianDate, TimeInterval, TimeIntervalCollection, SampledPositionProperty, GeoJsonDataSource, PinBuilder, CustomDataSource, ConstantProperty, ColorMaterialProperty, Cartographic } = Cesium;
+                `;
+            }
+            if (originalId === "resium") {
+                return `
+                    const Resium = globalThis.__WWV_HOST__.Resium;
+                    export default Resium;
+                    export const { Entity, PointGraphics, BillboardGraphics, CustomDataSource, Camera, PolygonGraphics, PolylineGraphics, EllipseGraphics, LabelGraphics, ModelGraphics, PathGraphics, BoxGraphics, GeoJsonDataSource, ScreenSpaceEventHandler, ScreenSpaceEvent } = Resium;
+                `;
+            }
+            if (originalId === "@worldwideview/wwv-plugin-sdk") {
+                return `
+                    const SDK = globalThis.__WWV_HOST__.WWVPluginSDK;
+                    export default SDK;
+                    export const { WorldPlugin, PluginManifest, createSvgIconUrl, DEFAULT_ICON_SIZE, dtProp, urlProp, imageProp, videoProp } = SDK;
+                `;
+            }
+            if (originalId === "zustand") {
+                return `
+                    if (!globalThis.__WWV_HOST__.zustand) {
+                        console.warn("zustand was not found on WWV_HOST");
+                    }
+                    const zustand = globalThis.__WWV_HOST__.zustand || {};
+                    export default zustand;
+                    export const { create, createStore, useStore } = zustand;
+                `;
+            }
+            if (originalId === "@/core/state/store") {
+                return `export const useStore = globalThis.__WWV_HOST__.useStore;`;
+            }
+            if (originalId === "@/core/plugins/PluginManager") {
+                return `export const pluginManager = globalThis.__WWV_HOST__.pluginManager;`;
+            }
+            if (originalId === "@/components/video/CameraStream") {
+                return `export const CameraStream = globalThis.__WWV_HOST__.CameraStream;`;
+            }
+            return null;
+        }
+    };
+}

--- a/src/app/api/marketplace/install-redirect/route.ts
+++ b/src/app/api/marketplace/install-redirect/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
         const rateLimited = installLimiter.check(getClientIp(request));
         if (rateLimited) return rateLimited;
 
-        // Auth: cloud edition uses Supabase session; local/demo uses NextAuth.
+        // Auth: cloud edition uses Supabase session; local/demo uses Better Auth.
         const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
         const isDummyUrl = !supabaseUrl || supabaseUrl.includes("dummy") || supabaseUrl.includes("xyz.supabase.co");
         const useSupabaseAuth = isCloud && !isDummyUrl;

--- a/src/app/setup/actions.ts
+++ b/src/app/setup/actions.ts
@@ -96,7 +96,7 @@ export async function createAdminAccount(formData: FormData): Promise<SetupResul
                 email,
                 name,
                 emailVerified: false,
-                role: isDemo ? "demo-admin" : "user",
+                role: isDemo ? "demo-admin" : "admin",
             },
         }),
         prisma.betterAuthAccount.create({

--- a/src/lib/auth/jwt-plugin.spec.ts
+++ b/src/lib/auth/jwt-plugin.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the JWKS contract this instance publishes for the data engine.
+ *
+ * The data engine verifies plugin tickets against the JWKS served at
+ * /api/ba/jwks (wwv-data-engine src/jwt-auth.ts uses createRemoteJWKSet with
+ * JWKS_URL). These tests pin the globe-side contract: the jwt plugin must
+ * register the JWKS + token endpoints and document the key-set response
+ * shape the engine's resolver consumes.
+ */
+import { describe, it, expect } from "vitest";
+import { jwtPlugin, JWT_PLUGIN_OPTIONS } from "./jwt-plugin";
+
+describe("JWT plugin JWKS contract (/api/ba/jwks)", () => {
+    it("registers the JWKS endpoint as a GET on /jwks", () => {
+        const endpoint = jwtPlugin.endpoints.getJwks as unknown as {
+            path: string;
+            options: { method: string };
+        };
+        expect(endpoint.path).toBe("/jwks");
+        expect(endpoint.options.method).toBe("GET");
+    });
+
+    it("registers the token endpoint as a GET on /token", () => {
+        const endpoint = jwtPlugin.endpoints.getToken as unknown as {
+            path: string;
+            options: { method: string };
+        };
+        expect(endpoint.path).toBe("/token");
+        expect(endpoint.options.method).toBe("GET");
+    });
+
+    it("maps JWKS storage to the pluginJwks model", () => {
+        expect(JWT_PLUGIN_OPTIONS.schema.jwks.modelName).toBe("pluginJwks");
+    });
+
+    it("documents the key-set response shape the data engine consumes", () => {
+        const endpoint = jwtPlugin.endpoints.getJwks as unknown as {
+            options: { metadata: unknown };
+        };
+        const metadata = JSON.stringify(endpoint.options.metadata);
+        expect(metadata).toContain("keys");
+        expect(metadata).toContain("kid");
+        expect(metadata).toContain("kty");
+        expect(metadata).toContain("alg");
+    });
+});

--- a/src/lib/auth/jwt-plugin.ts
+++ b/src/lib/auth/jwt-plugin.ts
@@ -1,0 +1,13 @@
+import { jwt } from "better-auth/plugins";
+
+/**
+ * Better Auth JWT plugin wiring — the JWKS this instance publishes at
+ * /api/ba/jwks is the trust anchor the data engine uses to verify plugin
+ * tickets (see wwv-data-engine src/jwt-auth.ts). Extracted so the
+ * contract is unit-testable and a regression fails loudly.
+ */
+export const JWT_PLUGIN_OPTIONS = {
+    schema: { jwks: { modelName: "pluginJwks" } },
+} as const;
+
+export const jwtPlugin = jwt(JWT_PLUGIN_OPTIONS);

--- a/src/lib/better-auth.ts
+++ b/src/lib/better-auth.ts
@@ -15,9 +15,10 @@ import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { prisma } from "@/lib/db";
 import { isLocal, isDemo } from "@/core/edition";
-import { organization, admin, jwt } from "better-auth/plugins";
+import { organization, admin } from "better-auth/plugins";
 import { oneTimeToken } from "better-auth/plugins/one-time-token";
 import { apiKey } from "@better-auth/api-key";
+import { jwtPlugin } from "@/lib/auth/jwt-plugin";
 import { evaluatePasswordStrength, MIN_PASSWORD_SCORE } from "@/lib/password-strength";
 
 /**
@@ -166,9 +167,7 @@ export const auth = betterAuth({
         admin(),
         // JWT + JWKS — token endpoint at /api/ba/token, JWKS at /api/ba/jwks.
         // The data engine fetches JWKS from this endpoint to verify plugin tickets.
-        jwt({
-            schema: { jwks: { modelName: "pluginJwks" } },
-        }),
+        jwtPlugin,
         // One-time tokens — replaces setup token flow from src/lib/auth/setupToken.ts.
         // Tokens expire after 1 hour by default.
         oneTimeToken({ expiresIn: 3600 }),

--- a/src/lib/ensureAdminSeeded.ts
+++ b/src/lib/ensureAdminSeeded.ts
@@ -2,6 +2,7 @@
 
 import { hashPassword } from "better-auth/crypto";
 import { prisma } from "@/lib/db";
+import { isDemo } from "@/core/edition";
 
 /**
  * Auto-seed the initial admin account from environment variables.
@@ -52,7 +53,7 @@ export async function ensureAdminSeeded(): Promise<{
                     email,
                     name: "Admin",
                     emailVerified: true,
-                    role: "demo-admin",
+                    role: isDemo ? "demo-admin" : "admin",
                 },
             }),
             prisma.betterAuthAccount.create({


### PR DESCRIPTION
## Summary

Completes the v3.3 Better Auth cleanup. Every June finding was re-verified against current code (origin/main 74cfbc23) — bugs 1-4 were already fixed by the migration work, so no changes were made where nothing was broken. Actual changes landed where gaps remained.

### Re-verified, no change needed (bugs 1-4)
1. **Revoke route** — already targets ''betterAuthSession'' + ''auth.api.signOut({ headers: request.headers })''; no legacy ''users''/''sessionVersion'' calls remain.
2. **Demo-admin check** — ''isDemoAdmin(session)'' is fed by Better Auth (''getServerSession()'' from ''@/lib/ba-session'', ''authClient.useSession()'' in the Header); no ''/api/auth/session'' fetch remains.
3. **Ghost-table prisma.user calls** — old NextAuth config is gone (no next-auth dep, no [...nextauth] route, no revalidateSession). One deliberate ''prisma.user'' call remains in the login-time legacy migration bridge (''src/lib/auth/migrate-legacy-user.ts'', tested) and is kept.
4. **Old auth.ts / NextAuth session endpoint** — already retired; all references are comments only.

### Fixes landed
- **Phase 74 role**: schema role column + ''additionalFields.role'' already existed; the real gap was ''setup/actions.ts'' seeding role ''user'' for local/cloud admins. Now ''isDemo ? "demo-admin" : "admin"''. Same class of bug fixed in ''ensureAdminSeeded.ts'' (auto-seed path).
- **JWKS contract test**: extracted the jwt plugin wiring to ''src/lib/auth/jwt-plugin.ts'' and pinned the ''/api/ba/jwks'' + ''/api/ba/token'' endpoint contract the data engine's ''createRemoteJWKSet'' consumes. (The data engine repo already has its own full JWKS verification E2E in ''websocket.spec.ts''.)
- **Build fix**: the tracked ''packages/wwv-plugin-sdk/dist/index.js'' requires ''./viteGlobals'' whose emitted files were never committed (hidden by ''packages/*/dist/'' gitignore) — fresh checkouts failed the test suite. Committed the missing artifacts.

### Not done (reported instead)
- **lib/supabase purge**: NOT deleted — ''src/lib/supabase/server.ts'' (getSupabaseUser) is live in ''src/app/api/marketplace/install-redirect/route.ts'' for cloud edition. Phase 75's premise (globe auth no longer uses Supabase) is only true for local/demo.

## Verification
- ''pnpm test'': 126 files / 1235 tests passed
- ''pnpm build'': success
- ''pnpm lint'': 0 errors (306 pre-existing warnings)