### PR TITLE
fix(globe): reconnect command bridge after restart (#417)

### DIFF
--- a/src/core/globe/hooks/useGlobeCommandBridge.test.ts
+++ b/src/core/globe/hooks/useGlobeCommandBridge.test.ts
@@ -13,11 +13,17 @@
  *   BRIDGE-05  Empty sessionId -> EventSource never created
  *   BRIDGE-06  Unmount -> EventSource.close() called
  *   BRIDGE-07  onerror firing -> no throw
+ *   BRIDGE-08  readyState CLOSED -> EventSource recreated with backoff, consumption resumes
+ *   BRIDGE-09  Backoff doubles per failed attempt, resets after successful onopen
+ *   BRIDGE-10  Unmount clears pending reconnect timer and closes current EventSource
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useGlobeCommandBridge } from "./useGlobeCommandBridge";
+import {
+    useGlobeCommandBridge,
+    SSE_RECONNECT_BASE_DELAY_MS,
+} from "./useGlobeCommandBridge";
 
 // ---------------------------------------------------------------------------
 // Mock DataBus
@@ -107,10 +113,17 @@ const mockedUseStore = useStore as unknown as {
 // ---------------------------------------------------------------------------
 
 let mockEs: MockEventSource;
+const mockEsInstances: MockEventSource[] = [];
 
 class MockEventSource {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSED = 2;
+
     url: string;
+    readyState = MockEventSource.CONNECTING;
     onmessage: ((ev: MessageEvent) => void) | null = null;
+    onopen: (() => void) | null = null;
     onerror: ((ev: Event) => void) | null = null;
     close = vi.fn();
 
@@ -118,6 +131,7 @@ class MockEventSource {
         this.url = url;
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         mockEs = this;
+        mockEsInstances.push(this);
     }
 }
 
@@ -127,6 +141,7 @@ class MockEventSource {
 
 beforeEach(() => {
     vi.resetAllMocks();
+    mockEsInstances.length = 0;
 
     // Install MockEventSource as the global before each test
     global.EventSource = MockEventSource as unknown as typeof EventSource;
@@ -331,5 +346,181 @@ describe("useGlobeCommandBridge onerror resilience (BRIDGE-07)", () => {
         });
 
         // Reaching here without an unhandled exception is the assertion
+    });
+});
+
+// ---------------------------------------------------------------------------
+// BRIDGE-08: reconnect after readyState CLOSED
+// ---------------------------------------------------------------------------
+
+describe("useGlobeCommandBridge reconnect on terminal close (BRIDGE-08)", () => {
+    it("creates a new EventSource after readyState becomes CLOSED", () => {
+        vi.useFakeTimers();
+        try {
+            renderHook(() => useGlobeCommandBridge("sess-1"));
+            const first = mockEs;
+            first.readyState = MockEventSource.CLOSED;
+
+            act(() => {
+                first.onerror?.(new Event("error"));
+            });
+
+            // A CLOSED stream must not reconnect instantly: creation waits for backoff.
+            expect(mockEsInstances).toHaveLength(1);
+
+            act(() => {
+                vi.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS);
+            });
+
+            expect(mockEsInstances).toHaveLength(2);
+            expect(mockEs.url).toContain("/api/globe/commands/stream");
+            expect(mockEs.url).toContain("sessionId=sess-1");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("resumes command consumption on the reconnected EventSource", () => {
+        vi.useFakeTimers();
+        try {
+            renderHook(() => useGlobeCommandBridge("sess-1"));
+            const first = mockEs;
+            first.readyState = MockEventSource.CLOSED;
+
+            act(() => {
+                first.onerror?.(new Event("error"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS);
+            });
+
+            // The reconnected instance must have onmessage re-wired, otherwise
+            // commands pushed after the restart would be silently dropped.
+            act(() => {
+                mockEs.onmessage?.(
+                    new MessageEvent("message", {
+                        data: JSON.stringify({
+                            commands: [{ type: "pan", lat: 5, lon: 6, alt: 100 }],
+                        }),
+                    }),
+                );
+            });
+
+            expect(mockEmit).toHaveBeenCalledWith(
+                "cameraGoTo",
+                expect.objectContaining({ lat: 5, lon: 6, alt: 100 }),
+            );
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// BRIDGE-09: backoff doubles per failure, resets after successful open
+// ---------------------------------------------------------------------------
+
+describe("useGlobeCommandBridge reconnect backoff (BRIDGE-09)", () => {
+    it("doubles the delay between failed reconnects and resets it after onopen", () => {
+        vi.useFakeTimers();
+        try {
+            renderHook(() => useGlobeCommandBridge("sess-1"));
+
+            // Failure 1 -> reconnect scheduled at the base delay (1s).
+            const first = mockEs;
+            first.readyState = MockEventSource.CLOSED;
+            act(() => {
+                first.onerror?.(new Event("error"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS);
+            });
+            expect(mockEsInstances).toHaveLength(2);
+
+            // Failure 2 -> the next reconnect must wait 2x the base delay.
+            const second = mockEs;
+            second.readyState = MockEventSource.CLOSED;
+            act(() => {
+                second.onerror?.(new Event("error"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS * 2);
+            });
+            expect(mockEsInstances).toHaveLength(3);
+
+            // Success: onopen resets the backoff to the base delay.
+            act(() => {
+                mockEs.onopen?.();
+            });
+
+            // Failure 3 -> reconnect must happen at the base delay again, not 4x.
+            const third = mockEs;
+            third.readyState = MockEventSource.CLOSED;
+            act(() => {
+                third.onerror?.(new Event("error"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS);
+            });
+            expect(mockEsInstances).toHaveLength(4);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// BRIDGE-10: unmount clears pending reconnect timer and closes current stream
+// ---------------------------------------------------------------------------
+
+describe("useGlobeCommandBridge unmount cleanup with pending reconnect (BRIDGE-10)", () => {
+    it("does not reconnect after unmount when a reconnect timer is pending", () => {
+        vi.useFakeTimers();
+        try {
+            const { unmount } = renderHook(() => useGlobeCommandBridge("sess-1"));
+            const first = mockEs;
+            first.readyState = MockEventSource.CLOSED;
+
+            act(() => {
+                first.onerror?.(new Event("error"));
+            });
+
+            unmount();
+            act(() => {
+                vi.advanceTimersByTime(60_000);
+            });
+
+            // No EventSource may be created after unmount (timer was cleared).
+            expect(mockEsInstances).toHaveLength(1);
+            expect(first.close).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("closes the reconnected EventSource on unmount", () => {
+        vi.useFakeTimers();
+        try {
+            const { unmount } = renderHook(() => useGlobeCommandBridge("sess-1"));
+            const first = mockEs;
+            first.readyState = MockEventSource.CLOSED;
+
+            act(() => {
+                first.onerror?.(new Event("error"));
+            });
+            act(() => {
+                vi.advanceTimersByTime(SSE_RECONNECT_BASE_DELAY_MS);
+            });
+            const second = mockEs;
+            expect(mockEsInstances).toHaveLength(2);
+
+            unmount();
+
+            // first.close() happened at reconnect time; second.close() on unmount.
+            expect(first.close).toHaveBeenCalledTimes(1);
+            expect(second.close).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/src/core/globe/hooks/useGlobeCommandBridge.ts
+++ b/src/core/globe/hooks/useGlobeCommandBridge.ts
@@ -6,6 +6,18 @@ import type { GlobeCommand } from "@/core/globe/types/GlobeCommand";
 import { setLayerActive } from "@/core/plugins/layerActivation";
 import { isDemo } from "@/core/edition";
 
+/**
+ * Reconnect backoff after a terminal SSE failure (readyState === CLOSED).
+ * Starts at 1s and doubles per failed attempt up to 30s; a successful
+ * reconnection (onopen) resets the delay back to the base value.
+ */
+export const SSE_RECONNECT_BASE_DELAY_MS = 1_000;
+export const SSE_RECONNECT_MAX_DELAY_MS = 30_000;
+
+function streamUrlForSession(sessionId: string): string {
+    return `/api/globe/commands/stream?sessionId=${encodeURIComponent(sessionId)}`;
+}
+
 function dispatchCommand(cmd: GlobeCommand): void {
     switch (cmd.type) {
         case "pan":
@@ -102,45 +114,85 @@ export function useGlobeCommandBridge(sessionId: string): void {
     useEffect(() => {
         if (!sessionId || isDemo) return;
 
-        const es = new EventSource(
-            `/api/globe/commands/stream?sessionId=${encodeURIComponent(sessionId)}`,
-        );
+        let es: EventSource | null = null;
+        let reconnectDelayMs = SSE_RECONNECT_BASE_DELAY_MS;
+        let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+        let disposed = false;
 
-        es.onmessage = (event: MessageEvent) => {
-            try {
-                const parsed: unknown = JSON.parse(event.data as string);
-                if (
-                    parsed !== null &&
-                    typeof parsed === "object" &&
-                    "commands" in parsed &&
-                    Array.isArray((parsed as { commands: unknown }).commands)
-                ) {
-                    (parsed as { commands: unknown[] }).commands
-                        .filter(isValidGlobeCommand)
-                        .forEach(dispatchCommand);
+        function connect(): void {
+            if (disposed) return;
+
+            es?.close();
+            es = new EventSource(streamUrlForSession(sessionId));
+
+            es.onmessage = (event: MessageEvent) => {
+                try {
+                    const parsed: unknown = JSON.parse(event.data as string);
+                    if (
+                        parsed !== null &&
+                        typeof parsed === "object" &&
+                        "commands" in parsed &&
+                        Array.isArray((parsed as { commands: unknown }).commands)
+                    ) {
+                        (parsed as { commands: unknown[] }).commands
+                            .filter(isValidGlobeCommand)
+                            .forEach(dispatchCommand);
+                    }
+                } catch (err) {
+                    console.error("[useGlobeCommandBridge] Failed to parse SSE message:", err);
                 }
-            } catch (err) {
-                console.error("[useGlobeCommandBridge] Failed to parse SSE message:", err);
-            }
-        };
+            };
 
-        es.onerror = () => {
-            // onerror fires on the normal stream close too: the server ends each
-            // stream at MAX_DURATION_MS (~16s), after which EventSource transparently
-            // reconnects (readyState === CONNECTING). Only a terminal failure leaves
-            // readyState === CLOSED -- e.g. a 401 because EventSource authenticates via
-            // the NextAuth session cookie (it cannot send a Bearer header), so an
-            // unauthenticated tab fails permanently rather than reconnecting.
-            if (es.readyState === EventSource.CLOSED) {
-                console.error(
-                    "[useGlobeCommandBridge] SSE stream closed without retry -- " +
-                        "is this tab signed in? EventSource auths via session cookie, not Bearer.",
-                );
-            }
-        };
+            es.onopen = () => {
+                // A successful connection re-establishes command consumption and
+                // resets the backoff so the next failure starts from the base delay.
+                reconnectDelayMs = SSE_RECONNECT_BASE_DELAY_MS;
+            };
+
+            es.onerror = () => {
+                // onerror fires on the normal stream close too: the server ends each
+                // stream at MAX_DURATION_MS (~16s), after which EventSource transparently
+                // reconnects (readyState === CONNECTING). Only a terminal failure leaves
+                // readyState === CLOSED -- e.g. a 401 because EventSource authenticates via
+                // the NextAuth session cookie (it cannot send a Bearer header), or a 5xx
+                // from the proxy while a container restarts. The browser never retries a
+                // CLOSED stream, so recreate it with backoff to resume consuming commands
+                // once the proxy/container is back up.
+                if (es?.readyState === EventSource.CLOSED) {
+                    console.error(
+                        "[useGlobeCommandBridge] SSE stream closed without browser retry -- " +
+                            `reconnecting in ${reconnectDelayMs}ms. Is this tab signed in? ` +
+                            "EventSource auths via session cookie, not Bearer.",
+                    );
+                    scheduleReconnect();
+                }
+            };
+        }
+
+        function scheduleReconnect(): void {
+            if (disposed || reconnectTimer !== null) return;
+
+            reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                connect();
+            }, reconnectDelayMs);
+
+            // Exponential backoff: double each failed attempt, capped at MAX.
+            reconnectDelayMs = Math.min(
+                reconnectDelayMs * 2,
+                SSE_RECONNECT_MAX_DELAY_MS,
+            );
+        }
+
+        connect();
 
         return () => {
-            es.close();
+            disposed = true;
+            if (reconnectTimer !== null) {
+                clearTimeout(reconnectTimer);
+                reconnectTimer = null;
+            }
+            es?.close();
         };
     }, [sessionId]);
 }


### PR DESCRIPTION
## Summary

Fixes #417: after any container/proxy restart, every open tab permanently stopped consuming globe commands.

**Root cause**: `useGlobeCommandBridge` opened a single `EventSource` to `/api/globe/commands/stream`. When a restart makes the proxy return a non-200 (e.g. 502/504, or 401), the EventSource spec treats it as a *fatal* connection failure: `readyState` becomes `CLOSED` and the browser never retries (normal stream ends stay at `CONNECTING` and auto-reconnect). The `onerror` handler only logged this state, so the bridge stayed dead until a full page reload.

**Fix** (`src/core/globe/hooks/useGlobeCommandBridge.ts`):
- On `readyState === EventSource.CLOSED`, recreate the `EventSource` with the same session-scoped URL, restoring command consumption (the `onmessage` handler is re-wired on the new instance).
- Exponential backoff: 1s base, doubling per failed attempt, capped at 30s, reset to 1s on a successful `onopen`.
- Unmount cleanup now also clears any pending reconnect timer (no timers leak, no reconnect after unmount).
- Hook public API unchanged (`useGlobeCommandBridge(sessionId)`); event handler behavior preserved.

**Tests** (`src/core/globe/hooks/useGlobeCommandBridge.test.ts`, 14 total, all green):
- BRIDGE-08: reconnect after `readyState` CLOSED + consumption resumes on the reconnected stream
- BRIDGE-09: backoff doubles per failure, resets after `onopen`
- BRIDGE-10: unmount clears pending reconnect timer; reconnected EventSource is closed on unmount

**#390 note**: the stale app-shell/MCP consumption issue is a *different mechanism* (fetch polling + `setInterval` in `useMcpRelayBridge`/`useMcpCatalogPublisher`, which self-heal after restart) — not this hook. Reported as a follow-up, out of scope here.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors (CI Type Check job command)
- [x] `pnpm test` — 126 files, 1240 tests passed
- [x] `pnpm build` — success
- [x] `pnpm lint` — 0 errors (0 on changed files; pre-existing warnings only)

## Notes

- No version bump (matches recent fix merges #461/#462).
- Pact artifacts regenerated by the test run were reverted before commit.