### PR TITLE
fix(camera): harden extract route against SSRF via safeFetch

### DIFF
--- a/src/app/api/camera/extract/route.test.ts
+++ b/src/app/api/camera/extract/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+vi.mock("@/lib/ba-session", () => ({
+    getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/security/ssrf", async (importOriginal) => {
+    const original = await importOriginal<typeof import("@/lib/security/ssrf")>();
+    return { ...original, safeFetch: vi.fn() };
+});
+
+import { getServerSession } from "@/lib/ba-session";
+import { safeFetch } from "@/lib/security/ssrf";
+
+/** Minimal fake Response: jsdom cannot read Response bodies, so the route's
+ *  `.text()` calls need a small object that resolves directly. */
+function htmlResponse(body: string): Response {
+    return { text: () => Promise.resolve(body) } as unknown as Response;
+}
+
+const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+
+function mockGetRequest(urlParam?: string): NextRequest {
+    const url = new URL("http://localhost/api/camera/extract");
+    if (urlParam !== undefined) url.searchParams.set("url", urlParam);
+    return new NextRequest(url, { method: "GET" });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "u1" } } as never);
+});
+
+describe("GET /api/camera/extract", () => {
+    it("returns 401 when unauthenticated", async () => {
+        vi.mocked(getServerSession).mockResolvedValue(null as never);
+        const res = await GET(mockGetRequest("https://balticlivecam.com/camera/1"));
+        expect(res.status).toBe(401);
+        expect(safeFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when url is missing", async () => {
+        const res = await GET(mockGetRequest());
+        expect(res.status).toBe(400);
+        expect(safeFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a host that merely contains the allowed string in its path", async () => {
+        const res = await GET(mockGetRequest("https://evil.com/balticlivecam.com/cam"));
+        expect(res.status).toBe(400);
+        expect(safeFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a lookalike host with the allowed string as a prefix", async () => {
+        const res = await GET(mockGetRequest("https://balticlivecam.com.evil.com/cam"));
+        expect(res.status).toBe(400);
+        expect(safeFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-web protocols even with a matching hostname", async () => {
+        const res = await GET(mockGetRequest("ftp://balticlivecam.com/cam"));
+        expect(res.status).toBe(400);
+        expect(safeFetch).not.toHaveBeenCalled();
+    });
+
+    it("allows a real balticlivecam URL and strips userinfo before fetching", async () => {
+        vi.mocked(safeFetch).mockResolvedValueOnce(
+            htmlResponse("<html>var id: 123;</html>"),
+        );
+        vi.mocked(safeFetch).mockResolvedValueOnce(
+            htmlResponse("<html>var src: 'https://balticlivecam.com/live/cam.m3u8?token=abc';</html>"),
+        );
+
+        const res = await GET(mockGetRequest("https://user:pass@balticlivecam.com/camera/1"));
+        expect(res.status).toBe(200);
+
+        // The URL actually fetched must never contain the userinfo credentials.
+        const firstCallUrl = vi.mocked(safeFetch).mock.calls[0][0];
+        expect(firstCallUrl).not.toContain("user:pass");
+        expect(firstCallUrl.startsWith("https://balticlivecam.com/")).toBe(true);
+
+        const body = await res.json();
+        expect(body.streamUrl).toBe("https://balticlivecam.com/live/cam.m3u8?token=abc");
+    });
+
+    it("rejects an extracted m3u8 whose host is not balticlivecam", async () => {
+        vi.mocked(safeFetch).mockResolvedValueOnce(
+            htmlResponse("<html>var id: 123;</html>"),
+        );
+        vi.mocked(safeFetch).mockResolvedValueOnce(
+            htmlResponse("<html>var src: 'https://evil.com/live/cam.m3u8?token=abc';</html>"),
+        );
+
+        const res = await GET(mockGetRequest("https://balticlivecam.com/camera/1"));
+        expect(res.status).toBe(400);
+    });
+});

--- a/src/app/api/camera/extract/route.ts
+++ b/src/app/api/camera/extract/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "@/lib/ba-session";
+import { safeFetch } from "@/lib/security/ssrf";
+import { isHostAllowlisted } from "@/lib/security/hostAllowlist";
 
 export async function GET(req: NextRequest) {
     const session = await getServerSession();
@@ -13,35 +15,57 @@ export async function GET(req: NextRequest) {
     }
 
     try {
-        if (targetUrl.includes("balticlivecam.com")) {
-            const response = await fetch(targetUrl, {
-                headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" },
-            });
-            const html = await response.text();
-
-            const idMatch = html.match(/id:\s*(\d+)/);
-            if (!idMatch) {
-                return NextResponse.json({ error: "Could not find camera ID on balticlivecam" }, { status: 400 });
-            }
-            const cameraId = idMatch[1];
-
-            const ajaxUrl = `https://balticlivecam.com/wp-admin/admin-ajax.php?action=auth_token&id=${cameraId}&embed=1&main_referer=`;
-            const ajaxRes = await fetch(ajaxUrl, {
-                headers: {
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-                    Referer: targetUrl
-                }
-            });
-            const ajaxHtml = await ajaxRes.text();
-
-            const streamMatch = ajaxHtml.match(/src:\s*'([^']+m3u8[^']+)'/);
-            if (streamMatch && streamMatch[1]) {
-                return NextResponse.json({ streamUrl: streamMatch[1] });
-            }
-                return NextResponse.json({ error: "Could not find m3u8 stream on balticlivecam backend" }, { status: 404 });
+        // Only balticlivecam.com (or a subdomain) may be extracted. The check
+        // runs on the parsed hostname -- never a raw substring over the whole
+        // URL -- so arbitrary hosts cannot precede or follow the allowed
+        // domain. Userinfo is stripped after validation so credentials never
+        // reach the network. Every outbound request goes through safeFetch
+        // (PROXY_HOST_ALLOWLIST + protocol check + DNS-pinned private-IP
+        // check + redirect:"manual"), matching the camera stream proxy.
+        if (!isHostAllowlisted(targetUrl, ["balticlivecam.com"])) {
+            return NextResponse.json({ error: "Unsupported extractor platform" }, { status: 400 });
         }
 
-        return NextResponse.json({ error: "Unsupported extractor platform" }, { status: 400 });
+        const resolved = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(targetUrl) ? targetUrl : `https://${targetUrl}`;
+        const parsedTarget = new URL(resolved);
+        parsedTarget.username = "";
+        parsedTarget.password = "";
+        const extractUrl = parsedTarget.toString();
+
+        const response = await safeFetch(extractUrl, {
+            headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" },
+            maxSize: 2 * 1024 * 1024,
+        });
+        const html = await response.text();
+
+        const idMatch = html.match(/id:\s*(\d+)/);
+        if (!idMatch) {
+            return NextResponse.json({ error: "Could not find camera ID on balticlivecam" }, { status: 400 });
+        }
+        const cameraId = idMatch[1];
+
+        const ajaxUrl = `https://balticlivecam.com/wp-admin/admin-ajax.php?action=auth_token&id=${cameraId}&embed=1&main_referer=`;
+        const ajaxRes = await safeFetch(ajaxUrl, {
+            headers: {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+                Referer: extractUrl
+            },
+            maxSize: 2 * 1024 * 1024,
+        });
+        const ajaxHtml = await ajaxRes.text();
+
+        const streamMatch = ajaxHtml.match(/src:\s*'([^']+m3u8[^']+)'/);
+        if (streamMatch && streamMatch[1]) {
+            // The m3u8 URL comes from the balticlivecam backend, but it is
+            // still attacker-influenced HTML; only return it when the hostname
+            // is balticlivecam.com so the client never renders an arbitrary
+            // origin as a stream source.
+            if (!isHostAllowlisted(streamMatch[1], ["balticlivecam.com"])) {
+                return NextResponse.json({ error: "Extracted stream host is not allowlisted" }, { status: 400 });
+            }
+            return NextResponse.json({ streamUrl: streamMatch[1] });
+        }
+            return NextResponse.json({ error: "Could not find m3u8 stream on balticlivecam backend" }, { status: 404 });
     } catch (error: any) {
         console.error("[CameraExtractor] Error:", error.message);
         return NextResponse.json({ error: "Failed to extract stream" }, { status: 500 });


### PR DESCRIPTION
Fixes the open CodeQL alerts on main for src/app/api/camera/extract/route.ts: js/request-forgery (#19) and js/incomplete-url-substring-sanitization (#4).

The extract route previously gated the balticlivecam fetch on `targetUrl.includes("balticlivecam.com")` (a substring check over the whole URL) and fetched directly. This change:

- Routes every outbound request through `safeFetch` (PROXY_HOST_ALLOWLIST + protocol check + DNS-pinned private-IP check + redirect:manual), matching the camera stream proxy.
- Keeps a parsed-hostname allowlist via `isHostAllowlisted` (exact or .subdomain match, userinfo stripped before fetch).
- Validates the extracted m3u8 against the same allowlist before returning it, so the client never renders an arbitrary origin as a stream source.

Adds route-level tests covering SSRF rejection (path-embedded host, prefix-lookalike host, non-web protocol), userinfo stripping, and extracted-host validation.
