### PR TITLE
fix(globe): entity selection picks resolve correctly (#398)

### DIFF
--- a/src/core/globe/GlobeView.tsx
+++ b/src/core/globe/GlobeView.tsx
@@ -147,7 +147,7 @@ enableLighting,
 
     useEffect(() => {
         if (!viewerRef.current || viewerRef.current.isDestroyed()) return;
-        return setupInteractionHandlers(viewerRef.current, hoveredEntityIdRef);
+        return setupInteractionHandlers(viewerRef.current, hoveredEntityIdRef, animatablesMapRef);
     }, [viewerReady]);
 
     useEffect(() => {

--- a/src/core/globe/InteractionHandler.test.ts
+++ b/src/core/globe/InteractionHandler.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { GeoEntity } from "@/core/plugins/PluginTypes";
+
+// Hoisted mocks: vi.mock factories cannot reference outer bindings.
+const mocks = vi.hoisted(() => {
+    const setSelectedEntity = vi.fn();
+    const setHoveredEntity = vi.fn();
+    const worldToWindow = vi.fn();
+    const handlerHolder: { current: any } = { current: null };
+
+    class FakeScreenSpaceEventHandler {
+        actions: Record<string, (event: unknown) => void> = {};
+        constructor(_canvas?: unknown) {
+            handlerHolder.current = this;
+        }
+        setInputAction(fn: (event: unknown) => void, type: string) {
+            this.actions[type] = fn;
+        }
+        destroy() {}
+        isDestroyed() { return false; }
+    }
+
+    return {
+        setSelectedEntity,
+        setHoveredEntity,
+        worldToWindow,
+        handlerHolder,
+        FakeScreenSpaceEventHandler,
+    };
+});
+
+vi.mock("@/core/state/store", () => ({
+    useStore: {
+        getState: () => ({
+            setSelectedEntity: mocks.setSelectedEntity,
+            setHoveredEntity: mocks.setHoveredEntity,
+            hoveredEntity: null,
+        }),
+    },
+}));
+
+vi.mock("cesium", () => ({
+    ScreenSpaceEventHandler: mocks.FakeScreenSpaceEventHandler,
+    ScreenSpaceEventType: { LEFT_CLICK: "LEFT_CLICK", MOUSE_MOVE: "MOUSE_MOVE" },
+    defined: (x: unknown) => x !== undefined && x !== null,
+    SceneMode: { MORPHING: "MORPHING" },
+    SceneTransforms: { worldToWindowCoordinates: mocks.worldToWindow },
+}));
+
+vi.mock("./StackManager", () => ({
+    findStackByEntityId: vi.fn(() => undefined),
+    expandStack: vi.fn(),
+    collapseStack: vi.fn(),
+    getStacks: vi.fn(() => new Map()),
+}));
+
+import {
+    setupInteractionHandlers,
+    extractWwvEntityFromPick,
+    extractWwvEntityFromPicks,
+    nearestEntityAtPosition,
+} from "./InteractionHandler";
+
+const aircraft: GeoEntity = {
+    id: "aviation-abc123",
+    pluginId: "aviation",
+    latitude: 51.47,
+    longitude: -0.45,
+    timestamp: new Date(),
+    properties: {},
+};
+
+function createViewer(picks: unknown[], pickResult: unknown) {
+    return {
+        isDestroyed: () => false,
+        scene: {
+            drillPick: vi.fn(() => picks),
+            pick: vi.fn(() => pickResult),
+            requestRender: vi.fn(),
+            canvas: document.createElement("canvas"),
+        },
+        camera: {
+            moveStart: { addEventListener: vi.fn(), removeEventListener: vi.fn() },
+            moveEnd: { addEventListener: vi.fn(), removeEventListener: vi.fn() },
+        },
+    };
+}
+
+describe("extractWwvEntityFromPick", () => {
+    it("returns the WWV entity for a tagged pick result", () => {
+        expect(extractWwvEntityFromPick({ id: { _wwvEntity: aircraft } })).toBe(aircraft);
+    });
+
+    it("returns the WWV entity for a tagged primitive (promoted glTF)", () => {
+        expect(extractWwvEntityFromPick({ primitive: { id: { _wwvEntity: aircraft } } })).toBe(aircraft);
+    });
+
+    it("returns null for unrelated Cesium picks", () => {
+        expect(extractWwvEntityFromPick({ primitive: {} })).toBeNull();
+    });
+
+    it("returns null for null/undefined pick results", () => {
+        expect(extractWwvEntityFromPick(null)).toBeNull();
+        expect(extractWwvEntityFromPick(undefined)).toBeNull();
+    });
+});
+
+describe("extractWwvEntityFromPicks", () => {
+    it("skips masking primitives in drill-pick order", () => {
+        expect(extractWwvEntityFromPicks([
+            { primitive: { kind: "label" } },
+            { id: { _wwvEntity: aircraft } },
+        ])).toBe(aircraft);
+    });
+
+    it("returns null when no drill-pick result belongs to WWV", () => {
+        expect(extractWwvEntityFromPicks([
+            { primitive: {} },
+            { id: { name: "unrelated" } },
+        ])).toBeNull();
+    });
+
+    it("returns null for an empty pick list", () => {
+        expect(extractWwvEntityFromPicks([])).toBeNull();
+    });
+});
+
+describe("nearestEntityAtPosition", () => {
+    it("selects the nearest visible screen-space fallback", () => {
+        const farther = { ...aircraft, id: "aviation-farther" };
+        expect(nearestEntityAtPosition([
+            { entity: farther, x: 114, y: 108, visible: true },
+            { entity: aircraft, x: 103, y: 104, visible: true },
+        ], { x: 100, y: 100 })).toBe(aircraft);
+    });
+
+    it("ignores hidden and out-of-radius fallback entities", () => {
+        expect(nearestEntityAtPosition([
+            { entity: aircraft, x: 101, y: 101, visible: false },
+            { entity: aircraft, x: 200, y: 200, visible: true },
+        ], { x: 100, y: 100 })).toBeNull();
+    });
+});
+
+describe("setupInteractionHandlers — click resolves picks", () => {
+    beforeEach(() => {
+        mocks.setSelectedEntity.mockClear();
+        mocks.setHoveredEntity.mockClear();
+        mocks.worldToWindow.mockReset();
+    });
+
+    it("selects an entity whose primitive is returned by drillPick", () => {
+        const viewer = createViewer([{ id: { _wwvEntity: aircraft } }], undefined);
+        setupInteractionHandlers(viewer as never, { current: null }, { current: new Map() } as never);
+
+        const click = mocks.handlerHolder.current.actions["LEFT_CLICK"];
+        click({ position: { x: 100, y: 100 } });
+
+        expect(mocks.setSelectedEntity).toHaveBeenCalledWith(aircraft);
+    });
+
+    it("falls back to plain pick when drillPick misses (custom scenes)", () => {
+        const viewer = createViewer([], { primitive: { id: { _wwvEntity: aircraft } } });
+        setupInteractionHandlers(viewer as never, { current: null }, { current: new Map() } as never);
+
+        const click = mocks.handlerHolder.current.actions["LEFT_CLICK"];
+        click({ position: { x: 100, y: 100 } });
+
+        expect(mocks.setSelectedEntity).toHaveBeenCalledWith(aircraft);
+    });
+
+    it("selects the nearest rendered entity via screen-space fallback when Cesium picks miss", () => {
+        mocks.worldToWindow.mockReturnValue({ x: 100, y: 100 });
+        const viewer = createViewer([], undefined);
+        const animatables = new Map([[
+            aircraft.id,
+            {
+                entity: aircraft,
+                posRef: {},
+                primitive: { pixelOffset: { x: 0, y: 0 }, show: true },
+                _occluded: false,
+            },
+        ]]);
+        setupInteractionHandlers(viewer as never, { current: null }, { current: animatables } as never);
+
+        const click = mocks.handlerHolder.current.actions["LEFT_CLICK"];
+        click({ position: { x: 100, y: 100 } });
+
+        expect(mocks.setSelectedEntity).toHaveBeenCalledWith(aircraft);
+    });
+
+    it("clears selection when no entity resolves and the fallback finds nothing", () => {
+        mocks.worldToWindow.mockReturnValue({ x: 100, y: 100 });
+        const viewer = createViewer([], undefined);
+        const animatables = new Map([[
+            aircraft.id,
+            {
+                entity: aircraft,
+                posRef: {},
+                primitive: { pixelOffset: { x: 0, y: 0 }, show: false }, // hidden
+                _occluded: false,
+            },
+        ]]);
+        setupInteractionHandlers(viewer as never, { current: null }, { current: animatables } as never);
+
+        const click = mocks.handlerHolder.current.actions["LEFT_CLICK"];
+        click({ position: { x: 100, y: 100 } });
+
+        expect(mocks.setSelectedEntity).toHaveBeenCalledWith(null);
+    });
+});

--- a/src/core/globe/InteractionHandler.ts
+++ b/src/core/globe/InteractionHandler.ts
@@ -8,19 +8,165 @@ import {
 import type { Viewer as CesiumViewer, Cartesian2 } from "cesium";
 import type { GeoEntity } from "@/core/plugins/PluginTypes";
 import { useStore } from "@/core/state/store";
+import type { AnimatableItem } from "./EntityRenderer";
 import {
     findStackByEntityId, expandStack, collapseStack, getStacks
 } from "./StackManager";
 
+/** Upper bound for the front-to-back drill-pick walk per click. */
+const DRILL_PICK_LIMIT = 16;
+
+/** Screen-space radius (px) for the proximity fallback when native picking misses. */
+const CLICK_PROXIMITY_RADIUS_PX = 20;
+
 /**
- * Pick a WorldWideView entity at a screen position using the Cesium pick API.
+ * Pull a WorldWideView entity out of a Cesium pick result.
+ * Point/billboard primitives tag themselves via `picked.id`; promoted glTF
+ * models expose the tag on `picked.primitive.id`.
  */
-function findEntityAtPosition(viewer: CesiumViewer, position: { x: number; y: number }): GeoEntity | null {
-    if (!viewer || viewer.isDestroyed()) return null;
-    const picked = viewer.scene.pick(position as Cartesian2);
-    if (defined(picked) && picked.id && picked.id._wwvEntity) {
-        return picked.id._wwvEntity as GeoEntity;
+export function extractWwvEntityFromPick(picked: unknown): GeoEntity | null {
+    if (!picked || typeof picked !== "object") return null;
+    const result = picked as { id?: unknown; primitive?: unknown };
+
+    const fromId = readTaggedEntity(result.id);
+    if (fromId) return fromId;
+
+    if (result.primitive && typeof result.primitive === "object") {
+        const fromPrimitive = readTaggedEntity((result.primitive as { id?: unknown }).id);
+        if (fromPrimitive) return fromPrimitive;
     }
+    return null;
+}
+
+/** Return the first WWV entity from Cesium's front-to-back drill-pick results. */
+export function extractWwvEntityFromPicks(picks: unknown[]): GeoEntity | null {
+    for (const picked of picks) {
+        const entity = extractWwvEntityFromPick(picked);
+        if (entity) return entity;
+    }
+    return null;
+}
+
+export interface ScreenEntityCandidate {
+    entity: GeoEntity;
+    x: number;
+    y: number;
+    visible: boolean;
+}
+
+/** Return the closest visible entity inside the supplied screen-space radius. */
+export function nearestEntityAtPosition(
+    candidates: ScreenEntityCandidate[],
+    position: { x: number; y: number },
+    radius: number = CLICK_PROXIMITY_RADIUS_PX
+): GeoEntity | null {
+    let nearest: GeoEntity | null = null;
+    let nearestSquared = radius * radius;
+    for (const candidate of candidates) {
+        if (!candidate.visible) continue;
+        const dx = candidate.x - position.x;
+        const dy = candidate.y - position.y;
+        const distanceSquared = dx * dx + dy * dy;
+        if (distanceSquared < nearestSquared) {
+            nearestSquared = distanceSquared;
+            nearest = candidate.entity;
+        }
+    }
+    return nearest;
+}
+
+/**
+ * Resolve a click by screen-space proximity against the primitives we actually
+ * rendered. Collapsed clusters project their hub; expanded spider stacks project
+ * each child plus its pixel offset. Clicks only — the hover path stays cheap.
+ */
+export function findEntityByScreenDistance(
+    viewer: CesiumViewer,
+    position: { x: number; y: number },
+    animatables: Map<string, AnimatableItem>
+): GeoEntity | null {
+    const candidates: ScreenEntityCandidate[] = [];
+    const stackedIds = new Set<string>();
+
+    for (const stack of getStacks().values()) {
+        for (const item of stack.children) stackedIds.add(item.entity.id);
+
+        if (stack.state === "collapsed" || stack.state === "collapsing") {
+            const screen = SceneTransforms.worldToWindowCoordinates(viewer.scene, stack.hubItem.posRef);
+            if (!screen) continue;
+            candidates.push({
+                entity: stack.hubItem.entity,
+                x: screen.x,
+                y: screen.y,
+                visible: !stack.hubItem._occluded,
+            });
+            continue;
+        }
+
+        for (const item of stack.children) {
+            if (!item.primitive) continue;
+            const screen = SceneTransforms.worldToWindowCoordinates(viewer.scene, item.posRef);
+            if (!screen) continue;
+            const offset = item.primitive.pixelOffset;
+            candidates.push({
+                entity: item.entity,
+                x: screen.x + (offset?.x ?? 0),
+                y: screen.y + (offset?.y ?? 0),
+                visible: !item._occluded && item.primitive.show !== false,
+            });
+        }
+    }
+
+    for (const item of animatables.values()) {
+        if (stackedIds.has(item.entity.id)) continue;
+        if (!item.primitive) continue;
+        const screen = SceneTransforms.worldToWindowCoordinates(viewer.scene, item.posRef);
+        if (!screen) continue;
+        const offset = item.primitive.pixelOffset;
+        candidates.push({
+            entity: item.entity,
+            x: screen.x + (offset?.x ?? 0),
+            y: screen.y + (offset?.y ?? 0),
+            visible: !item._occluded && item.primitive.show !== false,
+        });
+    }
+
+    return nearestEntityAtPosition(candidates, position);
+}
+
+/**
+ * Prefer the live entity from the animatables map over the tagged snapshot held
+ * by a primitive, so selections never resolve to a stale polled position.
+ */
+function resolveLiveEntity(entity: GeoEntity, animatables?: Map<string, AnimatableItem>): GeoEntity {
+    if (!animatables) return entity;
+    const live = animatables.get(entity.id);
+    return live ? live.entity : entity;
+}
+
+/**
+ * Pick a WorldWideView entity at a screen position.
+ * Fast path: native Cesium picking (front-to-back drill walk, then a plain pick
+ * for scenes that do not expose the same objects through drillPick). Fallback:
+ * screen-space proximity against rendered primitives, only when a caller can
+ * supply the animatables map (clicks; never the continuous hover path).
+ */
+export function findEntityAtPosition(
+    viewer: CesiumViewer,
+    position: { x: number; y: number },
+    animatables?: Map<string, AnimatableItem>
+): GeoEntity | null {
+    if (!viewer || viewer.isDestroyed()) return null;
+
+    const picks = viewer.scene.drillPick(position as Cartesian2, DRILL_PICK_LIMIT) ?? [];
+    const drilled = extractWwvEntityFromPicks(picks);
+    if (drilled) return resolveLiveEntity(drilled, animatables);
+
+    const picked = viewer.scene.pick(position as Cartesian2);
+    const pickedEntity = defined(picked) ? extractWwvEntityFromPick(picked) : null;
+    if (pickedEntity) return resolveLiveEntity(pickedEntity, animatables);
+
+    if (animatables) return findEntityByScreenDistance(viewer, position, animatables);
     return null;
 }
 
@@ -30,7 +176,8 @@ function findEntityAtPosition(viewer: CesiumViewer, position: { x: number; y: nu
  */
 export function setupInteractionHandlers(
     viewer: CesiumViewer,
-    hoveredEntityIdRef: React.MutableRefObject<string | null>
+    hoveredEntityIdRef: React.MutableRefObject<string | null>,
+    animatablesMapRef: React.MutableRefObject<Map<string, AnimatableItem>>
 ): () => void {
     if (!viewer || viewer.isDestroyed() || !viewer.scene) {
         return () => { };
@@ -45,7 +192,7 @@ export function setupInteractionHandlers(
     handler.setInputAction(
         (event: { position: { x: number; y: number } }) => {
             if (!viewer || viewer.isDestroyed()) return;
-            const entity = findEntityAtPosition(viewer, event.position);
+            const entity = findEntityAtPosition(viewer, event.position, animatablesMapRef.current);
 
             if (entity) {
                 const stack = findStackByEntityId(entity.id);
@@ -125,6 +272,7 @@ export function setupInteractionHandlers(
                 if (currentRequestId !== latestHoverRequestId) return;
                 if (!viewer || viewer.isDestroyed() || isDragging) return;
 
+                // Hover keeps the cheap native path — no proximity fallback.
                 const entity = findEntityAtPosition(viewer, pos);
 
                 const prevId = hoveredEntityIdRef.current;
@@ -155,4 +303,12 @@ export function setupInteractionHandlers(
             canvas.style.cursor = "default";
         }
     };
+}
+
+/** Read the `_wwvEntity` tag off an arbitrary pick payload object. */
+function readTaggedEntity(tagged: unknown): GeoEntity | null {
+    if (!tagged || typeof tagged !== "object") return null;
+    const entity = (tagged as { _wwvEntity?: unknown })._wwvEntity;
+    if (!entity || typeof entity !== "object") return null;
+    return entity as GeoEntity;
 }


### PR DESCRIPTION
Closes #398

## Root cause

Entity primitives (billboards/points/labels) are rendered into Cesium collections with an \id: { _wwvEntity: entity }\ tag, and the click handler resolved picks via a single \iewer.scene.pick()\ that only read \picked.id._wwvEntity\. With 9k-10k rendered entities (e.g. Aviation), a single pick frequently returns a masking primitive (terrain, an unrelated label/model, or an occluding primitive) or misses entirely, so \selectedEntity\ never gets set and the Intel sidebar stays on the layer legend.

## Fix

- \InteractionHandler.ts\: resolution now walks a front-to-back \drillPick(..., 16)\ list via \xtractWwvEntityFromPicks\, keeps a plain \pick()\ fallback for custom scenes, and maps through both \picked.id\ and \picked.primitive.id\ so promoted glTF models resolve too.
- Click-only screen-space proximity fallback (\indEntityByScreenDistance\): projects rendered \AnimatableItem\ positions with \SceneTransforms.worldToWindowCoordinates\, respects occlusion and primitive visibility, and covers collapsed stack hubs plus expanded spider offsets. Runs only for clicks, never the continuous hover path.
- \GlobeView.tsx\: passes the \nimatablesMapRef\ into \setupInteractionHandlers\ so the click path can reach rendered primitives.

## Tests

\InteractionHandler.test.ts\ (new, 13 tests): pick shape variants (tagged id, tagged primitive/glTF), drill-pick masking order, nearest-visible screen-space selection, hidden/out-of-radius exclusion, and a full click-path simulation asserting \setSelectedEntity\ fires via drill-pick, plain-pick fallback, and screen-space fallback (and clears on empty pick).

## Verification

- \pnpm exec tsc --noEmit\ (CI-exact typecheck): 0 errors
- \pnpm test\: 1359 passed (4 fork-pool worker start timeouts on unrelated files, all pass in isolation)
- \pnpm build\: exit 0
- \pnpm lint\: 0 errors (306 pre-existing warnings)