### PR TITLE
feat(alerts): alert/conditions API core (rules, evaluator, API)

### DIFF
--- a/packages/wwv-plugin-sdk/src/index.ts
+++ b/packages/wwv-plugin-sdk/src/index.ts
@@ -242,6 +242,45 @@ export type FilterValue =
     | { type: "range"; min: number; max: number }
     | { type: "boolean"; value: boolean };
 
+// ─── Alert Definitions ──────────────────────────────────────
+export type AlertFieldType = "number" | "string" | "boolean";
+
+export type AlertOperator =
+    | "gt"
+    | "lt"
+    | "gte"
+    | "lte"
+    | "eq"
+    | "neq"
+    | "contains"
+    | "exists";
+
+/** A field a plugin exposes to the alert-condition builder (P2, app-side rules). */
+export interface AlertFieldDefinition {
+    /** Key resolved against `entity.properties` first, then the entity top level (mirrors FilterDefinition.propertyKey). */
+    key: string;
+    /** Human-readable label shown in the condition builder. */
+    label: string;
+    type: AlertFieldType;
+    /** Operators allowed for this field. Defaults to all when omitted. */
+    operators?: AlertOperator[];
+}
+
+/** Single-condition shape used by rules (v1 keeps ONE condition per rule). */
+export interface AlertCondition {
+    field: string;
+    op: AlertOperator;
+    value?: unknown;
+}
+
+/** Client-safe snapshot of a persisted rule, carried by the `alertFired` bus event. */
+export interface AlertRuleSnapshot {
+    id: string;
+    name: string;
+    pluginId: string;
+    condition: AlertCondition;
+}
+
 /**
  * @interface WorldPlugin
  * @description The core lifecycle interface for all WorldWideView extensions.
@@ -271,6 +310,8 @@ export interface WorldPlugin {
     getSelectionBehavior?(entity: GeoEntity): SelectionBehavior | null;
     getServerConfig?(): ServerPluginConfig;
     getFilterDefinitions?(): FilterDefinition[];
+    /** Declares fields the plugin exposes to the alert-condition builder. Omit for no alertable fields. */
+    getAlertDefinitions?(): AlertFieldDefinition[];
     getLegend?(): { label: string; color: string; filterId?: string; filterValue?: string }[];
     getSidebarComponent?(): ComponentType<{ plugin?: any } | any>;
     getDetailComponent?(): ComponentType<{ entity: GeoEntity }>;
@@ -319,6 +360,7 @@ export type DataBusEvents = {
     globeReady: Record<string, never>;
     pluginError: { pluginId?: string; message: string; error?: Error };
     layerLoadingChanged: { pluginId: string; loading: boolean };
+    alertFired: { rule: AlertRuleSnapshot; entity: GeoEntity; pluginId: string };
 };
 
 export * from "./viteGlobals";

--- a/prisma/migrations/20260826000000_add_alert_rules/migration.sql
+++ b/prisma/migrations/20260826000000_add_alert_rules/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "alert_rules" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "pluginId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "condition" JSONB NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "alert_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "alert_events" (
+    "id" TEXT NOT NULL,
+    "ruleId" TEXT NOT NULL,
+    "pluginId" TEXT NOT NULL,
+    "entityId" TEXT,
+    "summary" TEXT NOT NULL,
+    "matchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "alert_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "alert_rules_userId_idx" ON "alert_rules"("userId");
+
+-- CreateIndex
+CREATE INDEX "alert_events_ruleId_idx" ON "alert_events"("ruleId");
+
+-- AddForeignKey
+ALTER TABLE "alert_rules" ADD CONSTRAINT "alert_rules_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alert_events" ADD CONSTRAINT "alert_events_ruleId_fkey" FOREIGN KEY ("ruleId") REFERENCES "alert_rules"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model BetterAuthUser {
   memberships   WorkspaceMember[]
   apiKeys       UserApiKey[]
   setupTokens   SetupToken[]
+  alertRules    AlertRule[]
 
   @@map("user")
 }
@@ -303,4 +304,37 @@ model SetupToken {
   @@index([tokenHash])
   @@index([userId])
   @@map("setup_tokens")
+}
+
+// -----------------------------------------------------------------------
+// Alerts (P2, app-side rules — see .planning, never committed)
+// -----------------------------------------------------------------------
+
+model AlertRule {
+  id        String   @id @default(cuid())
+  userId    String
+  pluginId  String
+  name      String
+  condition Json
+  enabled   Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      BetterAuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  events    AlertEvent[]
+
+  @@index([userId])
+  @@map("alert_rules")
+}
+
+model AlertEvent {
+  id        String    @id @default(cuid())
+  ruleId    String
+  pluginId  String
+  entityId  String?
+  summary   String
+  matchedAt DateTime  @default(now())
+  rule      AlertRule @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+
+  @@index([ruleId])
+  @@map("alert_events")
 }

--- a/src/app/api/alerts/[id]/route.test.ts
+++ b/src/app/api/alerts/[id]/route.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BetterAuthSession } from "@/lib/ba-session";
+import { DELETE, PATCH } from "./route";
+import { getServerSession } from "@/lib/ba-session";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/lib/ba-session", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/lib/ba-session")>();
+    return { ...actual, getServerSession: vi.fn() };
+});
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        alertRule: {
+            findMany: vi.fn(),
+            create: vi.fn(),
+            updateMany: vi.fn(),
+            findFirst: vi.fn(),
+            deleteMany: vi.fn(),
+        },
+        alertEvent: {
+            findFirst: vi.fn(),
+            create: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/core/edition", () => ({
+    isDemo: false,
+}));
+
+const mockAuth = vi.mocked(getServerSession);
+
+function ruleRow(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "rule-1",
+        pluginId: "earthquakes",
+        name: "Big quake",
+        condition: { field: "magnitude", op: "gt", value: 5 },
+        enabled: true,
+        createdAt: new Date("2026-08-26T00:00:00Z"),
+        updatedAt: new Date("2026-08-26T00:00:00Z"),
+        ...overrides,
+    };
+}
+
+function requestWith(body: unknown): Request {
+    return new Request("http://localhost/api/alerts/rule-1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+const params = Promise.resolve({ id: "rule-1" });
+
+describe("PATCH /api/alerts/[id]", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockAuth.mockResolvedValue({
+            user: { id: "user-123", email: "test@example.com" },
+        } as BetterAuthSession);
+    });
+
+    it("returns 401 when no session", async () => {
+        mockAuth.mockResolvedValue(null);
+        const res = await PATCH(requestWith({ enabled: false }), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it("enables/disables own rule", async () => {
+        vi.mocked(prisma.alertRule.updateMany).mockResolvedValue({ count: 1 } as never);
+        vi.mocked(prisma.alertRule.findFirst).mockResolvedValue(ruleRow({ enabled: false }) as never);
+
+        const res = await PATCH(requestWith({ enabled: false }), { params });
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.rule.enabled).toBe(false);
+        expect(prisma.alertRule.updateMany).toHaveBeenCalledWith({
+            where: { id: "rule-1", userId: "user-123" },
+            data: { enabled: false },
+        });
+    });
+
+    it("updates name and condition together", async () => {
+        vi.mocked(prisma.alertRule.updateMany).mockResolvedValue({ count: 1 } as never);
+        vi.mocked(prisma.alertRule.findFirst).mockResolvedValue(ruleRow({
+            name: "Renamed",
+            condition: { field: "place", op: "exists" },
+        }) as never);
+
+        const res = await PATCH(requestWith({
+            name: "Renamed",
+            condition: { field: "place", op: "exists" },
+        }), { params });
+
+        expect(res.status).toBe(200);
+        expect(prisma.alertRule.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ name: "Renamed" }),
+            }),
+        );
+    });
+
+    it("returns 404 for a foreign/missing rule", async () => {
+        vi.mocked(prisma.alertRule.updateMany).mockResolvedValue({ count: 0 } as never);
+        const res = await PATCH(requestWith({ enabled: true }), { params });
+        const body = await res.json();
+        expect(res.status).toBe(404);
+        expect(body.error).toBe("not_found");
+    });
+
+    it("rejects non-boolean enabled", async () => {
+        const res = await PATCH(requestWith({ enabled: "yes" }), { params });
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_enabled");
+        expect(prisma.alertRule.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid condition", async () => {
+        const res = await PATCH(requestWith({ condition: { field: "x", op: "bogus" } }), { params });
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_condition");
+    });
+
+    it("rejects an empty update body", async () => {
+        const res = await PATCH(requestWith({}), { params });
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("empty_update");
+    });
+
+    it("returns 404 when the row vanishes after update (concurrent delete)", async () => {
+        vi.mocked(prisma.alertRule.updateMany).mockResolvedValue({ count: 1 } as never);
+        vi.mocked(prisma.alertRule.findFirst).mockResolvedValue(null as never);
+        const res = await PATCH(requestWith({ enabled: false }), { params });
+        expect(res.status).toBe(404);
+    });
+});
+
+describe("DELETE /api/alerts/[id]", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockAuth.mockResolvedValue({
+            user: { id: "user-123", email: "test@example.com" },
+        } as BetterAuthSession);
+    });
+
+    it("returns 401 when no session", async () => {
+        mockAuth.mockResolvedValue(null);
+        const res = await DELETE(new Request("http://localhost/api/alerts/rule-1", { method: "DELETE" }), { params });
+        expect(res.status).toBe(401);
+    });
+
+    it("deletes own rule", async () => {
+        vi.mocked(prisma.alertRule.deleteMany).mockResolvedValue({ count: 1 } as never);
+        const res = await DELETE(new Request("http://localhost/api/alerts/rule-1", { method: "DELETE" }), { params });
+        const body = await res.json();
+        expect(res.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(prisma.alertRule.deleteMany).toHaveBeenCalledWith({
+            where: { id: "rule-1", userId: "user-123" },
+        });
+    });
+
+    it("returns 404 for a foreign/missing rule", async () => {
+        vi.mocked(prisma.alertRule.deleteMany).mockResolvedValue({ count: 0 } as never);
+        const res = await DELETE(new Request("http://localhost/api/alerts/rule-1", { method: "DELETE" }), { params });
+        const body = await res.json();
+        expect(res.status).toBe(404);
+        expect(body.error).toBe("not_found");
+    });
+});

