### PR TITLE
fix(marketplace): disabled plugins stay disabled after refresh (#409)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.36",
+  "version": "2.65.37",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/app/api/marketplace/load/route.test.ts
+++ b/src/app/api/marketplace/load/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import { GET } from "./route";
+import { prisma } from "@/lib/db";
+
+/**
+ * Regression tests for #409: the bootstrap endpoint must NOT return
+ * disabled plugins. The load route is the source of the runtime plugin
+ * list on every refresh, so a plugin the operator disabled (enabled:
+ * false in installed_plugins) must stay out of the payload — otherwise
+ * it reloads on the next page refresh.
+ */
+
+vi.mock("@/lib/db", () => {
+    const mockPrisma = {
+        installedPlugin: {
+            findMany: vi.fn(),
+        },
+    };
+    return { prisma: mockPrisma };
+});
+
+vi.mock("@/lib/marketplace/auth", () => ({
+    // Default: request is authorized. Individual tests override.
+    validateMarketplaceAuth: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/marketplace/registryClient", () => ({
+    getVerifiedPluginIds: vi.fn().mockResolvedValue(new Set<string>()),
+}));
+
+vi.mock("@/lib/marketplace/seedDefaultPlugins", () => ({
+    seedDefaultPlugins: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/core/edition", () => ({
+    isDemo: false,
+    isDemoAdmin: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/ba-session", () => ({
+    getServerSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+    captureMessage: vi.fn(),
+}));
+
+const mockInstalledPlugin = prisma.installedPlugin as unknown as {
+    findMany: ReturnType<typeof vi.fn>;
+};
+
+/** Valid bundle manifest that passes validateManifest. */
+function makeRecord(pluginId: string, enabled: boolean) {
+    return {
+        pluginId,
+        version: "1.0.0",
+        enabled,
+        config: JSON.stringify({
+            id: pluginId,
+            name: pluginId,
+            version: "1.0.0",
+            type: "data-layer",
+            format: "bundle",
+            trust: "verified",
+            capabilities: ["data:own"],
+            category: "custom",
+            icon: "Box",
+            entry: `https://cdn.jsdelivr.net/npm/wwv-plugin-${pluginId}@1.0.0/index.mjs`,
+        }),
+    };
+}
+
+describe("Marketplace Load Route (#409 regression)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("excludes disabled plugins from the bootstrap payload", async () => {
+        const records = [
+            makeRecord("alpha", true),
+            makeRecord("bravo", false),
+        ];
+        // Emulate Prisma semantics: only rows matching where.enabled are returned.
+        mockInstalledPlugin.findMany.mockImplementation(
+            (args?: { where?: { enabled?: boolean } }) => {
+                const enabled = args?.where?.enabled;
+                const rows = enabled === undefined
+                    ? records
+                    : records.filter((r: { enabled: boolean }) => r.enabled === enabled);
+                return Promise.resolve(rows);
+            },
+        );
+
+        const res = await GET(new Request("http://localhost/api/marketplace/load"));
+        const data = await res.json();
+
+        // The query itself must be filtered to enabled rows.
+        expect(mockInstalledPlugin.findMany).toHaveBeenCalledWith({
+            where: { enabled: true },
+        });
+
+        // The disabled plugin must not appear in the manifests.
+        const ids = data.manifests.map((m: { id: string }) => m.id);
+        expect(ids).toContain("alpha");
+        expect(ids).not.toContain("bravo");
+        expect(res.status).toBe(200);
+    });
+
+    it("returns an empty payload when all installed plugins are disabled", async () => {
+        const records = [
+            makeRecord("alpha", false),
+            makeRecord("bravo", false),
+        ];
+        mockInstalledPlugin.findMany.mockImplementation(
+            (args?: { where?: { enabled?: boolean } }) => {
+                const enabled = args?.where?.enabled;
+                const rows = enabled === undefined
+                    ? records
+                    : records.filter((r: { enabled: boolean }) => r.enabled === enabled);
+                return Promise.resolve(rows);
+            },
+        );
+
+        const res = await GET(new Request("http://localhost/api/marketplace/load"));
+        const data = await res.json();
+
+        expect(data.manifests).toEqual([]);
+        expect(mockInstalledPlugin.findMany).toHaveBeenCalledWith({
+            where: { enabled: true },
+        });
+    });
+
+    it("rejects unauthenticated requests on non-demo editions", async () => {
+        const { validateMarketplaceAuth } = await import("@/lib/marketplace/auth");
+        vi.mocked(validateMarketplaceAuth).mockResolvedValue(
+            NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+        );
+
+        const res = await GET(new Request("http://localhost/api/marketplace/load"));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns an empty payload when the database read fails", async () => {
+        const { validateMarketplaceAuth } = await import("@/lib/marketplace/auth");
+        // Re-arm the default (cleared by the 401 test above): auth must pass
+        // so the route actually reaches the database read.
+        vi.mocked(validateMarketplaceAuth).mockResolvedValue(null);
+        mockInstalledPlugin.findMany.mockRejectedValue(new Error("DB down"));
+
+        const res = await GET(new Request("http://localhost/api/marketplace/load"));
+        const data = await res.json();
+
+        expect(data.manifests).toEqual([]);
+        expect(res.status).toBe(200);
+    });
+});

