### PR TITLE
fix(data-query): engine URL resolution family (#387 #388 #396)

### DIFF
--- a/src/core/data/DataUtils.test.ts
+++ b/src/core/data/DataUtils.test.ts
@@ -37,13 +37,14 @@ describe("EngineManifest", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("should return null and cache failure if local engine is missing", async () => {
+  it("should return null and back off (not cache permanently) when local engine is missing", async () => {
     (global.fetch as any).mockRejectedValue(new Error("Connection refused"));
 
     const plugins = await fetchLocalEngineManifest();
     expect(plugins).toBeNull();
 
-    // Should not retry fetch
+    // Within the 30s backoff window the failure is served from memory, not
+    // re-fetched (fetch count stays 1) — but it is NOT cached permanently (#396).
     await fetchLocalEngineManifest();
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });

--- a/src/core/data/engineManifest.test.ts
+++ b/src/core/data/engineManifest.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+    fetchLocalEngineManifest,
+    localEngineHasPlugin,
+    resetManifestCache,
+    ENGINE_DISCOVERY_TIMEOUT_MS,
+    ENGINE_DISCOVERY_RETRY_MS,
+} from "./engineManifest";
+
+function okManifestResponse(plugins: string[]): Response {
+    return {
+        ok: true,
+        json: async () => ({ plugins }),
+    } as unknown as Response;
+}
+
+describe("fetchLocalEngineManifest", () => {
+    beforeEach(() => {
+        resetManifestCache();
+        global.fetch = vi.fn() as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        resetManifestCache();
+        vi.useRealTimers();
+    });
+
+    it("caches a successful discovery (fetch happens exactly once)", async () => {
+        vi.mocked(global.fetch).mockResolvedValue(okManifestResponse(["plugin-a"]));
+
+        expect(await fetchLocalEngineManifest()).toEqual(["plugin-a"]);
+        expect(localEngineHasPlugin("plugin-a")).toBe(true);
+        expect(localEngineHasPlugin("plugin-c")).toBe(false);
+
+        // Second call is served from cache.
+        expect(await fetchLocalEngineManifest()).toEqual(["plugin-a"]);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT cache a discovery failure permanently - re-tries after the backoff window (#396)", async () => {
+        vi.useFakeTimers();
+        vi.mocked(global.fetch).mockRejectedValue(new Error("connection refused"));
+
+        expect(await fetchLocalEngineManifest()).toBeNull();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        // Within the backoff window the failure is served from memory (no fetch).
+        expect(await fetchLocalEngineManifest()).toBeNull();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        // After the backoff window the next call attempts discovery again ...
+        vi.setSystemTime(Date.now() + ENGINE_DISCOVERY_RETRY_MS + 1);
+        vi.mocked(global.fetch).mockResolvedValue(okManifestResponse(["plugin-b"]));
+        expect(await fetchLocalEngineManifest()).toEqual(["plugin-b"]);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("raises the discovery timeout from 500ms to at least 2000ms by default (#396)", () => {
+        // 500ms caused the first-attempt timeout that got cached forever; the
+        // fix raises the default and makes it env-overridable.
+        expect(ENGINE_DISCOVERY_TIMEOUT_MS).toBeGreaterThanOrEqual(2000);
+    });
+});

--- a/src/core/data/engineManifest.ts
+++ b/src/core/data/engineManifest.ts
@@ -2,8 +2,14 @@
 // Fetches /manifest from a local data engine to discover available seeders.
 // Used by resolveEngineUrl for per-plugin local vs cloud routing.
 
+/** Abort timeout for a single manifest-discovery attempt (ms); env-overridable. */
+export const ENGINE_DISCOVERY_TIMEOUT_MS = Number(process.env.WWV_ENGINE_DISCOVERY_TIMEOUT_MS) || 2000;
+/** How long a failed discovery suppresses re-fetching (ms). Failures are NOT cached permanently. */
+export const ENGINE_DISCOVERY_RETRY_MS = 30_000;
+
 let localManifest: string[] | null = null;
 let manifestFetched = false;
+let lastFailureAt = 0;
 
 /**
  * Resolve the base URL of the local data engine.
@@ -23,40 +29,52 @@ function getLocalEngineBase() {
 
 /**
  * Fetch the list of available seeders from a local engine.
- * Returns null if no local engine is detected (timeout after 500ms).
+ * Returns null when no local engine is detected (request failure or an abort
+ * after ENGINE_DISCOVERY_TIMEOUT_MS).
  *
  * The engine guarantees manifest IDs are already in kebab-case (the seeder's
  * exported `name` field is the canonical plugin ID). No client-side translation
  * is needed — what the engine reports is what the frontend uses.
+ *
+ * Caching model: a SUCCESSFUL discovery is cached indefinitely, but a FAILED
+ * one is not — it backs off for ENGINE_DISCOVERY_RETRY_MS (30s) and the next
+ * call after that window tries discovery again. Previously the first 500ms
+ * timeout was cached as "no local engine" forever (until resetManifestCache()),
+ * permanently misrouting every plugin to the cloud engine.
  */
 export async function fetchLocalEngineManifest(): Promise<string[] | null> {
   if (manifestFetched) return localManifest;
-  manifestFetched = true;
+  // Backoff: serve the previous failure from memory (no network cost) only
+  // until the retry window elapses, then attempt discovery again.
+  if (lastFailureAt > 0 && Date.now() - lastFailureAt < ENGINE_DISCOVERY_RETRY_MS) {
+    return null;
+  }
 
   try {
     const controller = new AbortController();
-    // 500ms is more than enough for a localhost connection.
-    const timeout = setTimeout(() => controller.abort(), 500);
+    const timeout = setTimeout(() => controller.abort(), ENGINE_DISCOVERY_TIMEOUT_MS);
 
     const res = await fetch(`${getLocalEngineBase()}/manifest`, {
       signal: controller.signal,
     });
     clearTimeout(timeout);
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      lastFailureAt = Date.now();
+      return null;
+    }
 
     const data = await res.json();
     localManifest = data.plugins || [];
+    manifestFetched = true;
     console.log(
-      `[EngineManifest] Local engine detected: ${localManifest!.length} seeders`,
+      `[EngineManifest] Local engine detected: ${localManifest.length} seeders`,
       localManifest
     );
     return localManifest;
   } catch {
+    lastFailureAt = Date.now();
     console.log("[EngineManifest] No local engine detected, using cloud.");
-    // We intentionally leave manifestFetched = true here.
-    // This caches the failure so we don't incur this timeout penalty
-    // every single time a plugin is toggled.
     return null;
   }
 }
@@ -85,4 +103,5 @@ export function isPluginBlocklisted(pluginId: string): boolean {
 export function resetManifestCache(): void {
   localManifest = null;
   manifestFetched = false;
+  lastFailureAt = 0;
 }

--- a/src/core/data/engineManifest.ts
+++ b/src/core/data/engineManifest.ts
@@ -65,13 +65,14 @@ export async function fetchLocalEngineManifest(): Promise<string[] | null> {
     }
 
     const data = await res.json();
-    localManifest = data.plugins || [];
+    const plugins: string[] = data.plugins || [];
+    localManifest = plugins;
     manifestFetched = true;
     console.log(
-      `[EngineManifest] Local engine detected: ${localManifest.length} seeders`,
-      localManifest
+      `[EngineManifest] Local engine detected: ${plugins.length} seeders`,
+      plugins
     );
-    return localManifest;
+    return plugins;
   } catch {
     lastFailureAt = Date.now();
     console.log("[EngineManifest] No local engine detected, using cloud.");

--- a/src/lib/data-query/service.test.ts
+++ b/src/lib/data-query/service.test.ts
@@ -78,6 +78,7 @@ function mockEngine404(): void {
 describe("getEngineUrl", () => {
     const ORIGINAL_ENGINE_URL = process.env.WWV_DATA_ENGINE_URL;
     const ORIGINAL_ENGINE_PORT = process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+    const ORIGINAL_PUBLIC_ENGINE_URL = process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
 
     afterEach(() => {
         if (ORIGINAL_ENGINE_URL === undefined) {
@@ -90,22 +91,45 @@ describe("getEngineUrl", () => {
         } else {
             process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT = ORIGINAL_ENGINE_PORT;
         }
+        if (ORIGINAL_PUBLIC_ENGINE_URL === undefined) {
+            delete process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
+        } else {
+            process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL = ORIGINAL_PUBLIC_ENGINE_URL;
+        }
     });
 
-    it("returns localhost:5001 by default (no env vars set)", () => {
+    it("returns localhost:5000 by default (no env vars set)", () => {
         delete process.env.WWV_DATA_ENGINE_URL;
+        delete process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
         delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
-        expect(getEngineUrl()).toBe("http://localhost:5001");
+        expect(getEngineUrl()).toBe("http://localhost:5000");
     });
 
-    it("returns WWV_DATA_ENGINE_URL when set (overrides localhost default)", () => {
-        process.env.WWV_DATA_ENGINE_URL = "https://dataenginev2.worldwideview.dev";
+    it("returns WWV_DATA_ENGINE_URL when set (overrides all other sources)", () => {
+        process.env.WWV_DATA_ENGINE_URL = "https://dataenginev2.worldwideview.dev"; // lint-url: allow (test asserts env override wins)
+        process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL = "https://public-override.example";
         delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
         expect(getEngineUrl()).toBe("https://dataenginev2.worldwideview.dev"); // lint-url: allow (test assertion)
     });
 
-    it("uses NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT when WWV_DATA_ENGINE_URL is unset", () => {
+    it("returns NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL when WWV_DATA_ENGINE_URL is unset (#387)", () => {
         delete process.env.WWV_DATA_ENGINE_URL;
+        process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL = "https://dataengine.example.com";
+        delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+        expect(getEngineUrl()).toBe("https://dataengine.example.com");
+    });
+
+    it("normalizes the WS form (ws + /stream) of the public engine URL into a REST base (#387)", () => {
+        delete process.env.WWV_DATA_ENGINE_URL;
+        // This is exactly the shape .env.local ships for operator-run deployments.
+        process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL = "ws://localhost:5000/stream";
+        delete process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT;
+        expect(getEngineUrl()).toBe("http://localhost:5000");
+    });
+
+    it("uses NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT when no engine URL is configured", () => {
+        delete process.env.WWV_DATA_ENGINE_URL;
+        delete process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
         process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT = "5555";
         expect(getEngineUrl()).toBe("http://localhost:5555");
     });

--- a/src/lib/data-query/service.test.ts
+++ b/src/lib/data-query/service.test.ts
@@ -136,6 +136,55 @@ describe("getEngineUrl", () => {
 });
 
 // ---------------------------------------------------------------------------
+// fetchEngineSnapshot — engine snapshot shape normalization (#388)
+// ---------------------------------------------------------------------------
+
+describe("fetchEngineSnapshot shape normalization", () => {
+    function mockEngineResponse(body: unknown): void {
+        vi.mocked(global.fetch).mockResolvedValue(
+            new Response(JSON.stringify(body), { status: 200 }),
+        );
+    }
+
+    it("accepts an indexed map keyed by id without crashing", async () => {
+        mockEngineResponse({
+            "el-1": makeEntity({ id: "el-1", label: "Alpha", pluginId: "test-plugin" }),
+            "el-2": makeEntity({ id: "el-2", label: "Beta", pluginId: "test-plugin" }),
+        });
+        const snapshot = await fetchPluginSnapshot("test-plugin");
+        expect(snapshot?.entities).toHaveLength(2);
+        expect(snapshot?.entities.map((e) => e.id)).toEqual(["el-1", "el-2"]);
+    });
+
+    it("flattens a nested indexed map under items", async () => {
+        mockEngineResponse({
+            items: {
+                "el-1": makeEntity({ id: "el-1", label: "Gamma", pluginId: "test-plugin" }),
+            },
+        });
+        const snapshot = await fetchPluginSnapshot("test-plugin");
+        expect(snapshot?.entities).toHaveLength(1);
+        expect(snapshot?.entities[0]?.id).toBe("el-1");
+    });
+
+    it("accepts a data-array wrapper shape", async () => {
+        mockEngineResponse({
+            data: [makeEntity({ id: "el-9", label: "Delta", pluginId: "test-plugin" })],
+        });
+        const snapshot = await fetchPluginSnapshot("test-plugin");
+        expect(snapshot?.entities).toHaveLength(1);
+        expect(snapshot?.entities[0]?.id).toBe("el-9");
+    });
+
+    it("returns an empty snapshot instead of crashing on malformed payloads", async () => {
+        mockEngineResponse({ items: "not-an-array" });
+        const snapshot = await fetchPluginSnapshot("test-plugin");
+        expect(snapshot).not.toBeNull();
+        expect(snapshot?.entities).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // QUERY-01 — searchEntities
 // ---------------------------------------------------------------------------
 

--- a/src/lib/data-query/service.ts
+++ b/src/lib/data-query/service.ts
@@ -11,8 +11,36 @@ import { matchFilterValue } from "@/core/filters/matchFilterValue";
 import type { FilterValue } from "@/core/plugins/PluginTypes";
 import { hasLocalSource, resolveLocalSnapshot, getLocalSourceIds } from "./localSources";
 
+/**
+ * Normalize a configured engine base URL for HTTP (REST) usage.
+ * The WebSocket path suffix ("/stream") and ws(s):// scheme are the forms used
+ * by plugin routing (resolveEngineUrl.ts), but the engine's REST routes
+ * (/manifest, /api/:id) live at the root — a "/stream" suffix would 404 every
+ * snapshot request, so both are normalized away here.
+ */
+function normalizeEngineBaseUrl(raw: string): string {
+    const url = raw.trim().replace(/\/+$/, "");
+    const httpUrl = url.replace(/^wss:\/\//i, "https://").replace(/^ws:\/\//i, "http://");
+    if (httpUrl.endsWith("/stream")) return httpUrl.slice(0, -"/stream".length);
+    return httpUrl;
+}
+
+/**
+ * Resolve the data engine's REST base URL.
+ * Precedence:
+ *   1. WWV_DATA_ENGINE_URL — server-side explicit override.
+ *   2. NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL — public/operator override; the
+ *      same variable plugin routing uses as its global engine fallback.
+ *   3. Localhost on NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT — default 5000, the port
+ *      docker-compose.dev.yml binds for wwv-data-engine (HTTP and WS share it).
+ */
 export function getEngineUrl(): string {
-    return process.env.WWV_DATA_ENGINE_URL ?? `http://localhost:${process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT || '5001'}`;
+    const explicitUrl = process.env.WWV_DATA_ENGINE_URL;
+    if (explicitUrl) return normalizeEngineBaseUrl(explicitUrl);
+    const publicUrl = process.env.NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL;
+    if (publicUrl) return normalizeEngineBaseUrl(publicUrl);
+    const port = process.env.NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT || "5000";
+    return `http://localhost:${port}`;
 }
 
 function normalizeEntity(raw: unknown): GeoEntity | null {

--- a/src/lib/data-query/service.ts
+++ b/src/lib/data-query/service.ts
@@ -69,6 +69,36 @@ function validatePluginId(pluginId: string): string {
 }
 
 /**
+ * Normalize an engine snapshot payload into a flat list of entity records so
+ * callers can reduce/filter it safely regardless of shape:
+ *  - top-level array → as-is;
+ *  - wrapper object (`items`/`data`/`entities` array) → unwrapped (recursed one
+ *    level, so a wrapper containing an indexed map is fully flattened);
+ *  - indexed map keyed by id (`{ "<id>": entity }`) → Object.values;
+ *  - anything unrecognized → [] (defensive; never throws).
+ */
+function toEntityList(payload: unknown): unknown[] {
+    if (Array.isArray(payload)) return payload;
+    if (typeof payload !== "object" || payload === null) return [];
+
+    const obj = payload as Record<string, unknown>;
+    for (const key of ["items", "data", "entities"] as const) {
+        if (obj[key] !== undefined) {
+            return toEntityList(obj[key]);
+        }
+    }
+
+    // Indexed map: every value is itself an object (a scalar field soup is
+    // metadata, not an entity map). null values are tolerated — the reduce
+    // below filters them via normalizeEntity.
+    const values = Object.values(obj);
+    if (values.length > 0 && values.every((v) => typeof v === "object")) {
+        return values;
+    }
+    return [];
+}
+
+/**
  * Private helper: attempt to fetch a plugin snapshot from the data engine.
  * Returns null on 404, non-2xx, or network failure.
  * Validation of pluginId is the caller's responsibility.
@@ -84,8 +114,7 @@ async function fetchEngineSnapshot(safeId: string): Promise<PluginDataSnapshot |
             return null;
         }
         const data: unknown = await res.json();
-        const raw = Array.isArray(data) ? data : ((data as Record<string, unknown>)?.items ?? []) as unknown[];
-        const entities: GeoEntity[] = (raw as unknown[]).reduce<GeoEntity[]>((acc, item) => {
+        const entities: GeoEntity[] = toEntityList(data).reduce<GeoEntity[]>((acc, item) => {
             const entity = normalizeEntity(item);
             if (entity !== null) acc.push(entity);
             return acc;


### PR DESCRIPTION
## Summary

Fixes the engine-URL resolution bug family in one PR: data-query's engine base URL never honored the public engine URL (and probed the wrong port), engine snapshot payloads with indexed/nested shapes crashed the reduce, and a single 500ms engine-discovery timeout was cached as "no local engine" forever, permanently routing plugins to the cloud engine.

| Issue | Root cause (before) | Fix | Test |
|---|---|---|---|
| #387 | `getEngineUrl()` in `src/lib/data-query/service.ts` read only `WWV_DATA_ENGINE_URL`, ignoring the `NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL` operators set (`.env.local` ships it as `ws://localhost:5000/stream`), and defaulted the HTTP port to 5001 while the engine (HTTP + WS) listens on 5000 per `docker-compose.dev.yml` and the wwv-data-engine `port-contract.spec.ts`. MCP/v1 data-query probed a dead port and reported `plugin_not_streaming`. | Precedence: `WWV_DATA_ENGINE_URL` (server-side) > `NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL` (public, normalized from ws(s)+`/stream` form to the REST base) > `http://localhost:${NEXT_PUBLIC_WWV_LOCAL_ENGINE_PORT || 5000}`. | `service.test.ts`: default 5000, public-var precedence, WS-form normalization, server-side override wins, port env override (5 tests updated/added). |
| #388 | `fetchEngineSnapshot()` did `(data?.items ?? []).reduce(...)` — a `.reduce is not a function` crash on indexed maps (`{ "id": entity }`) and nested wrappers (`{ items: { "id": entity } }`); `{ data: [...] }` wrappers were silently dropped. | New `toEntityList()` normalizer flattens top-level arrays, `items`/`data`/`entities` wrappers (recurse one level), and id-keyed maps before the reduce; unrecognized payloads return `[]` so a malformed response degrades to an empty snapshot, never a crash. | `service.test.ts`: indexed map, nested indexed map under `items`, `data`-array wrapper, malformed `items` string (4 new tests). |
| #396 | `fetchLocalEngineManifest()` set `manifestFetched = true` before the attempt and cached the first failure — a 500ms timeout became a permanent "no local engine" cache, misrouting every plugin to cloud with a misleading log, until `resetManifestCache()`. | Success is cached indefinitely; a failure backs off for `ENGINE_DISCOVERY_RETRY_MS` (30s) and is re-attempted on the next call. Probe timeout raised 500ms → 2s default, env-overridable via `WWV_ENGINE_DISCOVERY_TIMEOUT_MS`. | `engineManifest.test.ts` (new): success caches (fetch once), first failure does not stick (re-tries after backoff), timeout default >= 2000ms. `DataUtils.test.ts` stale "cache failure" test retitled to backoff semantics. |

## Gates

- `pnpm test`: **127 test files, 1244 tests, 0 failures** (fresh-worktree env gaps — missing Prisma client + unbuilt `wwv-plugin-sdk` dist — were bootstrapped via `npx prisma generate` + sdk build; the `better-auth.test.ts` timeout was a cold-import flake, passes standalone).
- `pnpm build`: `next build --webpack` completed (exit 0, full route tree emitted).
- `pnpm lint`: **0 errors** (306 pre-existing warnings, all in untouched files; scoped eslint on changed files is clean).

## Notes

- Pact churn: `pacts/WorldWideView-WWVDataEngine.json` was rewritten by a test run (pact-js V3→V4 upgrade) and **reverted**; not committed.
- Related chore #418 (7 hardcoded 5000/5001 URLs): the two references in files touched here were fixed (service.ts 5001 default, service.test.ts 5001 assertions). The `DeclarativePlugin.test.ts` `localhost:5001` fixture is a host-injection mock ("arbitrary for this test"), not a real engine URL, and was left alone.
- No semver bump: recent origin/main commits do not bump `package.json` version, so none was added.

Closes #387, Closes #388, Closes #396