--- a/src/app/api/alerts/[id]/route.ts
+++ b/src/app/api/alerts/[id]/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server";
+import type { Prisma } from "@/generated/prisma";
+import { getServerSession, requireSession } from "@/lib/ba-session";
+import { prisma } from "@/lib/db";
+import { isDemo } from "@/core/edition";
+import { validateCondition, validateRuleName } from "@/lib/alerts/validation";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/alerts/[id] — update own rule (enable/disable, rename, condition)
+// ---------------------------------------------------------------------------
+
+export async function PATCH(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    if (isDemo) {
+        return NextResponse.json({ error: "Not available in demo edition" }, { status: 403 });
+    }
+
+    const auth = requireSession(await getServerSession());
+    if (auth instanceof NextResponse) return auth;
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const data: Prisma.AlertRuleUpdateManyMutationInput = {};
+
+    if ("enabled" in body) {
+        if (typeof body.enabled !== "boolean") {
+            return NextResponse.json(
+                { error: "invalid_enabled", message: "enabled must be a boolean" },
+                { status: 422 },
+            );
+        }
+        data.enabled = body.enabled;
+    }
+    if ("name" in body) {
+        const nameError = validateRuleName(body.name);
+        if (nameError) {
+            return NextResponse.json({ error: "invalid_name", message: nameError }, { status: 422 });
+        }
+        data.name = (body.name as string).trim();
+    }
+    if ("condition" in body) {
+        const conditionError = validateCondition(body.condition);
+        if (conditionError) {
+            return NextResponse.json(
+                { error: "invalid_condition", message: conditionError },
+                { status: 422 },
+            );
+        }
+        data.condition = body.condition as Prisma.InputJsonValue;
+    }
+
+    if (Object.keys(data).length === 0) {
+        return NextResponse.json(
+            { error: "empty_update", message: "Provide at least one of enabled, name, condition" },
+            { status: 422 },
+        );
+    }
+
+    try {
+        // Ownership-scoped updateMany — a foreign id yields count 0 (404), no TOCTOU.
+        const updated = await prisma.alertRule.updateMany({
+            where: { id, userId: auth.userId },
+            data,
+        });
+        if (updated.count === 0) {
+            return NextResponse.json({ error: "not_found" }, { status: 404 });
+        }
+
+        const row = await prisma.alertRule.findFirst({
+            where: { id, userId: auth.userId },
+        });
+        if (!row) {
+            // Row vanished between update and read (concurrent delete).
+            return NextResponse.json({ error: "not_found" }, { status: 404 });
+        }
+        return NextResponse.json({
+            rule: {
+                id: row.id,
+                pluginId: row.pluginId,
+                name: row.name,
+                condition: row.condition,
+                enabled: row.enabled,
+                createdAt: row.createdAt,
+                updatedAt: row.updatedAt,
+            },
+        });
+    } catch (err) {
+        console.error("[alerts] PATCH error:", err);
+        return NextResponse.json({ error: "Failed to update alert rule" }, { status: 500 });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/alerts/[id] — remove own rule (cascades to its events)
+// ---------------------------------------------------------------------------
+
+export async function DELETE(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    if (isDemo) {
+        return NextResponse.json({ error: "Not available in demo edition" }, { status: 403 });
+    }
+
+    const auth = requireSession(await getServerSession());
+    if (auth instanceof NextResponse) return auth;
+
+    try {
+        const deleted = await prisma.alertRule.deleteMany({
+            where: { id, userId: auth.userId },
+        });
+        if (deleted.count === 0) {
+            return NextResponse.json({ error: "not_found" }, { status: 404 });
+        }
+        return NextResponse.json({ success: true });
+    } catch (err) {
+        console.error("[alerts] DELETE error:", err);
+        return NextResponse.json({ error: "Failed to delete alert rule" }, { status: 500 });
+    }
+}
+
+export const runtime = "nodejs";

--- a/src/app/api/alerts/events/route.test.ts
+++ b/src/app/api/alerts/events/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BetterAuthSession } from "@/lib/ba-session";
+import { POST, DEDUPE_WINDOW_MS } from "./route";
+import { getServerSession } from "@/lib/ba-session";
+import { prisma } from "@/lib/db";
+
+vi.mock("@/lib/ba-session", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/lib/ba-session")>();
+    return { ...actual, getServerSession: vi.fn() };
+});
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        alertRule: {
+            findMany: vi.fn(),
+            create: vi.fn(),
+            updateMany: vi.fn(),
+            findFirst: vi.fn(),
+            deleteMany: vi.fn(),
+        },
+        alertEvent: {
+            findFirst: vi.fn(),
+            create: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/core/edition", () => ({
+    isDemo: false,
+}));
+
+const mockAuth = vi.mocked(getServerSession);
+
+function eventRequest(body: unknown): Request {
+    return new Request("http://localhost/api/alerts/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+const validBody = {
+    ruleId: "rule-1",
+    pluginId: "earthquakes",
+    entityId: "eq-42",
+    summary: "Big quake matched earthquakes entity eq-42",
+};
+
+describe("POST /api/alerts/events", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockAuth.mockResolvedValue({
+            user: { id: "user-123", email: "test@example.com" },
+        } as BetterAuthSession);
+    });
+
+    it("returns 401 when no session", async () => {
+        mockAuth.mockResolvedValue(null);
+        const res = await POST(eventRequest(validBody));
+        expect(res.status).toBe(401);
+    });
+
+    it("rejects a missing summary", async () => {
+        const res = await POST(eventRequest({ ...validBody, summary: "" }));
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_summary");
+    });
+
+    it("returns 404 when the rule does not belong to the user (BOLA guard)", async () => {
+        vi.mocked(prisma.alertRule.findFirst).mockResolvedValue(null as never);
+        const res = await POST(eventRequest(validBody));
+        const body = await res.json();
+        expect(res.status).toBe(404);
+        expect(body.error).toBe("not_found");
+        expect(prisma.alertEvent.create).not.toHaveBeenCalled();
+    });
+
+    it("persists an event for an owned rule", async () => {
+        vi.mocked(prisma.alertRule.findFirst).mockResolvedValue({ id: "rule-1" } as never);
+        vi.mocked(prisma.alertEvent.findFirst).mockResolvedValue(null as never);
+        vi.mocked(prisma.alertEvent.create).mockResolvedValue({
+            id: "evt-1",
+            ruleId: "rule-1",
+            pluginId: "earthquakes",
+            matchedAt: new Date(),
+        } as never);
+
+        const res = await POST(eventRequest(validBody));
+        const body = await res.json();
+
+        expect(res.status).toBe(201);
+        expect(body.event.id).toBe("evt-1");
+        expect(prisma.alertEvent.create).toHaveBeenCalledWith({
+            data: {
+                ruleId: "rule-1",
+                pluginId: "earthquakes",
+                entityId: "eq-42",
+                summary: validBody.summary,
+            },
+        });
+    });
+
+    it("dedupes the same rule+entity fired within the 60s window", async () => {
+        vi.mocked(prisma.alertRule.findFirst).mockResolvedValue({ id: "rule-1" } as never);
+        vi.mocked(prisma.alertEvent.findFirst).mockResolvedValue({ id: "evt-1" } as never);
+
+        const res = await POST(eventRequest(validBody));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.deduped).toBe(true);
+        expect(prisma.alertEvent.create).not.toHaveBeenCalled();
+        expect(prisma.alertEvent.findFirst).toHaveBeenCalledWith({
+            where: {
+                ruleId: "rule-1",
+                entityId: "eq-42",
+                matchedAt: { gte: expect.any(Date) },
+            },
+            select: { id: true },
+        });
+    });
+
+    it("declares a 60s dedupe window", () => {
+        expect(DEDUPE_WINDOW_MS).toBe(60_000);
+    });
+});