--- a/src/app/api/marketplace/load/route.ts
+++ b/src/app/api/marketplace/load/route.ts
@@ -37,7 +37,10 @@ export async function GET(request: Request) {
 
     try {
         const [records, verifiedIds] = await Promise.all([
-            prisma.installedPlugin.findMany(),
+            // Only enabled plugins belong in the runtime bootstrap. Disabled
+            // records (enabled: false) must stay out of the payload, otherwise
+            // a plugin the operator disabled reloads on the next refresh (#409).
+            prisma.installedPlugin.findMany({ where: { enabled: true } }),
             getVerifiedPluginIds(),
         ]);
 

--- a/src/components/panels/PluginsTab.tsx
+++ b/src/components/panels/PluginsTab.tsx
@@ -214,6 +214,21 @@ export function PluginsTab() {
         if (state.selectedEntity?.pluginId === pluginId) state.setSelectedEntity(null);
         setNeedsReload(true);
         trackEvent("plugin-disable", { plugin: pluginId });
+
+        // Persist the disabled state in the installed_plugins row as well,
+        // so the disabled plugin is also excluded from the bootstrap payload
+        // (/api/marketplace/load only returns enabled rows). Best-effort:
+        // the localStorage guard above still protects this browser.
+        try {
+            await fetch("/api/marketplace/disable", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ pluginId }),
+            });
+        } catch {
+            /* non-critical — localStorage state already applied */
+        }
+
         await loadPlugins();
         setRemoving(null);
     };
@@ -222,6 +237,19 @@ export function PluginsTab() {
         setRemoving(pluginId);
         setPluginDisabled(pluginId, false);
         setNeedsReload(false);
+
+        // Flip the DB flag before hot-loading: the load API only returns
+        // enabled plugins, so a disabled-at-startup plugin must be enabled
+        // server-side first or its manifest won't come back.
+        try {
+            await fetch("/api/marketplace/enable", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ pluginId }),
+            });
+        } catch {
+            /* non-critical — localStorage guard already cleared */
+        }
 
         const alreadyRegistered = pluginManager.getPlugin(pluginId);
         if (!alreadyRegistered) {


### PR DESCRIPTION
Closes #409

## Root cause

`GET /api/marketplace/load` is the bootstrap source of the runtime plugin list on every page refresh, but it called `prisma.installedPlugin.findMany()` with **no `enabled` filter** — every installed row came back regardless of disabled state. So a plugin the operator disabled (DB `enabled: false` in `installed_plugins`) reloaded on the next refresh.

The disable/enable API routes and repository functions (`disablePlugin`/`enablePlugin`) correctly persisted the flag, but nothing in the app UI called them — `PluginsTab` only wrote the browser-local `wwv-disabled-plugins` set, which never touched the shared DB state.

## Fix

1. `src/app/api/marketplace/load/route.ts` — query only `where: { enabled: true }` so disabled records never enter the bootstrap payload.
2. `src/components/panels/PluginsTab.tsx` — `handleDisable`/`handleEnable` now also POST to `/api/marketplace/disable` / `/api/marketplace/enable` (best-effort, localStorage guard retained), so the DB flag is flipped and the disabled plugin is excluded on every browser, not just the one where it was disabled. The enable path flips the DB flag before the hot-load fetch since the load API now only returns enabled plugins.

## Tests

`src/app/api/marketplace/load/route.test.ts` (4 tests):
- excludes disabled plugins from the bootstrap payload (asserts `findMany` called with `{ where: { enabled: true } }`)
- returns an empty payload when all installed plugins are disabled
- rejects unauthenticated requests on non-demo editions
- returns an empty payload when the database read fails

## Gates

- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm test` — 127 files, 1239 tests passed
- `pnpm build` — passed
- `pnpm lint` — 0 errors