--- a/src/app/api/alerts/events/route.ts
+++ b/src/app/api/alerts/events/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { getServerSession, requireSession } from "@/lib/ba-session";
+import { prisma } from "@/lib/db";
+import { isDemo } from "@/core/edition";
+import { MAX_SUMMARY_LENGTH, PLUGIN_ID_RE } from "@/lib/alerts/validation";
+
+export const DEDUPE_WINDOW_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// POST /api/alerts/events — persist a fired alert (fire-and-forget from the
+// client alert engine; dedupes same rule+entity within 60s).
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request) {
+    if (isDemo) {
+        return NextResponse.json({ error: "Not available in demo edition" }, { status: 403 });
+    }
+
+    const auth = requireSession(await getServerSession());
+    if (auth instanceof NextResponse) return auth;
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+
+    if (typeof body.ruleId !== "string" || body.ruleId.trim() === "") {
+        return NextResponse.json({ error: "invalid_rule", message: "ruleId is required" }, { status: 422 });
+    }
+    if (typeof body.pluginId !== "string" || !PLUGIN_ID_RE.test(body.pluginId)) {
+        return NextResponse.json({ error: "invalid_plugin", message: "pluginId is invalid" }, { status: 422 });
+    }
+    if (typeof body.summary !== "string" || body.summary.trim() === "") {
+        return NextResponse.json({ error: "invalid_summary", message: "summary is required" }, { status: 422 });
+    }
+    if (body.summary.length > MAX_SUMMARY_LENGTH) {
+        return NextResponse.json(
+            { error: "invalid_summary", message: `summary must be ${MAX_SUMMARY_LENGTH} characters or fewer` },
+            { status: 422 },
+        );
+    }
+    const entityId = typeof body.entityId === "string" && body.entityId !== ""
+        ? body.entityId
+        : null;
+
+    try {
+        // The rule must exist and belong to this user (BOLA guard).
+        const rule = await prisma.alertRule.findFirst({
+            where: { id: body.ruleId, userId: auth.userId },
+            select: { id: true },
+        });
+        if (!rule) {
+            return NextResponse.json({ error: "not_found" }, { status: 404 });
+        }
+
+        // Idempotency: skip when the same rule+entity already fired within the window.
+        const recent = await prisma.alertEvent.findFirst({
+            where: {
+                ruleId: body.ruleId,
+                entityId,
+                matchedAt: { gte: new Date(Date.now() - DEDUPE_WINDOW_MS) },
+            },
+            select: { id: true },
+        });
+        if (recent) {
+            return NextResponse.json({ deduped: true });
+        }
+
+        const event = await prisma.alertEvent.create({
+            data: {
+                ruleId: body.ruleId,
+                pluginId: body.pluginId,
+                entityId,
+                summary: body.summary,
+            },
+        });
+        return NextResponse.json({
+            event: { id: event.id, ruleId: event.ruleId, pluginId: event.pluginId, matchedAt: event.matchedAt },
+        }, { status: 201 });
+    } catch (err) {
+        console.error("[alerts] events POST error:", err);
+        return NextResponse.json({ error: "Failed to persist alert event" }, { status: 500 });
+    }
+}
+
+export const runtime = "nodejs";

--- a/src/app/api/alerts/route.test.ts
+++ b/src/app/api/alerts/route.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BetterAuthSession } from "@/lib/ba-session";
+import { GET, POST } from "./route";
+import { getServerSession } from "@/lib/ba-session";
+import { prisma } from "@/lib/db";
+import { isKnownPluginId } from "@/lib/alerts/knownPlugins";
+
+// Keep the real requireSession/NextResponse, stub only the session source.
+vi.mock("@/lib/ba-session", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/lib/ba-session")>();
+    return { ...actual, getServerSession: vi.fn() };
+});
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        alertRule: {
+            findMany: vi.fn(),
+            create: vi.fn(),
+            updateMany: vi.fn(),
+            findFirst: vi.fn(),
+            deleteMany: vi.fn(),
+        },
+        alertEvent: {
+            findFirst: vi.fn(),
+            create: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/core/edition", () => ({
+    isDemo: false,
+}));
+
+vi.mock("@/lib/alerts/knownPlugins", () => ({
+    isKnownPluginId: vi.fn(),
+    getKnownPluginIds: vi.fn(),
+}));
+
+const mockAuth = vi.mocked(getServerSession);
+const mockKnown = vi.mocked(isKnownPluginId);
+
+function ruleRow(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "rule-1",
+        pluginId: "earthquakes",
+        name: "Big quake",
+        condition: { field: "magnitude", op: "gt", value: 5 },
+        enabled: true,
+        createdAt: new Date("2026-08-26T00:00:00Z"),
+        updatedAt: new Date("2026-08-26T00:00:00Z"),
+        ...overrides,
+    };
+}
+
+describe("GET /api/alerts", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockAuth.mockResolvedValue({
+            user: { id: "user-123", email: "test@example.com" },
+        } as BetterAuthSession);
+    });
+
+    it("returns 401 when no session", async () => {
+        mockAuth.mockResolvedValue(null);
+        const res = await GET();
+        expect(res.status).toBe(401);
+    });
+
+    it("lists only the current user's rules, newest first", async () => {
+        const rows = [ruleRow({ id: "rule-new" }), ruleRow({ id: "rule-old" })];
+        vi.mocked(prisma.alertRule.findMany).mockResolvedValue(rows as never);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.rules).toHaveLength(2);
+        expect(prisma.alertRule.findMany).toHaveBeenCalledWith({
+            where: { userId: "user-123" },
+            orderBy: { createdAt: "desc" },
+        });
+    });
+
+    it("never leaks the userId field in the response", async () => {
+        vi.mocked(prisma.alertRule.findMany).mockResolvedValue([
+            { ...ruleRow(), userId: "user-123" } as never,
+        ]);
+        const res = await GET();
+        const body = await res.json();
+        expect(body.rules[0]).not.toHaveProperty("userId");
+    });
+});
+
+describe("POST /api/alerts", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        mockAuth.mockResolvedValue({
+            user: { id: "user-123", email: "test@example.com" },
+        } as BetterAuthSession);
+        mockKnown.mockResolvedValue(true);
+    });
+
+    it("returns 401 when no session", async () => {
+        mockAuth.mockResolvedValue(null);
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pluginId: "earthquakes", name: "R", condition: { field: "x", op: "exists" } }),
+        }));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 201 and persists the rule for the authenticated user", async () => {
+        vi.mocked(prisma.alertRule.create).mockResolvedValue(ruleRow() as never);
+
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                pluginId: "earthquakes",
+                name: "Big quake",
+                condition: { field: "magnitude", op: "gt", value: 5 },
+            }),
+        }));
+        const body = await res.json();
+
+        expect(res.status).toBe(201);
+        expect(body.rule.name).toBe("Big quake");
+        expect(prisma.alertRule.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ userId: "user-123", pluginId: "earthquakes" }),
+            }),
+        );
+    });
+
+    it("rejects a pluginId whose format is invalid", async () => {
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                pluginId: "../../etc",
+                name: "R",
+                condition: { field: "x", op: "exists" },
+            }),
+        }));
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_plugin");
+        expect(prisma.alertRule.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a pluginId that is not a known channel", async () => {
+        mockKnown.mockResolvedValue(false);
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                pluginId: "made-up-channel",
+                name: "R",
+                condition: { field: "x", op: "exists" },
+            }),
+        }));
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("unknown_plugin");
+    });
+
+    it("rejects a blank name", async () => {
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pluginId: "earthquakes", name: "   ", condition: { field: "x", op: "exists" } }),
+        }));
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_name");
+    });
+
+    it("rejects a condition with an unknown operator", async () => {
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                pluginId: "earthquakes",
+                name: "R",
+                condition: { field: "mag", op: "is_near" },
+            }),
+        }));
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_condition");
+    });
+
+    it("rejects a gt condition without a value", async () => {
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pluginId: "earthquakes", name: "R", condition: { field: "mag", op: "gt" } }),
+        }));
+        const body = await res.json();
+        expect(res.status).toBe(422);
+        expect(body.error).toBe("invalid_condition");
+    });
+
+    it("accepts an exists condition without a value", async () => {
+        vi.mocked(prisma.alertRule.create).mockResolvedValue(ruleRow({
+            condition: { field: "place", op: "exists" },
+        }) as never);
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pluginId: "earthquakes", name: "R", condition: { field: "place", op: "exists" } }),
+        }));
+        expect(res.status).toBe(201);
+    });
+
+    it("returns 500 when persistence fails", async () => {
+        vi.mocked(prisma.alertRule.create).mockRejectedValue(new Error("db down"));
+        const res = await POST(new Request("http://localhost/api/alerts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pluginId: "earthquakes", name: "R", condition: { field: "x", op: "exists" } }),
+        }));
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import type { AlertCondition } from "@worldwideview/wwv-plugin-sdk";
+import type { Prisma } from "@/generated/prisma";
+import { getServerSession, requireSession } from "@/lib/ba-session";
+import { prisma } from "@/lib/db";
+import { isDemo } from "@/core/edition";
+import { isKnownPluginId } from "@/lib/alerts/knownPlugins";
+import { PLUGIN_ID_RE, validateCondition, validateRuleName } from "@/lib/alerts/validation";
+
+interface RuleRecord {
+    id: string;
+    pluginId: string;
+    name: string;
+    condition: AlertCondition;
+    enabled: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+function toRuleRecord(row: {
+    id: string;
+    pluginId: string;
+    name: string;
+    enabled: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    condition: unknown;
+}): RuleRecord {
+    return {
+        id: row.id,
+        pluginId: row.pluginId,
+        name: row.name,
+        condition: row.condition as AlertCondition,
+        enabled: row.enabled,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/alerts — list the current user's rules, newest first
+// ---------------------------------------------------------------------------
+
+export async function GET() {
+    if (isDemo) {
+        return NextResponse.json({ error: "Not available in demo edition" }, { status: 403 });
+    }
+
+    const auth = requireSession(await getServerSession());
+    if (auth instanceof NextResponse) return auth;
+
+    try {
+        const rows = await prisma.alertRule.findMany({
+            where: { userId: auth.userId },
+            orderBy: { createdAt: "desc" },
+        });
+        return NextResponse.json({ rules: rows.map(toRuleRecord) });
+    } catch (err) {
+        console.error("[alerts] GET error:", err);
+        return NextResponse.json({ error: "Failed to fetch alert rules" }, { status: 500 });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/alerts — create a rule
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request) {
+    if (isDemo) {
+        return NextResponse.json({ error: "Not available in demo edition" }, { status: 403 });
+    }
+
+    const auth = requireSession(await getServerSession());
+    if (auth instanceof NextResponse) return auth;
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+
+    if (typeof body.pluginId !== "string" || !PLUGIN_ID_RE.test(body.pluginId)) {
+        return NextResponse.json(
+            { error: "invalid_plugin", message: "pluginId must be a valid plugin channel id" },
+            { status: 422 },
+        );
+    }
+
+    const nameError = validateRuleName(body.name);
+    if (nameError) {
+        return NextResponse.json({ error: "invalid_name", message: nameError }, { status: 422 });
+    }
+
+    const conditionError = validateCondition(body.condition);
+    if (conditionError) {
+        return NextResponse.json(
+            { error: "invalid_condition", message: conditionError },
+            { status: 422 },
+        );
+    }
+
+    try {
+        if (!(await isKnownPluginId(body.pluginId))) {
+            return NextResponse.json(
+                { error: "unknown_plugin", message: `No known channel named "${body.pluginId}"` },
+                { status: 422 },
+            );
+        }
+    } catch {
+        return NextResponse.json(
+            { error: "unknown_plugin", message: "Could not verify plugin channel" },
+            { status: 422 },
+        );
+    }
+
+    try {
+        const created = await prisma.alertRule.create({
+            data: {
+                userId: auth.userId,
+                pluginId: body.pluginId,
+                name: (body.name as string).trim(),
+                condition: body.condition as Prisma.InputJsonValue,
+            },
+        });
+        return NextResponse.json({ rule: toRuleRecord(created) }, { status: 201 });
+    } catch (err) {
+        console.error("[alerts] POST error:", err);
+        return NextResponse.json({ error: "Failed to create alert rule" }, { status: 500 });
+    }
+}
+
+export const runtime = "nodejs";

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -21,6 +21,7 @@ import { pluginRegistry } from "@/core/plugins/PluginRegistry";
 
 import { useStore } from "@/core/state/store";
 import { dataBus } from "@/core/data/DataBus";
+import { useAlertEngine } from "@/lib/alerts/engine";
 import { PanelToggleArrows } from "@/components/layout/PanelToggleArrows";
 import { FloatingVideoManager } from "@/components/video/FloatingVideoManager";
 import { BootOverlay } from "@/components/common/BootOverlay";
@@ -168,6 +169,11 @@ export function AppShell() {
         }
     }, [boot.phase, bootStart]);
     const activeBottomPanel = useStore((s) => s.activeBottomPanel);
+
+    // Alert engine (P2 backend core): evaluates enabled alert rules against
+    // live dataBus updates and emits `alertFired`. Headless — the UI agent
+    // builds the bell/badge/panel/toasts on top of the alertFired event.
+    useAlertEngine();
 
     const rootClasses = [
         "app-shell",

--- a/src/lib/alerts/engine.test.ts
+++ b/src/lib/alerts/engine.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { DataBusEvents, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import { attachAlertEngine, DEDUPE_WINDOW_MS, RULES_REFRESH_MS, type AlertBusLike, type RuleRecord } from "./engine";
+
+type Handler = (data: unknown) => void;
+
+class MockBus implements AlertBusLike {
+    handlers = new Map<keyof DataBusEvents, Set<Handler>>();
+    emitCalls: Array<{ event: string; data: unknown }> = [];
+    unsubscribed = false;
+
+    on<K extends keyof DataBusEvents>(event: K, handler: (data: DataBusEvents[K]) => void): () => void {
+        if (!this.handlers.has(event)) this.handlers.set(event, new Set());
+        this.handlers.get(event)!.add(handler as Handler);
+        return () => {
+            this.handlers.get(event)?.delete(handler as Handler);
+            this.unsubscribed = this.handlers.get(event)?.size === 0;
+        };
+    }
+
+    off<K extends keyof DataBusEvents>(event: K, handler: (data: DataBusEvents[K]) => void): void {
+        this.handlers.get(event)?.delete(handler as Handler);
+    }
+
+    emit<K extends keyof DataBusEvents>(event: K, data: DataBusEvents[K]): void {
+        this.emitCalls.push({ event: String(event), data });
+        this.handlers.get(event)?.forEach((h) => h(data));
+    }
+
+    fireDataUpdated(pluginId: string, entities: GeoEntity[]): void {
+        this.emit("dataUpdated", { pluginId, entities });
+    }
+
+    firedAlerts(): Array<{ rule: RuleRecord; entity: GeoEntity; pluginId: string }> {
+        return this.emitCalls
+            .filter((c) => c.event === "alertFired")
+            .map((c) => c.data as { rule: RuleRecord; entity: GeoEntity; pluginId: string });
+    }
+}
+
+function entity(id: string, magnitude = 6.2): GeoEntity {
+    return {
+        id,
+        pluginId: "earthquakes",
+        latitude: 61,
+        longitude: -149,
+        timestamp: new Date("2026-08-26T00:00:00Z"),
+        label: `M${magnitude} quake`,
+        // Plugin-mapped fields live in the metadata bag (matches FilterDefinition.propertyKey).
+        properties: { magnitude, place: "Alaska" },
+    };
+}
+
+function rule(overrides: Partial<RuleRecord> = {}): RuleRecord {
+    return {
+        id: "rule-1",
+        name: "Big quake",
+        pluginId: "earthquakes",
+        condition: { field: "magnitude", op: "gt", value: 5 },
+        enabled: true,
+        ...overrides,
+    };
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()!();
+});
+
+function attach(bus: MockBus, rules: RuleRecord[], now: () => number, persistEvent = vi.fn(async () => undefined)) {
+    const fetchRules = vi.fn(async () => rules);
+    const cleanup = attachAlertEngine(bus, { fetchRules, persistEvent, now });
+    cleanups.push(cleanup);
+    return { fetchRules, persistEvent };
+}
+
+async function flush(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("attachAlertEngine", () => {
+    it("loads enabled rules for the emitted plugin channel and fires alertFired on match", async () => {
+        const bus = new MockBus();
+        const { persistEvent } = attach(bus, [rule()], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+
+        const alerts = bus.firedAlerts();
+        expect(alerts).toHaveLength(1);
+        expect(alerts[0].rule.id).toBe("rule-1");
+        expect(alerts[0].entity.id).toBe("eq-1");
+        expect(alerts[0].pluginId).toBe("earthquakes");
+        expect(persistEvent).toHaveBeenCalledWith({
+            ruleId: "rule-1",
+            pluginId: "earthquakes",
+            entityId: "eq-1",
+            summary: "Big quake matched earthquakes entity eq-1",
+        });
+    });
+
+    it("does not fire when the entity does not match the condition", async () => {
+        const bus = new MockBus();
+        attach(bus, [rule()], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1", 3.1)]);
+        expect(bus.firedAlerts()).toHaveLength(0);
+    });
+
+    it("does not evaluate rules belonging to other plugin channels", async () => {
+        const bus = new MockBus();
+        attach(bus, [rule({ pluginId: "volcanoes" })], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        expect(bus.firedAlerts()).toHaveLength(0);
+    });
+
+    it("skips disabled rules", async () => {
+        const bus = new MockBus();
+        attach(bus, [rule({ enabled: false })], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        expect(bus.firedAlerts()).toHaveLength(0);
+    });
+
+    it("dedupes the same rule+entity within the 60s window", async () => {
+        const bus = new MockBus();
+        const clock = { t: 0 };
+        attach(bus, [rule()], () => clock.t);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        expect(bus.firedAlerts()).toHaveLength(1);
+
+        clock.t = DEDUPE_WINDOW_MS;
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        expect(bus.firedAlerts()).toHaveLength(2);
+    });
+
+    it("fires once per entity when multiple entities match", async () => {
+        const bus = new MockBus();
+        attach(bus, [rule()], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1"), entity("eq-2")]);
+        expect(bus.firedAlerts()).toHaveLength(2);
+    });
+
+    it("evaluates multiple rules for the same channel independently", async () => {
+        const bus = new MockBus();
+        attach(bus, [
+            rule(),
+            rule({ id: "rule-2", name: "Deep quake", condition: { field: "magnitude", op: "lt", value: 1 } }),
+        ], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        expect(bus.firedAlerts()).toHaveLength(1);
+        expect(bus.firedAlerts()[0].rule.id).toBe("rule-1");
+    });
+
+    it("keeps the last known rules when a refresh fails", async () => {
+        vi.useFakeTimers();
+        try {
+            const bus = new MockBus();
+            const fetchRules = vi.fn()
+                .mockRejectedValueOnce(new Error("network"))
+                .mockResolvedValueOnce([rule()]);
+            const cleanup = attachAlertEngine(bus, { fetchRules, now: () => 0 });
+            cleanups.push(cleanup);
+
+            // Initial refresh fails -> no rules, no alert.
+            await vi.advanceTimersByTimeAsync(0);
+            await Promise.resolve();
+            bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+            expect(bus.firedAlerts()).toHaveLength(0);
+
+            // The 60s rules refresh now succeeds and picks up the rule.
+            await vi.advanceTimersByTimeAsync(RULES_REFRESH_MS);
+            bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+            expect(bus.firedAlerts()).toHaveLength(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("cleanup unsubscribes: no alert fires after detach", async () => {
+        const bus = new MockBus();
+        attach(bus, [rule()], () => 0);
+        await flush();
+
+        cleanups.pop()!();
+        bus.fireDataUpdated("earthquakes", [entity("eq-1")]);
+        expect(bus.firedAlerts()).toHaveLength(0);
+    });
+
+    it("ignores empty entity batches", async () => {
+        const bus = new MockBus();
+        attach(bus, [rule()], () => 0);
+        await flush();
+
+        bus.fireDataUpdated("earthquakes", []);
+        expect(bus.firedAlerts()).toHaveLength(0);
+    });
+});

--- a/src/lib/alerts/engine.ts
+++ b/src/lib/alerts/engine.ts
@@ -1,0 +1,144 @@
+/**
+ * Client-side alert engine (P2, v1 — app-side evaluation).
+ *
+ * Attaches to the app DataBus: on `dataUpdated` it evaluates the current
+ * user's enabled rules for that plugin channel, emits `alertFired` on the
+ * same bus (UI agent subscribes for toasts/panel), and fire-and-forget
+ * persists an AlertEvent via POST /api/alerts/events.
+ *
+ * SSR-safe: no ambient browser state at module scope and the React hook only
+ * attaches inside useEffect (which never runs during SSR).
+ */
+
+import { useEffect } from "react";
+import type { AlertRuleSnapshot, DataBusEvents, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import { dataBus } from "@/core/data/DataBus";
+import { evaluateRule } from "./evaluate";
+
+export const DEDUPE_WINDOW_MS = 60_000;
+export const RULES_REFRESH_MS = 60_000;
+
+/** Rule as loaded from the API (snapshot + server flags). */
+export interface RuleRecord extends AlertRuleSnapshot {
+    enabled: boolean;
+}
+
+/** Structural subset of the DataBus the engine needs (mockable in tests). */
+export interface AlertBusLike {
+    on<K extends keyof DataBusEvents>(event: K, handler: (data: DataBusEvents[K]) => void): () => void;
+    off<K extends keyof DataBusEvents>(event: K, handler: (data: DataBusEvents[K]) => void): void;
+    emit<K extends keyof DataBusEvents>(event: K, data: DataBusEvents[K]): void;
+}
+
+export interface AlertEngineOptions {
+    /** Rule source; defaults to GET /api/alerts. Injectable for tests. */
+    fetchRules?: () => Promise<RuleRecord[]>;
+    /** Match persister; defaults to POST /api/alerts/events. Injectable for tests. */
+    persistEvent?: (match: {
+        ruleId: string;
+        pluginId: string;
+        entityId: string | null;
+        summary: string;
+    }) => Promise<unknown>;
+    /** Clock source (dedupe window); injectable for tests. */
+    now?: () => number;
+}
+
+async function defaultFetchRules(): Promise<RuleRecord[]> {
+    const res = await fetch("/api/alerts", { cache: "no-store" });
+    if (!res.ok) throw new Error(`[alerts] Failed to load rules: ${res.status}`);
+    const data = (await res.json()) as { rules?: RuleRecord[] };
+    return data.rules ?? [];
+}
+
+function defaultPersistEvent(match: {
+    ruleId: string;
+    pluginId: string;
+    entityId: string | null;
+    summary: string;
+}): Promise<unknown> {
+    return fetch("/api/alerts/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(match),
+    }).catch(() => undefined);
+}
+
+/**
+ * Subscribe a bus to data updates and fire alerts per the user's enabled rules.
+ * Returns a cleanup function (unsubscribe + stop rule refresh).
+ */
+export function attachAlertEngine(
+    bus: AlertBusLike,
+    opts: AlertEngineOptions = {},
+): () => void {
+    const fetchRules = opts.fetchRules ?? defaultFetchRules;
+    const persistEvent = opts.persistEvent ?? defaultPersistEvent;
+    const now = opts.now ?? Date.now;
+
+    let rules: RuleRecord[] = [];
+    let refreshTimer: ReturnType<typeof setInterval> | null = null;
+    const lastFired = new Map<string, number>();
+
+    const refreshRules = async (): Promise<void> => {
+        try {
+            rules = await fetchRules();
+        } catch {
+            // Keep the last-known rules; the next refresh retries.
+        }
+    };
+
+    const handleDataUpdated = ({ pluginId, entities }: DataBusEvents["dataUpdated"]): void => {
+        if (entities.length === 0) return;
+        const relevant = rules.filter((rule) => rule.enabled && rule.pluginId === pluginId);
+        if (relevant.length === 0) return;
+
+        for (const entity of entities) {
+            for (const rule of relevant) {
+                if (!evaluateRule({ condition: rule.condition, name: rule.name, pluginId }, entity)) {
+                    continue;
+                }
+                const key = `${rule.id}:${entity.id}`;
+                const last = lastFired.get(key);
+                if (last !== undefined && now() - last < DEDUPE_WINDOW_MS) continue;
+                lastFired.set(key, now());
+
+                bus.emit("alertFired", { rule, entity: entity as GeoEntity, pluginId });
+                void persistEvent({
+                    ruleId: rule.id,
+                    pluginId,
+                    entityId: entity.id,
+                    summary: `${rule.name} matched ${pluginId} entity ${entity.id}`,
+                });
+
+                if (lastFired.size > 500) {
+                    for (const [k, t] of lastFired) {
+                        if (now() - t >= DEDUPE_WINDOW_MS) lastFired.delete(k);
+                    }
+                }
+            }
+        }
+    };
+
+    const unsubscribe = bus.on("dataUpdated", handleDataUpdated);
+    void refreshRules();
+    refreshTimer = setInterval(() => void refreshRules(), RULES_REFRESH_MS);
+
+    return () => {
+        unsubscribe();
+        if (refreshTimer !== null) clearInterval(refreshTimer);
+        lastFired.clear();
+    };
+}
+
+/**
+ * React hook — attach the engine to the app-level dataBus for the lifetime of
+ * the mounting client component. Returns nothing; `alertFired` events surface
+ * through the dataBus for UI consumers (toasts/badge/panel — UI agent).
+ */
+export function useAlertEngine(): void {
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        return attachAlertEngine(dataBus);
+    }, []);
+}

--- a/src/lib/alerts/evaluate.test.ts
+++ b/src/lib/alerts/evaluate.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import type { GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import { evaluateCondition, evaluateRule } from "./evaluate";
+
+const MAG_ENTITY = {
+    id: "eq-1",
+    place: "Alaska",
+    magnitude: 6.2,
+    depth_km: 12,
+    status: "major",
+    feltCount: 0,
+    isTsunami: false,
+    codes: ["us", "6000"],
+};
+
+describe("evaluateCondition — numeric operators (gt/lt/gte/lte)", () => {
+    it("gt: true when field is numerically greater", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "gt", value: 5 }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("gt: false when field is not greater", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "gt", value: 6.2 }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("gt: numeric string field coerces via Number()", () => {
+        expect(evaluateCondition({ field: "place", op: "gt", value: 0 }, MAG_ENTITY)).toBe(false);
+        expect(evaluateCondition({ field: "magnitude", op: "gt", value: "5" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("lt: true when field is smaller", () => {
+        expect(evaluateCondition({ field: "depth_km", op: "lt", value: 20 }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("gte: true on equality boundary", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "gte", value: 6.2 }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("lte: true on equality boundary", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "lte", value: 6.2 }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("gt: missing field -> false", () => {
+        expect(evaluateCondition({ field: "nope", op: "gt", value: 0 }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("gt: NaN target value -> false", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "gt", value: "abc" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("gt: null field -> false", () => {
+        expect(evaluateCondition({ field: "depth_km", op: "gt", value: 0 }, { ...MAG_ENTITY, depth_km: null })).toBe(false);
+    });
+
+    it("gt: array field -> false (Number(array) is NaN)", () => {
+        expect(evaluateCondition({ field: "codes", op: "gt", value: 0 }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("gte: non-numeric field -> false", () => {
+        expect(evaluateCondition({ field: "place", op: "gte", value: 5 }, MAG_ENTITY)).toBe(false);
+    });
+});
+
+describe("evaluateCondition — eq/neq", () => {
+    it("eq: same-type equality", () => {
+        expect(evaluateCondition({ field: "status", op: "eq", value: "major" }, MAG_ENTITY)).toBe(true);
+        expect(evaluateCondition({ field: "status", op: "eq", value: "minor" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("eq: number vs numeric string coerces", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "eq", value: "6.2" }, MAG_ENTITY)).toBe(true);
+        expect(evaluateCondition({ field: "magnitude", op: "eq", value: "6" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("eq: numeric string field vs number coerces", () => {
+        expect(evaluateCondition({ field: "place", op: "eq", value: 0 }, { ...MAG_ENTITY, place: "0" })).toBe(true);
+    });
+
+    it("eq: boolean vs 'true'/'false' string coerces", () => {
+        expect(evaluateCondition({ field: "isTsunami", op: "eq", value: "false" }, MAG_ENTITY)).toBe(true);
+        expect(evaluateCondition({ field: "isTsunami", op: "eq", value: "true" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("eq: boolean vs case-variant string coerces", () => {
+        expect(evaluateCondition({ field: "isTsunami", op: "eq", value: "FALSE" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("eq: string field vs boolean with non-boolean string -> false", () => {
+        expect(evaluateCondition({ field: "status", op: "eq", value: true }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("eq: missing field -> false", () => {
+        expect(evaluateCondition({ field: "nope", op: "eq", value: "x" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("eq: null field -> false", () => {
+        expect(evaluateCondition({ field: "depth_km", op: "eq", value: null }, { ...MAG_ENTITY, depth_km: null })).toBe(false);
+    });
+
+    it("eq: array field compares via String() fallback", () => {
+        expect(evaluateCondition({ field: "codes", op: "eq", value: "us,6000" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("neq: different values -> true", () => {
+        expect(evaluateCondition({ field: "status", op: "neq", value: "minor" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("neq: equal values -> false", () => {
+        expect(evaluateCondition({ field: "status", op: "neq", value: "major" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("neq: coercible strings count as equal -> false", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "neq", value: "6.2" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("neq: missing field -> false (rule cannot fire on unseen data)", () => {
+        expect(evaluateCondition({ field: "nope", op: "neq", value: "x" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("eq: incompatible scalar types without coercion -> false", () => {
+        expect(evaluateCondition({ field: "status", op: "eq", value: 5 }, MAG_ENTITY)).toBe(false);
+    });
+});
+
+describe("evaluateCondition — contains", () => {
+    it("contains: case-insensitive substring", () => {
+        expect(evaluateCondition({ field: "place", op: "contains", value: "alask" }, MAG_ENTITY)).toBe(true);
+        expect(evaluateCondition({ field: "place", op: "contains", value: "hawaii" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("contains: numeric field coerces to string on both sides", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "contains", value: "6" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("contains: array field coerces to its joined string", () => {
+        expect(evaluateCondition({ field: "codes", op: "contains", value: "6000" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("contains: missing field -> false", () => {
+        expect(evaluateCondition({ field: "nope", op: "contains", value: "x" }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("contains: missing value -> false", () => {
+        expect(evaluateCondition({ field: "place", op: "contains" }, MAG_ENTITY)).toBe(false);
+    });
+});
+
+describe("evaluateCondition — exists", () => {
+    it("exists: present value -> true", () => {
+        expect(evaluateCondition({ field: "magnitude", op: "exists" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("exists: falsy-but-present values (0, false, \"\") -> true", () => {
+        expect(evaluateCondition({ field: "feltCount", op: "exists" }, MAG_ENTITY)).toBe(true);
+        expect(evaluateCondition({ field: "isTsunami", op: "exists" }, MAG_ENTITY)).toBe(true);
+    });
+
+    it("exists: null value -> false", () => {
+        expect(evaluateCondition({ field: "depth_km", op: "exists" }, { ...MAG_ENTITY, depth_km: null })).toBe(false);
+    });
+
+    it("exists: missing field -> false", () => {
+        expect(evaluateCondition({ field: "nope", op: "exists" }, MAG_ENTITY)).toBe(false);
+    });
+});
+
+describe("evaluateCondition — entities and robustness", () => {
+    const geoEntity: GeoEntity = {
+        id: "geo-1",
+        pluginId: "earthquakes",
+        latitude: 61.2,
+        longitude: -149.4,
+        timestamp: new Date("2026-08-01T00:00:00Z"),
+        label: "M6.2 Alaska",
+        properties: { mag: 6.2 },
+    };
+
+    it("evaluates top-level GeoEntity fields directly", () => {
+        expect(evaluateCondition({ field: "latitude", op: "gt", value: 60 }, geoEntity)).toBe(true);
+        expect(evaluateCondition({ field: "properties", op: "exists" }, geoEntity)).toBe(true);
+        expect(evaluateCondition({ field: "label", op: "contains", value: "alaska" }, geoEntity)).toBe(true);
+    });
+
+    it("resolves fields from the GeoEntity properties bag first (plugin-mapped fields)", () => {
+        expect(evaluateCondition({ field: "mag", op: "gt", value: 6 }, geoEntity)).toBe(true);
+        expect(evaluateCondition({ field: "mag", op: "exists" }, geoEntity)).toBe(true);
+        expect(evaluateCondition({ field: "mag", op: "lt", value: 6 }, geoEntity)).toBe(false);
+    });
+
+    it("prefers the properties bag over a same-named top-level field", () => {
+        expect(evaluateCondition(
+            { field: "mag", op: "gt", value: 10 },
+            { ...geoEntity, properties: { mag: 9 } },
+        )).toBe(false);
+        expect(evaluateCondition(
+            { field: "mag", op: "gt", value: 5 },
+            { ...geoEntity, properties: { mag: 9 } },
+        )).toBe(true);
+    });
+
+    it("malformed condition object -> false", () => {
+        expect(evaluateCondition({ field: "", op: "gt", value: 1 }, MAG_ENTITY)).toBe(false);
+        expect(evaluateCondition({ field: "magnitude", op: "bogus" as never, value: 1 }, MAG_ENTITY)).toBe(false);
+    });
+
+    it("null/undefined condition -> false", () => {
+        expect(evaluateCondition(null as never, MAG_ENTITY)).toBe(false);
+    });
+});
+
+describe("evaluateRule (v1 single-condition wrapper)", () => {
+    it("matches when condition matches", () => {
+        const rule = { name: "Big quake", pluginId: "earthquakes", condition: { field: "magnitude", op: "gt", value: 5 } };
+        expect(evaluateRule(rule, MAG_ENTITY)).toBe(true);
+        expect(evaluateRule(rule, { ...MAG_ENTITY, magnitude: 3 })).toBe(false);
+    });
+
+    it("false when rule has no condition", () => {
+        expect(evaluateRule({ name: "broken" } as never, MAG_ENTITY)).toBe(false);
+    });
+
+    it("works against a GeoEntity shape (evaluateRule accepts GeoEntity)", () => {
+        const rule = { condition: { field: "latitude", op: "gt", value: 60 } };
+        const geoEntity: GeoEntity = {
+            id: "geo-2",
+            pluginId: "earthquakes",
+            latitude: 61,
+            longitude: 0,
+            timestamp: new Date(),
+            properties: {},
+        };
+        expect(evaluateRule(rule, geoEntity)).toBe(true);
+    });
+});

--- a/src/lib/alerts/evaluate.test.ts
+++ b/src/lib/alerts/evaluate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import type { AlertCondition, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
 import { evaluateCondition, evaluateRule } from "./evaluate";
 
 const MAG_ENTITY = {
@@ -209,7 +209,11 @@ describe("evaluateCondition — entities and robustness", () => {
 
 describe("evaluateRule (v1 single-condition wrapper)", () => {
     it("matches when condition matches", () => {
-        const rule = { name: "Big quake", pluginId: "earthquakes", condition: { field: "magnitude", op: "gt", value: 5 } };
+        const rule: { name: string; pluginId: string; condition: AlertCondition } = {
+            name: "Big quake",
+            pluginId: "earthquakes",
+            condition: { field: "magnitude", op: "gt", value: 5 },
+        };
         expect(evaluateRule(rule, MAG_ENTITY)).toBe(true);
         expect(evaluateRule(rule, { ...MAG_ENTITY, magnitude: 3 })).toBe(false);
     });
@@ -219,7 +223,7 @@ describe("evaluateRule (v1 single-condition wrapper)", () => {
     });
 
     it("works against a GeoEntity shape (evaluateRule accepts GeoEntity)", () => {
-        const rule = { condition: { field: "latitude", op: "gt", value: 60 } };
+        const rule: { condition: AlertCondition } = { condition: { field: "latitude", op: "gt", value: 60 } };
         const geoEntity: GeoEntity = {
             id: "geo-2",
             pluginId: "earthquakes",

--- a/src/lib/alerts/evaluate.ts
+++ b/src/lib/alerts/evaluate.ts
@@ -1,0 +1,140 @@
+/**
+ * Pure rule evaluator for app-side alert conditions (P2, v1).
+ * No I/O and no ambient state — fully unit-testable.
+ *
+ * Field resolution: alertable fields live in the GeoEntity metadata bag
+ * (`entity.properties`, mirroring FilterDefinition.propertyKey); a field is
+ * read from `properties` when the bag owns the key, otherwise from the
+ * entity's top level. Semantics:
+ * - gt/lt/gte/lte: numeric comparison after Number() coercion on BOTH sides.
+ *   Missing fields, non-numeric values, NaN, or arrays -> false.
+ * - eq/neq: natural equality restricted to string/number/boolean with
+ *   coercion between numeric strings and numbers and "true"/"false" strings
+ *   and booleans. Anything else falls back to String() comparison.
+ *   Missing fields -> false (a rule cannot fire on data it cannot see).
+ * - contains: case-insensitive string inclusion after String() coercion
+ *   on both sides (arrays coerce to their joined string form).
+ * - exists: field present AND not null/undefined.
+ */
+
+import type { GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import type { AlertCondition } from "@worldwideview/wwv-plugin-sdk";
+
+/** Entity shapes evaluable by conditions: mapped GeoEntity or any flat record. */
+export type AlertableEntity = Record<string, unknown> | GeoEntity;
+
+function getField(entity: AlertableEntity, field: string): unknown {
+    const record = entity as Record<string, unknown>;
+    const bag = record.properties;
+    if (typeof bag === "object" && bag !== null && !Array.isArray(bag)) {
+        const props = bag as Record<string, unknown>;
+        if (Object.prototype.hasOwnProperty.call(props, field)) return props[field];
+    }
+    return record[field];
+}
+
+function isPresent(value: unknown): boolean {
+    return value !== undefined && value !== null;
+}
+
+/** Number() coercion that rejects non-numeric input (NaN, "", [], objects). */
+function toNumber(value: unknown): number | null {
+    const n = Number(value);
+    return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Natural equality over string/number/boolean. Same-type values compare with
+ * ===; numeric strings compare numerically; "true"/"false" strings compare
+ * as booleans; anything else falls back to String() comparison.
+ */
+function looseEquals(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+
+    if (typeof a === "number" && typeof b === "string") {
+        const nb = toNumber(b);
+        return b.trim() !== "" && nb !== null && a === nb;
+    }
+    if (typeof a === "string" && typeof b === "number") {
+        const na = toNumber(a);
+        return a.trim() !== "" && na !== null && na === b;
+    }
+    if (typeof a === "boolean" && typeof b === "string") {
+        const lower = b.trim().toLowerCase();
+        if (lower === "true") return a;
+        if (lower === "false") return !a;
+        return false;
+    }
+    if (typeof a === "string" && typeof b === "boolean") {
+        return looseEquals(b, a);
+    }
+
+    return String(a) === String(b);
+}
+
+function compareNumeric(
+    left: unknown,
+    right: unknown,
+    op: "gt" | "lt" | "gte" | "lte",
+): boolean {
+    if (!isPresent(left)) return false;
+    const a = toNumber(left);
+    const b = toNumber(right);
+    if (a === null || b === null) return false;
+
+    switch (op) {
+        case "gt": return a > b;
+        case "lt": return a < b;
+        case "gte": return a >= b;
+        case "lte": return a <= b;
+    }
+}
+
+function matches(condition: AlertCondition, entity: AlertableEntity): boolean {
+    const { field, op, value } = condition;
+    const actual = getField(entity, field);
+    const present = isPresent(actual);
+
+    switch (op) {
+        case "gt":
+        case "lt":
+        case "gte":
+        case "lte":
+            return compareNumeric(actual, value, op);
+        case "eq":
+            return present ? looseEquals(actual, value) : false;
+        case "neq":
+            return present ? !looseEquals(actual, value) : false;
+        case "contains":
+            if (!present || !isPresent(value)) return false;
+            return String(actual).toLowerCase().includes(String(value).toLowerCase());
+        case "exists":
+            return present;
+        default:
+            return false;
+    }
+}
+
+/** Evaluate a single condition against an entity (flat record or GeoEntity). */
+export function evaluateCondition(
+    condition: AlertCondition,
+    entity: AlertableEntity,
+): boolean {
+    if (!condition || typeof condition.field !== "string" || !condition.op) {
+        return false;
+    }
+    try {
+        return matches(condition, entity);
+    } catch {
+        return false;
+    }
+}
+
+/** Evaluate a persisted rule (single-condition shape, v1) against an entity. */
+export function evaluateRule(
+    rule: { condition: AlertCondition; name?: string; pluginId?: string },
+    entity: AlertableEntity,
+): boolean {
+    if (!rule?.condition) return false;
+    return evaluateCondition(rule.condition, entity);
+}

--- a/src/lib/alerts/knownPlugins.ts
+++ b/src/lib/alerts/knownPlugins.ts
@@ -1,0 +1,57 @@
+/**
+ * Known plugin channel names for alert-rule validation (P2, v1).
+ *
+ * The runtime union of "channels whose data can reach the app's dataBus":
+ *   1. Built-in plugins shipped in this repo (src/plugins/* — always valid).
+ *   2. Engine-seeded channels advertised by the data engine manifest
+ *      (graceful — unreachable engine degrades to the built-ins).
+ *   3. Local-registry plugin ids (public/plugins-local manifests, see
+ *      data-query/localSources).
+ */
+
+import { getEngineUrl } from "@/lib/data-query/service";
+
+/** Built-in plugin ids shipped in src/plugins (channel names are folder ids). */
+const BUILTIN_ALERTABLE_PLUGIN_IDS = ["earthquakes", "geojson", "iss", "weather"];
+
+/**
+ * Resolve the set of plugin ids that are valid alert-rule targets.
+ * @param fetcher - injectable for tests; defaults to global fetch.
+ */
+export async function getKnownPluginIds(
+    fetcher: typeof fetch = fetch,
+): Promise<Set<string>> {
+    const ids = new Set<string>(BUILTIN_ALERTABLE_PLUGIN_IDS);
+
+    try {
+        const res = await fetcher(`${getEngineUrl()}/manifest`, {
+            signal: AbortSignal.timeout(3000),
+        });
+        if (res.ok) {
+            const data = (await res.json()) as { plugins?: unknown };
+            if (Array.isArray(data.plugins)) {
+                for (const id of data.plugins) {
+                    if (typeof id === "string") ids.add(id);
+                }
+            }
+        }
+    } catch {
+        // Engine offline — built-ins still validate.
+    }
+
+    try {
+        const { getLocalSourceIds } = await import("@/lib/data-query/localSources");
+        for (const id of await getLocalSourceIds()) {
+            ids.add(id);
+        }
+    } catch {
+        // Local registry unavailable (e.g. test env without public/plugins-local).
+    }
+
+    return ids;
+}
+
+/** True when pluginId is a channel the app can evaluate alerts against. */
+export async function isKnownPluginId(pluginId: string): Promise<boolean> {
+    return (await getKnownPluginIds()).has(pluginId);
+}

--- a/src/lib/alerts/validation.ts
+++ b/src/lib/alerts/validation.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-side validation for alert rule inputs (P2, v1).
+ * Regex / constants / shape checks shared by the alerts routes and their tests.
+ */
+
+import type { AlertCondition, AlertFieldType, AlertOperator } from "@worldwideview/wwv-plugin-sdk";
+
+export const ALERT_FIELD_TYPES: AlertFieldType[] = ["number", "string", "boolean"];
+
+export const ALERT_OPERATORS: AlertOperator[] = [
+    "gt",
+    "lt",
+    "gte",
+    "lte",
+    "eq",
+    "neq",
+    "contains",
+    "exists",
+];
+
+export const MAX_RULE_NAME_LENGTH = 120;
+export const MAX_FIELD_NAME_LENGTH = 100;
+export const MAX_SUMMARY_LENGTH = 500;
+
+/** Channel names are safe URL/engine identifiers (mirrors data-query/service.ts). */
+export const PLUGIN_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+export function isAlertOperator(value: unknown): value is AlertOperator {
+    return typeof value === "string" && (ALERT_OPERATORS as string[]).includes(value);
+}
+
+/**
+ * Validate a condition payload against the SDK shape.
+ * Returns an error message string, or null when valid.
+ */
+export function validateCondition(condition: unknown): string | null {
+    if (typeof condition !== "object" || condition === null || Array.isArray(condition)) {
+        return "condition must be an object";
+    }
+    const c = condition as Record<string, unknown>;
+
+    if (typeof c.field !== "string" || c.field.trim() === "") {
+        return "condition.field must be a non-empty string";
+    }
+    if (c.field.length > MAX_FIELD_NAME_LENGTH) {
+        return `condition.field must be ${MAX_FIELD_NAME_LENGTH} characters or fewer`;
+    }
+    if (!isAlertOperator(c.op)) {
+        return `condition.op must be one of: ${ALERT_OPERATORS.join(", ")}`;
+    }
+
+    const hasValue = "value" in c && c.value !== undefined;
+    if (c.op !== "exists" && !hasValue) {
+        return `condition.value is required for operator "${c.op}"`;
+    }
+    if (c.op === "exists" && c.value !== undefined && c.value !== null) {
+        return 'condition.value must be omitted for operator "exists"';
+    }
+    return null;
+}
+
+/** Validate a rule name payload. Returns an error message, or null when valid. */
+export function validateRuleName(name: unknown): string | null {
+    if (typeof name !== "string" || name.trim() === "") {
+        return "name must be a non-empty string";
+    }
+    if (name.length > MAX_RULE_NAME_LENGTH) {
+        return `name must be ${MAX_RULE_NAME_LENGTH} characters or fewer`;
+    }
+    return null;
+}
+
+export function isCondition(value: unknown): value is AlertCondition {
+    return validateCondition(value) === null;
+}


### PR DESCRIPTION
## Summary (P2 v1 — app-side alert rules; backend core only)

Backend core for alert/conditions on live plugin data. A user creates a rule
(e.g. `magnitude > 5`), the app evaluates it against `dataUpdated` stream
events, and fires/persists alerts. NO UI in this PR (separate agent builds
bell/panel/toasts on the `alertFired` bus event).

### What ships

1. **SDK** (`packages/wwv-plugin-sdk`): `AlertFieldType`, `AlertOperator`,
   `AlertFieldDefinition`, `AlertCondition`, `AlertRuleSnapshot` exports;
   optional `WorldPlugin.getAlertDefinitions?()` (non-breaking); typed
   `alertFired` DataBus event.
2. **Prisma**: `AlertRule` + `AlertEvent` models (FK to `BetterAuthUser`,
   `ON DELETE CASCADE`) and migration `20260826000000_add_alert_rules`.
   Note: the legacy `User` model is migration-source-only ("Do NOT add
   relations") — the relation targets `BetterAuthUser`, per Favorite/
   UserApiKey/WorkspaceMember conventions.
3. **Evaluator** `src/lib/alerts/evaluate.ts`: pure `evaluateCondition` /
   `evaluateRule`; field resolution reads `entity.properties` first then
   top-level (mirrors `FilterDefinition.propertyKey` — plugin-mapped fields
   like `magnitude`/`place` live in the metadata bag).
4. **API**: `GET/POST /api/alerts`, `PATCH/DELETE /api/alerts/[id]`
   (ownership-scoped via `requireSession`; 404 for foreign rows),
   `POST /api/alerts/events` (persist + 60s dedupe). POST validates the
   channel against known plugin ids (built-ins + engine manifest + local
   registry) and the condition shape against SDK operators.
5. **Engine** `src/lib/alerts/engine.ts`: `attachAlertEngine(dataBus)` +
   `useAlertEngine()` (SSR-safe); evaluates enabled per-user rules on
   `dataUpdated`, emits `alertFired`, fire-and-forget persists events;
   60s dedupe. Minimal wiring in `AppShell` (headless hook call).

### Gates
- `pnpm test` — 131 files / 1316 tests passed 
- `pnpm build` — exit 0; `/api/alerts*` routes compiled
- `pnpm lint` — 0 errors (306 pre-existing warnings; URL linter PASS)

### Notes / follow-ups
- Engine-side push notifications = v2 (attach at engine `broadcastPluginData`).
- Geo rules (distance/radius) not in v1 (field ops only).
