### PR TITLE
feat(alerts): alert UI panel and condition builder

### DIFF
--- a/public/e2e-fixtures/alert-mock-manifest.json
+++ b/public/e2e-fixtures/alert-mock-manifest.json
@@ -8,7 +8,7 @@
   "format": "bundle",
   "trust": "unverified",
   "entry": "/e2e-fixtures/alert-mock-plugin.js",
-  "capabilities": [],
+  "capabilities": ["ui:sidebar"],
   "category": "utility",
-  "extends": []
+  "extends": ["sidebar"]
 }

--- a/public/e2e-fixtures/alert-mock-manifest.json
+++ b/public/e2e-fixtures/alert-mock-manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "e2e-alert-mock",
+  "name": "E2E Alert Mock",
+  "version": "1.0.0",
+  "description": "A mock plugin declaring alert definitions, used for the alerts Playwright E2E tests.",
+  "author": "WorldWideView Automated Tests",
+  "type": "extension",
+  "format": "bundle",
+  "trust": "unverified",
+  "entry": "/e2e-fixtures/alert-mock-plugin.js",
+  "capabilities": [],
+  "category": "utility",
+  "extends": []
+}

--- a/public/e2e-fixtures/alert-mock-plugin.js
+++ b/public/e2e-fixtures/alert-mock-plugin.js
@@ -1,0 +1,42 @@
+// Mock plugin declaring alert definitions, used by the alerts E2E suite.
+// The test drives payloads through the global hook and asks PluginManager to
+// refetch, which flows through the real dataBus -> alert engine path.
+
+let payload = [];
+
+globalThis.__setE2eAlertMockPayload = (entities) => {
+    payload = Array.isArray(entities) ? entities : [];
+};
+
+export default {
+    id: "e2e-alert-mock",
+    name: "E2E Alert Mock",
+    description: "Mock plugin declaring alert definitions for alerts E2E tests.",
+    icon: "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+    category: "custom",
+    version: "1.0.0",
+
+    initialize: async () => {},
+    destroy: () => {},
+
+    fetch: async () => payload,
+    getPollingInterval: () => 60000,
+
+    getLayerConfig: () => ({
+        color: "#38bdf8",
+        clusterEnabled: false,
+        clusterDistance: 50,
+    }),
+
+    renderEntity: () => ({
+        type: "point",
+        color: "#38bdf8",
+        size: 5,
+    }),
+
+    getAlertDefinitions: () => [
+        { key: "magnitude", label: "Magnitude", type: "number" },
+        { key: "place", label: "Place", type: "string" },
+        { key: "felt", label: "Felt", type: "boolean" },
+    ],
+};

--- a/src/components/alerts/AlertRuleForm.module.css
+++ b/src/components/alerts/AlertRuleForm.module.css
@@ -1,0 +1,109 @@
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    background: var(--glass-bg, rgba(255, 255, 255, 0.03));
+}
+
+.fieldRow {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+}
+
+.input {
+    width: 100%;
+    padding: 7px 10px;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-sm);
+    background: rgba(0, 0, 0, 0.25);
+    color: var(--text-primary);
+    font-size: 13px;
+    outline: none;
+    transition: border-color var(--duration-normal) var(--ease-spring);
+}
+
+.input:focus {
+    border-color: rgba(56, 189, 248, 0.6);
+}
+
+.error {
+    margin: 0;
+    font-size: 12px;
+    color: #f87171;
+}
+
+.actions {
+    display: flex;
+    gap: var(--space-sm);
+    margin-top: 2px;
+}
+
+.save {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: rgba(56, 189, 248, 0.25);
+    color: #7dd3fc;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--duration-normal) var(--ease-spring);
+}
+
+.save:hover:not(:disabled) {
+    background: rgba(56, 189, 248, 0.4);
+}
+
+.save:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.cancel {
+    padding: 8px 12px;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.cancel:hover {
+    color: var(--text-primary);
+}
+
+.empty {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: var(--space-md);
+    border: 1px dashed var(--glass-border);
+    border-radius: var(--radius-md);
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.emptyHint {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
+.empty code {
+    font-family: var(--font-mono, monospace);
+}

--- a/src/components/alerts/AlertRuleForm.spec.tsx
+++ b/src/components/alerts/AlertRuleForm.spec.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useStore } from "@/core/state/store";
+import { AlertRuleForm } from "./AlertRuleForm";
+import type { AlertablePlugin } from "@/lib/alerts/alertablePlugins";
+
+const PLUGINS: AlertablePlugin[] = [
+    {
+        id: "quakes",
+        name: "Earthquakes",
+        definitions: [
+            { key: "magnitude", label: "Magnitude", type: "number" },
+            { key: "place", label: "Place", type: "string" },
+            { key: "felt", label: "Felt", type: "boolean" },
+        ],
+    },
+];
+
+describe("AlertRuleForm — condition builder", () => {
+    beforeEach(() => {
+        useStore.setState({
+            alertRules: [],
+            alertRulesLoading: false,
+            alertRulesError: null,
+            alertUnreadCount: 0,
+            alertToasts: [],
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("renders the plugin, field and operator selects for the default plugin/field", () => {
+        render(<AlertRuleForm plugins={PLUGINS} />);
+
+        const pluginSelect = screen.getByTestId("alert-rule-plugin-select");
+        expect(pluginSelect).toBeDefined();
+        expect(screen.getByTestId("alert-rule-field-select")).toBeDefined();
+
+        const opSelect = screen.getByTestId("alert-rule-op-select") as HTMLSelectElement;
+        const ops = Array.from(opSelect.options).map((o) => o.value);
+        // Number fields: numeric + eq/neq/exists, never "contains".
+        expect(ops).toEqual(["gt", "lt", "gte", "lte", "eq", "neq", "exists"]);
+    });
+
+    it("restricts operators when the field changes to a string type", () => {
+        render(<AlertRuleForm plugins={PLUGINS} />);
+        const fieldSelect = screen.getByTestId("alert-rule-field-select");
+        fireEvent.change(fieldSelect, { target: { value: "place" } });
+
+        const opSelect = screen.getByTestId("alert-rule-op-select") as HTMLSelectElement;
+        const ops = Array.from(opSelect.options).map((o) => o.value);
+        expect(ops).toEqual(["eq", "neq", "contains", "exists"]);
+    });
+
+    it("switches the value input to a true/false select for boolean fields", () => {
+        render(<AlertRuleForm plugins={PLUGINS} />);
+        const fieldSelect = screen.getByTestId("alert-rule-field-select");
+        fireEvent.change(fieldSelect, { target: { value: "felt" } });
+
+        const valueSelect = screen.getByTestId("alert-rule-value-select") as HTMLSelectElement;
+        expect(Array.from(valueSelect.options).map((o) => o.value)).toEqual(["true", "false"]);
+        expect(screen.queryByTestId("alert-rule-value-input")).toBeNull();
+    });
+
+    it("hides the value input for the exists operator", () => {
+        render(<AlertRuleForm plugins={PLUGINS} />);
+        const opSelect = screen.getByTestId("alert-rule-op-select");
+        fireEvent.change(opSelect, { target: { value: "exists" } });
+        expect(screen.queryByTestId("alert-rule-value-input")).toBeNull();
+    });
+
+    it("builds a correct number-typed condition payload on save", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 201,
+            json: async () => ({ rule: { id: "r1" } }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        const onCreated = vi.fn();
+        render(<AlertRuleForm plugins={PLUGINS} onCreated={onCreated} />);
+
+        fireEvent.change(screen.getByTestId("alert-rule-name-input"), { target: { value: "Big quake" } });
+        fireEvent.change(screen.getByTestId("alert-rule-value-input"), { target: { value: "5.5" } });
+        fireEvent.click(screen.getByTestId("alert-rule-save"));
+
+        await waitFor(() => expect(onCreated).toHaveBeenCalled());
+        const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        expect(call[0]).toBe("/api/alerts");
+        expect(call[1].method).toBe("POST");
+        expect(JSON.parse(String(call[1].body))).toEqual({
+            pluginId: "quakes",
+            name: "Big quake",
+            condition: { field: "magnitude", op: "gt", value: 5.5 },
+        });
+    });
+
+    it("omits value from the saved condition when operator is exists", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 201,
+            json: async () => ({ rule: { id: "r2" } }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        const onCreated = vi.fn();
+        render(<AlertRuleForm plugins={PLUGINS} onCreated={onCreated} />);
+
+        fireEvent.change(screen.getByTestId("alert-rule-name-input"), { target: { value: "Has place" } });
+        const opSelect = screen.getByTestId("alert-rule-op-select");
+        fireEvent.change(opSelect, { target: { value: "exists" } });
+        const fieldSelect = screen.getByTestId("alert-rule-field-select");
+        fireEvent.change(fieldSelect, { target: { value: "place" } });
+        // Changing the field resets the operator to the first allowed one (eq);
+        // choose exists again after the reset.
+        fireEvent.change(screen.getByTestId("alert-rule-op-select"), { target: { value: "exists" } });
+
+        fireEvent.click(screen.getByTestId("alert-rule-save"));
+
+        await waitFor(() => expect(onCreated).toHaveBeenCalled());
+        const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const body = JSON.parse(String(call[1].body)) as { condition: Record<string, unknown> };
+        expect(body.condition).toEqual({ field: "place", op: "exists" });
+        expect("value" in body.condition).toBe(false);
+    });
+
+    it("blocks saving without a rule name", () => {
+        render(<AlertRuleForm plugins={PLUGINS} />);
+        fireEvent.click(screen.getByTestId("alert-rule-save"));
+        expect(screen.getByTestId("alert-form-error").textContent).toContain("name");
+    });
+
+    it("shows an explanatory empty state when no alertable plugins exist", () => {
+        render(<AlertRuleForm plugins={[]} />);
+        expect(screen.getByTestId("alert-form-empty")).toBeDefined();
+        expect(screen.getByText(/getAlertDefinitions/)).toBeDefined();
+    });
+});

--- a/src/components/alerts/AlertRuleForm.tsx
+++ b/src/components/alerts/AlertRuleForm.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+/**
+ * @file AlertRuleForm.tsx
+ * @description Alert rule creation form with a plugin-driven condition builder.
+ * The plugin list comes from the live plugin registry (plugins declaring
+ * `getAlertDefinitions`); operators are constrained to what the selected
+ * field's type allows, and value inputs are typed per field type
+ * (number / string / boolean).
+ * @module src/components/alerts
+ */
+
+import { useState } from "react";
+import type { AlertOperator } from "@worldwideview/wwv-plugin-sdk";
+import type { AlertablePlugin } from "@/lib/alerts/alertablePlugins";
+import { getAlertablePlugins } from "@/lib/alerts/alertablePlugins";
+import { OPERATOR_LABELS, operatorsForField } from "@/lib/alerts/format";
+import { useStore } from "@/core/state/store";
+import styles from "./AlertRuleForm.module.css";
+
+export interface AlertRuleFormProps {
+    /** Alertable plugins; defaults to the live registry enumeration. */
+    plugins?: AlertablePlugin[];
+    onCreated?: () => void;
+    onCancel?: () => void;
+}
+
+interface CreatePayload {
+    pluginId: string;
+    name: string;
+    condition: { field: string; op: AlertOperator; value?: unknown };
+}
+
+function firstOperator(field: { type: "number" | "string" | "boolean"; operators?: AlertOperator[] }): AlertOperator {
+    return operatorsForField(field)[0];
+}
+
+function defaultValueFor(field: { type: "number" | "string" | "boolean" }): string {
+    return field.type === "number" ? "0" : field.type === "boolean" ? "true" : "";
+}
+
+/**
+ * @component AlertRuleForm
+ * @description Builds a single-condition alert rule: pick a plugin, then a
+ * field exposed by that plugin's AlertFieldDefinitions, an operator valid for
+ * the field type, and a typed value. POSTs on save.
+ */
+export function AlertRuleForm({ plugins: pluginProp, onCreated, onCancel }: AlertRuleFormProps) {
+    const createAlert = useStore((s) => s.createAlert);
+    // Enumerate the live plugin registry when the caller does not pass a fixed
+    // list, so the builder shows whatever alertable plugins are registered.
+    const plugins: AlertablePlugin[] = pluginProp ?? getAlertablePlugins();
+
+    const [pluginId, setPluginId] = useState<string>(() => plugins[0]?.id ?? "");
+    const selectedPlugin = plugins.find((p) => p.id === pluginId);
+
+    const [fieldKey, setFieldKey] = useState<string>(() => selectedPlugin?.definitions[0]?.key ?? "");
+    const selectedField = selectedPlugin?.definitions.find((d) => d.key === fieldKey);
+
+    const [op, setOp] = useState<AlertOperator>(() =>
+        selectedField ? firstOperator(selectedField) : "eq",
+    );
+    const [valueInput, setValueInput] = useState<string>(() =>
+        selectedField ? defaultValueFor(selectedField) : "",
+    );
+    const [name, setName] = useState("");
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handlePluginChange = (nextPluginId: string) => {
+        const nextPlugin = plugins.find((p) => p.id === nextPluginId);
+        if (!nextPlugin) return;
+        setPluginId(nextPluginId);
+        const nextField = nextPlugin.definitions[0];
+        setFieldKey(nextField?.key ?? "");
+        setOp(nextField ? firstOperator(nextField) : "eq");
+        setValueInput(nextField ? defaultValueFor(nextField) : "");
+        setError(null);
+    };
+
+    const handleFieldChange = (nextKey: string) => {
+        const nextField = selectedPlugin?.definitions.find((d) => d.key === nextKey);
+        if (!nextField) return;
+        setFieldKey(nextKey);
+        setOp(firstOperator(nextField));
+        setValueInput(defaultValueFor(nextField));
+        setError(null);
+    };
+
+    const handleSave = async () => {
+        if (!selectedPlugin || !selectedField) {
+            setError("Select a plugin and a field first.");
+            return;
+        }
+        if (!selectedPlugin.definitions.some((d) => d.key === fieldKey)) {
+            setError("The selected field is not alertable by this plugin.");
+            return;
+        }
+        if (name.trim() === "") {
+            setError("Give the rule a name.");
+            return;
+        }
+
+        if (!operatorsForField(selectedField).includes(op)) {
+            setError("The chosen operator is not valid for this field type.");
+            return;
+        }
+
+        let parsedValue: unknown;
+        if (op === "exists") {
+            parsedValue = undefined;
+        } else if (selectedField.type === "number") {
+            parsedValue = Number(valueInput);
+            if (valueInput.trim() === "" || Number.isNaN(parsedValue)) {
+                setError("Enter a valid number.");
+                return;
+            }
+        } else if (selectedField.type === "boolean") {
+            parsedValue = valueInput === "true";
+        } else {
+            parsedValue = valueInput;
+        }
+
+        const payload: CreatePayload = {
+            pluginId: selectedPlugin.id,
+            name: name.trim(),
+            condition:
+                op === "exists"
+                    ? { field: fieldKey, op }
+                    : { field: fieldKey, op, value: parsedValue },
+        };
+
+        setSaving(true);
+        setError(null);
+        try {
+            const result = await createAlert(payload);
+            if (!result.ok) {
+                setError(result.error ?? "Failed to create the rule.");
+                return;
+            }
+            onCreated?.();
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const allowedOperators = selectedField ? operatorsForField(selectedField) : [];
+    const showValueInput = selectedField !== undefined && op !== "exists";
+
+    if (plugins.length === 0) {
+        return (
+          <div className={styles.empty} data-testid="alert-form-empty">
+            <p>No plugins with alert definitions are installed.</p>
+            <p className={styles.emptyHint}>
+              Plugins declare alertable fields via <code>getAlertDefinitions()</code>.
+            </p>
+            {onCancel && (
+              <button className={styles.cancel} onClick={onCancel}>Cancel</button>
+            )}
+          </div>
+        );
+    }
+
+    return (
+      <form
+        className={styles.form}
+        data-testid="alert-rule-form"
+        onSubmit={(e) => {
+                e.preventDefault();
+                void handleSave();
+            }}
+      >
+        <div className={styles.fieldRow}>
+          <label className={styles.label} htmlFor="alert-rule-name">Rule name</label>
+          <input
+            id="alert-rule-name"
+            className={styles.input}
+            type="text"
+            value={name}
+            maxLength={120}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Big quake in Alaska"
+            data-testid="alert-rule-name-input"
+          />
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.label} htmlFor="alert-rule-plugin">Plugin</label>
+          <select
+            id="alert-rule-plugin"
+            className={styles.input}
+            value={pluginId}
+            onChange={(e) => handlePluginChange(e.target.value)}
+            data-testid="alert-rule-plugin-select"
+          >
+            {plugins.map((plugin) => (
+              <option key={plugin.id} value={plugin.id}>{plugin.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.label} htmlFor="alert-rule-field">Field</label>
+          <select
+            id="alert-rule-field"
+            className={styles.input}
+            value={fieldKey}
+            onChange={(e) => handleFieldChange(e.target.value)}
+            data-testid="alert-rule-field-select"
+          >
+            {selectedPlugin?.definitions.map((definition) => (
+              <option key={definition.key} value={definition.key}>{definition.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.label} htmlFor="alert-rule-op">Condition</label>
+          <select
+            id="alert-rule-op"
+            className={styles.input}
+            value={op}
+            onChange={(e) => {
+                    setOp(e.target.value as AlertOperator);
+                    setError(null);
+                }}
+            data-testid="alert-rule-op-select"
+          >
+            {allowedOperators.map((allowed) => (
+              <option key={allowed} value={allowed}>{OPERATOR_LABELS[allowed]}</option>
+            ))}
+          </select>
+        </div>
+
+        {showValueInput && selectedField && (
+          <div className={styles.fieldRow}>
+            <label className={styles.label} htmlFor="alert-rule-value">
+              {selectedField.type === "boolean" ? "Value" : "Value"}
+            </label>
+            {selectedField.type === "boolean" ? (
+              <select
+                id="alert-rule-value"
+                className={styles.input}
+                value={valueInput}
+                onChange={(e) => setValueInput(e.target.value)}
+                data-testid="alert-rule-value-select"
+              >
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+            ) : (
+              <input
+                id="alert-rule-value"
+                className={styles.input}
+                type={selectedField.type === "number" ? "number" : "text"}
+                step={selectedField.type === "number" ? "any" : undefined}
+                value={valueInput}
+                onChange={(e) => setValueInput(e.target.value)}
+                data-testid="alert-rule-value-input"
+              />
+            )}
+          </div>
+        )}
+
+        {error && <p className={styles.error} data-testid="alert-form-error">{error}</p>}
+
+        <div className={styles.actions}>
+          <button
+            type="submit"
+            className={styles.save}
+            disabled={saving}
+            data-testid="alert-rule-save"
+          >
+            {saving ? "Saving..." : "Create Rule"}
+          </button>
+          {onCancel && (
+            <button
+              type="button"
+              className={styles.cancel}
+              onClick={onCancel}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+    );
+}

--- a/src/components/alerts/AlertToasts.module.css
+++ b/src/components/alerts/AlertToasts.module.css
@@ -1,0 +1,86 @@
+.stack {
+    position: fixed;
+    top: 72px;
+    right: 24px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: min(380px, calc(100vw - 48px));
+    pointer-events: none;
+}
+
+.toast {
+    pointer-events: auto;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px 14px;
+    background: rgba(16, 40, 60, 0.9);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid rgba(56, 189, 248, 0.4);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--glass-shadow);
+    color: #bae6fd;
+    font-size: 13px;
+    animation: alertIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+@keyframes alertIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.iconWrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.title {
+    font-weight: 600;
+    color: #e0f2fe;
+}
+
+.detail {
+    font-size: 12px;
+    color: rgba(186, 230, 253, 0.7);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dismiss {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 4px;
+    margin-left: auto;
+    border: none;
+    background: none;
+    color: rgba(186, 230, 253, 0.6);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: color var(--duration-normal) var(--ease-spring);
+}
+
+.dismiss:hover {
+    color: #e0f2fe;
+    background: rgba(56, 189, 248, 0.15);
+}

--- a/src/components/alerts/AlertToasts.spec.tsx
+++ b/src/components/alerts/AlertToasts.spec.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { dataBus } from "@/core/data/DataBus";
+import { useStore } from "@/core/state/store";
+import { AlertToasts } from "./AlertToasts";
+import type { DataBusEvents } from "@worldwideview/wwv-plugin-sdk";
+
+const FIRED: DataBusEvents["alertFired"] = {
+    rule: {
+        id: "rule-1",
+        name: "Big quake",
+        pluginId: "earthquakes",
+        condition: { field: "magnitude", op: "gt", value: 5 },
+    },
+    entity: {
+        id: "q-1",
+        pluginId: "earthquakes",
+        latitude: 61,
+        longitude: -149,
+        timestamp: new Date("2026-08-25T00:00:00Z"),
+        properties: { magnitude: 6.2, place: "Alaska" },
+    },
+    pluginId: "earthquakes",
+};
+
+function fireAlert() {
+    act(() => {
+        dataBus.emit("alertFired", FIRED);
+    });
+}
+
+describe("AlertToasts", () => {
+    beforeEach(() => {
+        useStore.setState({ alertToasts: [], alertUnreadCount: 0 });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("renders a toast when alertFired fires on the data bus and bumps unread", () => {
+        render(<AlertToasts />);
+        fireAlert();
+        expect(screen.getByText("Big quake")).toBeDefined();
+        expect(screen.getByText(/Central Alaska|Alaska/)).toBeDefined();
+        expect(useStore.getState().alertUnreadCount).toBe(1);
+        expect(useStore.getState().alertToasts).toHaveLength(1);
+    });
+
+    it("auto-dismisses the toast after the TTL", () => {
+        vi.useFakeTimers();
+        render(<AlertToasts />);
+        fireAlert();
+        expect(useStore.getState().alertToasts).toHaveLength(1);
+        act(() => {
+            vi.advanceTimersByTime(8500);
+        });
+        expect(useStore.getState().alertToasts).toHaveLength(0);
+    });
+
+    it("dismisses on the X button", () => {
+        render(<AlertToasts />);
+        fireAlert();
+        act(() => {
+            screen.getByRole("button", { name: "Dismiss alert" }).click();
+        });
+        expect(useStore.getState().alertToasts).toHaveLength(0);
+    });
+});

--- a/src/components/alerts/AlertToasts.tsx
+++ b/src/components/alerts/AlertToasts.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * @file AlertToasts.tsx
+ * @description Headless + presentational bridge for the `alertFired` bus
+ * event: subscribes once, pushes fired alerts into the store (toast queue +
+ * unread badge), and renders the transient toast stack. Auto-dismisses each
+ * toast after 8 seconds.
+ * @module src/components/alerts
+ */
+
+import { useEffect } from "react";
+import { Bell, X } from "lucide-react";
+import { dataBus } from "@/core/data/DataBus";
+import { useStore } from "@/core/state/store";
+import type { AlertToastItem } from "@/core/state/alertsSlice";
+import styles from "./AlertToasts.module.css";
+
+const TOAST_TTL_MS = 8000;
+
+function AlertToastView({ toast }: { toast: AlertToastItem }) {
+    const dismissAlertToast = useStore((s) => s.dismissAlertToast);
+
+    useEffect(() => {
+        const timer = setTimeout(() => dismissAlertToast(toast.id), TOAST_TTL_MS);
+        return () => clearTimeout(timer);
+    }, [toast.id, dismissAlertToast]);
+
+    return (
+      <div
+        className={styles.toast}
+        role="status"
+        data-testid={`alert-toast-${toast.id}`}
+      >
+        <div className={styles.iconWrapper}>
+          <Bell size={18} />
+        </div>
+        <div className={styles.body}>
+          <div className={styles.title}>{toast.ruleName}</div>
+          <div className={styles.detail}>
+            {toast.entityLabel}
+            {' '}
+            ·
+            {' '}
+            {toast.pluginId}
+          </div>
+        </div>
+        <button
+          className={styles.dismiss}
+          aria-label="Dismiss alert"
+          onClick={() => dismissAlertToast(toast.id)}
+        >
+          <X size={14} />
+        </button>
+      </div>
+    );
+}
+
+/**
+ * @component AlertToasts
+ * @description Renders fired alert toasts and feeds the unread badge. Mount
+ * once near the app's other global overlays.
+ */
+export function AlertToasts() {
+    const toasts = useStore((s) => s.alertToasts);
+    const handleAlertFired = useStore((s) => s.handleAlertFired);
+
+    useEffect(() => {
+        return dataBus.on("alertFired", handleAlertFired);
+    }, [handleAlertFired]);
+
+    if (toasts.length === 0) return null;
+
+    return (
+      <div className={styles.stack} data-testid="alert-toasts">
+        {toasts.map((toast) => (
+          <AlertToastView key={toast.id} toast={toast} />
+        ))}
+      </div>
+    );
+}

--- a/src/components/alerts/AlertsPanel.module.css
+++ b/src/components/alerts/AlertsPanel.module.css
@@ -1,0 +1,174 @@
+.panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+    width: 100%;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.muted {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
+.error {
+    font-size: 12px;
+    color: #f87171;
+    margin: 0;
+}
+
+.empty {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--space-md);
+    border: 1px dashed var(--glass-border);
+    border-radius: var(--radius-md);
+    font-size: 13px;
+    color: var(--text-primary);
+}
+
+.list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.rule {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--glass-bg, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-md);
+    padding-right: 44px;
+}
+
+.ruleHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+}
+
+.ruleName {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ruleMeta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: 11px;
+    color: var(--text-secondary);
+    min-width: 0;
+}
+
+.pluginId {
+    flex-shrink: 0;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    background: rgba(56, 189, 248, 0.12);
+    color: #7dd3fc;
+    font-family: var(--font-mono, monospace);
+}
+
+.condition {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.delete {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: color var(--duration-normal) var(--ease-spring);
+}
+
+.delete:hover {
+    color: #f87171;
+    background: rgba(239, 68, 68, 0.12);
+}
+
+.toggle {
+    position: relative;
+    width: 34px;
+    height: 18px;
+    border: none;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background var(--duration-normal) var(--ease-spring);
+}
+
+.toggle[aria-checked="true"] {
+    background: rgba(56, 189, 248, 0.45);
+}
+
+.toggleKnob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform var(--duration-normal) var(--ease-spring);
+}
+
+.toggleKnobOn {
+    transform: translateX(16px);
+}
+
+.create {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border: 1px dashed var(--glass-border);
+    border-radius: var(--radius-md);
+    background: none;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color var(--duration-normal) var(--ease-spring);
+}
+
+.create:hover {
+    border-color: rgba(56, 189, 248, 0.5);
+    color: #7dd3fc;
+}

--- a/src/components/alerts/AlertsPanel.spec.tsx
+++ b/src/components/alerts/AlertsPanel.spec.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useStore } from "@/core/state/store";
+import { AlertsPanel } from "./AlertsPanel";
+
+const RULES = [
+    {
+        id: "rule-a",
+        pluginId: "quakes",
+        name: "Big quake",
+        condition: { field: "magnitude", op: "gt", value: 5 },
+        enabled: true,
+        createdAt: "2026-08-25T00:00:00Z",
+        updatedAt: "2026-08-25T00:00:00Z",
+    },
+    {
+        id: "rule-b",
+        pluginId: "quakes",
+        name: "Place alert",
+        condition: { field: "place", op: "contains", value: "Alaska" },
+        enabled: false,
+        createdAt: "2026-08-24T00:00:00Z",
+        updatedAt: "2026-08-24T00:00:00Z",
+    },
+];
+
+describe("AlertsPanel — rule list", () => {
+    beforeEach(() => {
+        useStore.setState({
+            alertRules: [],
+            alertRulesLoading: false,
+            alertRulesError: null,
+            alertUnreadCount: 3,
+            alertToasts: [],
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("renders rules with name, plugin and a labelled condition summary", async () => {
+        // No alert definitions registered -> raw condition fallback text.
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ rules: RULES }),
+        }));
+        render(<AlertsPanel />);
+
+        expect(await screen.findByTestId("alerts-list")).toBeDefined();
+        expect(screen.getByText("Big quake")).toBeDefined();
+        expect(screen.getByText("Place alert")).toBeDefined();
+        // No alert definitions registered -> raw key fallback with operator words.
+        expect(screen.getByTestId("alert-condition-rule-a").textContent).toBe("magnitude greater than 5");
+        expect(screen.getByTestId("alert-condition-rule-b").textContent).toBe("place contains \"Alaska\"");
+        // Opening the panel clears the unread badge.
+        expect(useStore.getState().alertUnreadCount).toBe(0);
+    });
+
+    it("renders the empty state when there are no rules", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ rules: [] }) }));
+        render(<AlertsPanel />);
+        expect(await screen.findByTestId("alerts-empty")).toBeDefined();
+        expect(screen.queryByTestId("alerts-list")).toBeNull();
+    });
+
+    it("surfaces a load error", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({ message: "db down" }) }));
+        render(<AlertsPanel />);
+        expect((await screen.findByTestId("alerts-error")).textContent).toContain("db down");
+    });
+
+    it("toggle sends a PATCH and flips the stored rule", async () => {
+        vi.stubGlobal("fetch", vi.fn()
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ rules: RULES }) }) // GET
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ rule: { ...RULES[0], enabled: false } }) })); // PATCH
+        render(<AlertsPanel />);
+        await screen.findByTestId("alerts-list");
+
+        fireEvent.click(screen.getByTestId("alert-toggle-rule-a"));
+        await waitFor(() => expect(useStore.getState().alertRules[0].enabled).toBe(false));
+
+        const patchCall = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[1] as unknown as [string, RequestInit];
+        expect(patchCall[0]).toBe("/api/alerts/rule-a");
+        expect(patchCall[1].method).toBe("PATCH");
+        expect(JSON.parse(String(patchCall[1].body))).toEqual({ enabled: false });
+    });
+
+    it("delete confirms then DELETEs and removes the row", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(true);
+        vi.stubGlobal("fetch", vi.fn()
+            .mockResolvedValueOnce({ ok: true, json: async () => ({ rules: RULES }) }) // GET
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ success: true }) })); // DELETE
+        render(<AlertsPanel />);
+        await screen.findByTestId("alerts-list");
+
+        fireEvent.click(screen.getByTestId("alert-delete-rule-a"));
+        await waitFor(() => expect(useStore.getState().alertRules.some((r) => r.id === "rule-a")).toBe(false));
+
+        const deleteCall = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[1] as unknown as [string, RequestInit];
+        expect(deleteCall[0]).toBe("/api/alerts/rule-a");
+        expect(deleteCall[1].method).toBe("DELETE");
+    });
+
+    it("skips the DELETE when the confirmation is declined", async () => {
+        vi.spyOn(window, "confirm").mockReturnValue(false);
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ rules: RULES }) }));
+        render(<AlertsPanel />);
+        await screen.findByTestId("alerts-list");
+
+        fireEvent.click(screen.getByTestId("alert-delete-rule-a"));
+        expect(useStore.getState().alertRules).toHaveLength(2);
+        expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    });
+
+    it("toggles into the create form via New Rule", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ rules: [] }) }));
+        render(<AlertsPanel />);
+        await screen.findByTestId("alerts-empty");
+
+        fireEvent.click(screen.getByTestId("alert-create-button"));
+        // With no alertable plugins registered the builder shows its empty state.
+        expect(screen.getByTestId("alert-form-empty")).toBeDefined();
+    });
+});

--- a/src/components/alerts/AlertsPanel.tsx
+++ b/src/components/alerts/AlertsPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * @file AlertsPanel.tsx
+ * @description The alerts management panel: lists the current user's alert
+ * rules with a condition summary, enable/disable and delete actions, an empty
+ * state, and a create-rule entry that opens the plugin-driven condition
+ * builder.
+ * @module src/components/alerts
+ */
+
+import { useEffect, useState } from "react";
+import { Bell, Plus, Trash2 } from "lucide-react";
+import { useStore } from "@/core/state/store";
+import { getAlertDefinitionsFor } from "@/lib/alerts/alertablePlugins";
+import { formatCondition } from "@/lib/alerts/format";
+import { AlertRuleForm } from "./AlertRuleForm";
+import styles from "./AlertsPanel.module.css";
+
+/**
+ * @component AlertsPanel
+ * @description Rule list + create entry. Rendered inside the right
+ * configuration sidebar's alerts tab; clearing the unread badge happens when
+ * the panel mounts (i.e. the user opened it).
+ */
+export function AlertsPanel() {
+    const rules = useStore((s) => s.alertRules);
+    const loading = useStore((s) => s.alertRulesLoading);
+    const error = useStore((s) => s.alertRulesError);
+    const fetchAlerts = useStore((s) => s.fetchAlerts);
+    const setAlertEnabled = useStore((s) => s.setAlertEnabled);
+    const deleteAlert = useStore((s) => s.deleteAlert);
+    const clearAlertUnread = useStore((s) => s.clearAlertUnread);
+    const [creating, setCreating] = useState(false);
+
+    useEffect(() => {
+        void fetchAlerts();
+        clearAlertUnread();
+    }, [fetchAlerts, clearAlertUnread]);
+
+    const handleDelete = (id: string, name: string) => {
+        if (!window.confirm(`Delete alert rule "${name}"?`)) return;
+        void deleteAlert(id);
+    };
+
+    const handleToggle = (id: string, enabled: boolean) => {
+        void setAlertEnabled(id, !enabled);
+    };
+
+    return (
+      <div className={styles.panel} data-testid="alerts-panel">
+        <div className={styles.header}>
+          <Bell size={18} />
+          <span>Alert Rules</span>
+        </div>
+
+        {loading && rules.length === 0 && (
+          <p className={styles.muted} data-testid="alerts-loading">Loading rules...</p>
+        )}
+
+        {error && !loading && (
+          <p className={styles.error} data-testid="alerts-error">{error}</p>
+        )}
+
+        {!loading && !error && rules.length === 0 && (
+          <div className={styles.empty} data-testid="alerts-empty">
+            <p>No alert rules yet.</p>
+            <p className={styles.muted}>
+              Create a rule to get notified when live plugin data matches a condition.
+            </p>
+          </div>
+        )}
+
+        {rules.length > 0 && (
+          <ul className={styles.list} data-testid="alerts-list">
+            {rules.map((rule) => (
+              <li key={rule.id} className={styles.rule} data-testid={`alert-rule-${rule.id}`}>
+                <div className={styles.ruleHeader}>
+                  <span className={styles.ruleName}>{rule.name}</span>
+                  <button
+                    className={styles.toggle}
+                    role="switch"
+                    aria-checked={rule.enabled}
+                    aria-label={`${rule.enabled ? "Disable" : "Enable"} rule ${rule.name}`}
+                    data-testid={`alert-toggle-${rule.id}`}
+                    onClick={() => handleToggle(rule.id, rule.enabled)}
+                  >
+                    <span className={`${styles.toggleKnob} ${rule.enabled ? styles.toggleKnobOn : ""}`} />
+                  </button>
+                </div>
+                <div className={styles.ruleMeta}>
+                  <span className={styles.pluginId}>{rule.pluginId}</span>
+                  <span className={styles.condition} data-testid={`alert-condition-${rule.id}`}>
+                    {formatCondition(rule.condition, getAlertDefinitionsFor(rule.pluginId))}
+                  </span>
+                </div>
+                <button
+                  className={styles.delete}
+                  aria-label={`Delete rule ${rule.name}`}
+                  data-testid={`alert-delete-${rule.id}`}
+                  onClick={() => handleDelete(rule.id, rule.name)}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {creating ? (
+          <AlertRuleForm onCreated={() => setCreating(false)} onCancel={() => setCreating(false)} />
+        ) : (
+          <button
+            className={styles.create}
+            data-testid="alert-create-button"
+            onClick={() => setCreating(true)}
+          >
+            <Plus size={14} />
+            New Rule
+          </button>
+        )}
+      </div>
+    );
+}

--- a/src/components/alerts/AlertsTabButton.module.css
+++ b/src/components/alerts/AlertsTabButton.module.css
@@ -1,0 +1,18 @@
+.badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    color: #fff;
+    background: #f43f5e;
+    border-radius: 999px;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.4);
+}

--- a/src/components/alerts/AlertsTabButton.tsx
+++ b/src/components/alerts/AlertsTabButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * @file AlertsTabButton.tsx
+ * @description Bell entry point for the right configuration sidebar: opens the
+ * alerts tab and shows an unread badge when fired alerts are pending. Mirrors
+ * the sibling `panel-tab` buttons in DataConfigPanel.
+ * @module src/components/alerts
+ */
+
+import { Bell } from "lucide-react";
+import { useStore } from "@/core/state/store";
+import styles from "./AlertsTabButton.module.css";
+
+/**
+ * @component AlertsTabButton
+ * @description The alerts tab control with unread badge. Rendered inside the
+ * right sidebar's tab strip.
+ */
+export function AlertsTabButton() {
+    const unread = useStore((s) => s.alertUnreadCount);
+    const activeTab = useStore((s) => s.activeConfigTab);
+    const setActiveTab = useStore((s) => s.setActiveConfigTab);
+    const setConfigPanelOpen = useStore((s) => s.setConfigPanelOpen);
+
+    return (
+      <button
+        className={`panel-tab ${activeTab === "alerts" ? "panel-tab--active" : ""}`}
+        onClick={() => {
+                setActiveTab("alerts");
+                setConfigPanelOpen(true);
+            }}
+        title="Alerts"
+        aria-label="Alerts"
+        style={{ width: "100%" }}
+        data-testid="alerts-tab"
+      >
+        <Bell size="20" style={{ margin: 5, maxHeight: "20%" }} />
+        {unread > 0 && (
+          <span className={styles.badge} data-testid="alerts-tab-badge">
+            {unread > 9 ? "9+" : unread}
+          </span>
+        )}
+      </button>
+    );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -22,6 +22,7 @@ import { pluginRegistry } from "@/core/plugins/PluginRegistry";
 import { useStore } from "@/core/state/store";
 import { dataBus } from "@/core/data/DataBus";
 import { useAlertEngine } from "@/lib/alerts/engine";
+import { AlertToasts } from "@/components/alerts/AlertToasts";
 import { PanelToggleArrows } from "@/components/layout/PanelToggleArrows";
 import { FloatingVideoManager } from "@/components/video/FloatingVideoManager";
 import { BootOverlay } from "@/components/common/BootOverlay";
@@ -209,6 +210,7 @@ export function AppShell() {
         <FloatingVideoManager />
         {needsReload && <ReloadToast />}
         <ErrorToast />
+        <AlertToasts />
         <FeedbackDialog />
         {pendingUnverified.length > 0 && (
         <UnverifiedPluginBatchDialog

--- a/src/components/panels/DataConfig/index.tsx
+++ b/src/components/panels/DataConfig/index.tsx
@@ -17,6 +17,8 @@ import { useResizablePanel } from "@/core/hooks/useResizablePanel";
 import { IntelTab } from "./IntelTab";
 import { CacheTab } from "./CacheTab";
 import { OverlayTab } from "./OverlayTab";
+import { AlertsPanel } from "@/components/alerts/AlertsPanel";
+import { AlertsTabButton } from "@/components/alerts/AlertsTabButton";
 import { sectionHeaderStyle } from "./sharedStyles";
 
 import "./index.css";
@@ -99,6 +101,7 @@ export function DataConfigPanel() {
           >
             <Cog size="20" style={{ margin: 5, maxHeight: "20%" }} />
           </button>
+          <AlertsTabButton />
         </div>
 
         <div style={{
@@ -119,6 +122,12 @@ export function DataConfigPanel() {
           </div>
                 )}
           {activeTab === "overlay" && <OverlayTab />}
+          {activeTab === "alerts" && (
+          <div style={{ marginBottom: "var(--space-lg)" }}>
+            <div style={sectionHeaderStyle}>Alerts</div>
+            <AlertsPanel />
+          </div>
+                )}
         </div>
 
         <button

--- a/src/core/state/alertsSlice.test.ts
+++ b/src/core/state/alertsSlice.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import type { AlertRuleSnapshot, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import type { AlertRuleRecord } from "@/lib/alerts/api";
+import { createAlertsSlice, type AlertsSlice } from "./alertsSlice";
+
+/** Slice-only store: other slices are absent, so cross-slice helpers no-op. */
+type TestStore = AlertsSlice;
+let store: StoreApi<TestStore>;
+
+const RULE: AlertRuleRecord = {
+    id: "rule-1",
+    pluginId: "earthquakes",
+    name: "Big quake",
+    condition: { field: "magnitude", op: "gt", value: 5 },
+    enabled: true,
+    createdAt: "2026-08-25T00:00:00Z",
+    updatedAt: "2026-08-25T00:00:00Z",
+};
+
+const firedEvent: { rule: AlertRuleSnapshot; entity: GeoEntity; pluginId: string } = {
+    rule: { id: "rule-1", name: "Big quake", pluginId: "earthquakes", condition: { field: "magnitude", op: "gt", value: 5 } },
+    entity: {
+        id: "q-1",
+        pluginId: "earthquakes",
+        latitude: 61,
+        longitude: -149,
+        timestamp: new Date("2026-08-25T00:00:00Z"),
+        label: "M6.2 Alaska",
+        properties: { magnitude: 6.2, place: "Alaska" },
+    },
+    pluginId: "earthquakes",
+};
+
+describe("alertsSlice", () => {
+    beforeEach(() => {
+        store = createStore<TestStore>((set, get, api) =>
+            createAlertsSlice(set as never, get as never, api as never),
+        );
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("initializes with empty rules and no unread alerts", () => {
+        const state = store.getState();
+        expect(state.alertRules).toEqual([]);
+        expect(state.alertUnreadCount).toBe(0);
+        expect(state.alertToasts).toEqual([]);
+        expect(state.alertRulesLoading).toBe(false);
+    });
+
+    it("fetchAlerts loads rules from GET /api/alerts", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ rules: [RULE] }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await store.getState().fetchAlerts();
+        expect(fetchMock).toHaveBeenCalledWith("/api/alerts", expect.objectContaining({ cache: "no-store" }));
+        expect(store.getState().alertRules).toEqual([RULE]);
+        expect(store.getState().alertRulesLoading).toBe(false);
+    });
+
+    it("fetchAlerts records an error when the request fails", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({ message: "boom" }) }));
+        await store.getState().fetchAlerts();
+        expect(store.getState().alertRulesError).toBe("boom");
+        expect(store.getState().alertRulesLoading).toBe(false);
+    });
+
+    it("createAlert POSTs the payload and prepends the created rule", async () => {
+        const created = { ...RULE, id: "rule-2" };
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 201,
+            json: async () => ({ rule: created }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        store.setState({ alertRules: [] });
+
+        const result = await store.getState().createAlert({
+            pluginId: "earthquakes",
+            name: "Big quake",
+            condition: { field: "magnitude", op: "gt", value: 5 },
+        });
+
+        expect(result.ok).toBe(true);
+        const [url] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        expect(url).toBe("/api/alerts");
+        expect(JSON.parse(String((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].body)))
+            .toEqual({ pluginId: "earthquakes", name: "Big quake", condition: { field: "magnitude", op: "gt", value: 5 } });
+        expect(store.getState().alertRules[0]).toEqual(created);
+    });
+
+    it("createAlert surfaces the server error without mutating the list", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 422,
+            json: async () => ({ message: "condition.op must be one of: ..." }),
+        }));
+        const result = await store.getState().createAlert({
+            pluginId: "earthquakes",
+            name: "x",
+            condition: { field: "m", op: "bogus" as never, value: 1 },
+        });
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain("condition.op");
+        expect(store.getState().alertRules).toEqual([]);
+    });
+
+    it("setAlertEnabled PATCHes enabled and updates the rule", async () => {
+        store.setState({ alertRules: [{ ...RULE, enabled: true }] });
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ rule: { ...RULE, enabled: false } }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await store.getState().setAlertEnabled("rule-1", false);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "/api/alerts/rule-1",
+            expect.objectContaining({ method: "PATCH" }),
+        );
+        expect(store.getState().alertRules[0].enabled).toBe(false);
+    });
+
+    it("setAlertEnabled reverts on failure", async () => {
+        store.setState({ alertRules: [{ ...RULE, enabled: true }] });
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: false,
+            status: 422,
+            json: async () => ({ message: "enabled must be a boolean" }),
+        }));
+        await store.getState().setAlertEnabled("rule-1", false);
+        expect(store.getState().alertRules[0].enabled).toBe(true);
+    });
+
+    it("deleteAlert removes the rule after a successful DELETE", async () => {
+        store.setState({ alertRules: [RULE] });
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ success: true }) });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await store.getState().deleteAlert("rule-1");
+        expect(fetchMock).toHaveBeenCalledWith("/api/alerts/rule-1", expect.objectContaining({ method: "DELETE" }));
+        expect(store.getState().alertRules).toEqual([]);
+    });
+
+    it("handles a fired alert: increments unread and queues a toast", () => {
+        store.getState().handleAlertFired(firedEvent);
+        expect(store.getState().alertUnreadCount).toBe(1);
+        expect(store.getState().alertToasts).toHaveLength(1);
+        expect(store.getState().alertToasts[0].entityLabel).toBe("M6.2 Alaska");
+        expect(store.getState().alertToasts[0].ruleName).toBe("Big quake");
+    });
+
+    it("uses the entity properties place as fallback toast label", () => {
+        const event = {
+            ...firedEvent,
+            entity: { ...firedEvent.entity, label: undefined },
+        };
+        store.getState().handleAlertFired(event);
+        expect(store.getState().alertToasts[0].entityLabel).toBe("Alaska");
+    });
+
+    it("caps the toast queue at four entries", () => {
+        for (let i = 0; i < 6; i += 1) store.getState().handleAlertFired(firedEvent);
+        expect(store.getState().alertToasts).toHaveLength(4);
+        expect(store.getState().alertUnreadCount).toBe(6);
+    });
+
+    it("clearAlertUnread and dismissAlertToast update state", () => {
+        store.getState().handleAlertFired(firedEvent);
+        store.getState().dismissAlertToast(store.getState().alertToasts[0].id);
+        expect(store.getState().alertToasts).toHaveLength(0);
+        store.getState().clearAlertUnread();
+        expect(store.getState().alertUnreadCount).toBe(0);
+    });
+});

--- a/src/core/state/alertsSlice.ts
+++ b/src/core/state/alertsSlice.ts
@@ -1,0 +1,156 @@
+/**
+ * @file alertsSlice.ts
+ * @description Zustand slice for alert rules, alert toasts and the unread badge.
+ * Owns the rules list (GET/POST/PATCH/DELETE /api/alerts) and the client-side
+ * side-effects of the `alertFired` bus event (toast queue + unread count).
+ */
+
+import type { StateCreator } from "zustand";
+import type { AlertCondition, AlertRuleSnapshot, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import type { AppStore } from "./store";
+import {
+    createAlertRule,
+    deleteAlertRule,
+    fetchAlertRules,
+    updateAlertRule,
+    type AlertRuleRecord,
+} from "@/lib/alerts/api";
+import { requestAlertRulesRefresh } from "@/lib/alerts/engine";
+
+export interface AlertToastItem {
+    id: string;
+    ruleName: string;
+    pluginId: string;
+    entityLabel: string;
+    firedAt: number;
+}
+
+export interface CreateAlertInput {
+    pluginId: string;
+    name: string;
+    condition: AlertCondition;
+}
+
+export interface CreateAlertResult {
+    ok: boolean;
+    error?: string;
+    rule?: AlertRuleRecord;
+}
+
+export interface AlertsSlice {
+    /** The current user's alert rules, newest first. */
+    alertRules: AlertRuleRecord[];
+    alertRulesLoading: boolean;
+    alertRulesError: string | null;
+    /** Unread alert count shown on the bell/badge. */
+    alertUnreadCount: number;
+    /** Recently fired alerts rendered as toasts (newest last). */
+    alertToasts: AlertToastItem[];
+    fetchAlerts: () => Promise<void>;
+    createAlert: (input: CreateAlertInput) => Promise<CreateAlertResult>;
+    setAlertEnabled: (id: string, enabled: boolean) => Promise<void>;
+    deleteAlert: (id: string) => Promise<void>;
+    handleAlertFired: (event: { rule: AlertRuleSnapshot; entity: GeoEntity; pluginId: string }) => void;
+    clearAlertUnread: () => void;
+    dismissAlertToast: (id: string) => void;
+}
+
+const MAX_TOASTS = 4;
+let toastSeq = 0;
+
+function entityLabel(entity: GeoEntity): string {
+    if (entity.label) return entity.label;
+    const place = entity.properties?.place;
+    if (typeof place === "string" && place !== "") return place;
+    return entity.id;
+}
+
+export const createAlertsSlice: StateCreator<AppStore, [], [], AlertsSlice> = (set, get) => ({
+    alertRules: [],
+    alertRulesLoading: false,
+    alertRulesError: null,
+    alertUnreadCount: 0,
+    alertToasts: [],
+
+    fetchAlerts: async () => {
+        set({ alertRulesLoading: true, alertRulesError: null });
+        try {
+            const rules = await fetchAlertRules();
+            set({ alertRules: rules, alertRulesLoading: false });
+        } catch (err) {
+            set({
+                alertRulesError: err instanceof Error ? err.message : "Failed to load alert rules",
+                alertRulesLoading: false,
+            });
+        }
+    },
+
+    createAlert: async (input) => {
+        const result = await createAlertRule(input);
+        if (!result.ok || !result.rule) {
+            return { ok: false, error: result.error ?? "Failed to create alert rule" };
+        }
+        set((state) => ({
+            alertRules: [result.rule as AlertRuleRecord, ...state.alertRules],
+        }));
+        requestAlertRulesRefresh();
+        return { ok: true, rule: result.rule };
+    },
+
+    setAlertEnabled: async (id, enabled) => {
+        // Optimistic flip; revert + surface the error when the server disagrees.
+        set((state) => ({
+            alertRules: state.alertRules.map((rule) =>
+                rule.id === id ? { ...rule, enabled } : rule,
+            ),
+        }));
+        const result = await updateAlertRule(id, { enabled });
+        if (!result.ok) {
+            set((state) => ({
+                alertRules: state.alertRules.map((rule) =>
+                    rule.id === id ? { ...rule, enabled: !enabled } : rule,
+                ),
+                alertRulesError: result.error ?? "Failed to update rule",
+            }));
+            get().showErrorToast?.(result.error ?? "Failed to update alert rule");
+            return;
+        }
+        requestAlertRulesRefresh();
+    },
+
+    deleteAlert: async (id) => {
+        const result = await deleteAlertRule(id);
+        if (!result.ok) {
+            get().showErrorToast?.(result.error ?? "Failed to delete alert rule");
+            return;
+        }
+        set((state) => ({
+            alertRules: state.alertRules.filter((rule) => rule.id !== id),
+        }));
+        requestAlertRulesRefresh();
+    },
+
+    handleAlertFired: ({ rule, entity, pluginId }) => {
+        set((state) => {
+            const nextToast: AlertToastItem = {
+                id: `alert-toast-${++toastSeq}-${Date.now()}`,
+                ruleName: rule.name,
+                pluginId,
+                entityLabel: entityLabel(entity),
+                firedAt: Date.now(),
+            };
+            const alertToasts = [...state.alertToasts, nextToast].slice(-MAX_TOASTS);
+            return {
+                alertUnreadCount: state.alertUnreadCount + 1,
+                alertToasts,
+            };
+        });
+    },
+
+    clearAlertUnread: () => set({ alertUnreadCount: 0 }),
+
+    dismissAlertToast: (id) =>
+        set((state) => ({
+            alertToasts: state.alertToasts.filter((toast) => toast.id !== id),
+        })),
+});

--- a/src/core/state/store.ts
+++ b/src/core/state/store.ts
@@ -13,6 +13,7 @@ import { createFilterSlice, type FilterSlice } from "./filterSlice";
 import { createDataSlice, type DataSlice } from "./dataSlice";
 import { createConfigSlice, type ConfigSlice } from "./configSlice";
 import { createFavoritesSlice, type FavoritesSlice } from "./favoritesSlice";
+import { createAlertsSlice, type AlertsSlice } from "./alertsSlice";
 
 /**
  * Re-exporting slice types for easier access from components and utilities.
@@ -28,7 +29,8 @@ export type AppStore = GlobeSlice &
     FilterSlice &
     DataSlice &
     ConfigSlice &
-    FavoritesSlice;
+    FavoritesSlice &
+    AlertsSlice;
 
 /**
  * The primary hook for accessing and modifying the application state.
@@ -45,4 +47,5 @@ export const useStore = create<AppStore>((...args) => ({
     ...createDataSlice(...args),
     ...createConfigSlice(...args),
     ...createFavoritesSlice(...args),
+    ...createAlertsSlice(...args),
 }));

--- a/src/core/state/uiSlice.ts
+++ b/src/core/state/uiSlice.ts
@@ -56,7 +56,7 @@ export interface UISlice {
     /** List of active floating stream windows. */
     floatingStreams: FloatingStream[];
     /** The active sub-tab within the configuration panel. */
-    activeConfigTab: "intel" | "filters" | "cache" | "overlay" | "apikeys";
+    activeConfigTab: "intel" | "filters" | "cache" | "overlay" | "apikeys" | "alerts";
     /** The ID of a layer currently being highlighted/flashed in the UI. */
     highlightLayerId: string | null;
     /** Active panel in mobile view layout. */
@@ -92,7 +92,7 @@ export interface UISlice {
     /** Updates properties (position, size, state) of an existing stream window. */
     updateFloatingStream: (id: string, updates: Partial<FloatingStream>) => void;
     /** Switches between configuration tabs. */
-    setActiveConfigTab: (tab: "intel" | "filters" | "cache" | "overlay" | "apikeys") => void;
+    setActiveConfigTab: (tab: "intel" | "filters" | "cache" | "overlay" | "apikeys" | "alerts") => void;
     /** Triggers a visual highlight on a specific layer in the layer list. */
     setHighlightLayerId: (id: string | null) => void;
     /** Explicitly sets the configuration panel visibility. */

--- a/src/lib/alerts/alertablePlugins.ts
+++ b/src/lib/alerts/alertablePlugins.ts
@@ -1,0 +1,35 @@
+/**
+ * Client-side enumeration of alertable plugins (P2, v1).
+ *
+ * A plugin participates in the alert condition builder when it declares
+ * `getAlertDefinitions()`. The set is read from the live plugin registry, so
+ * marketplace and local plugins register whenever the app loads them.
+ */
+
+import type { AlertFieldDefinition } from "@worldwideview/wwv-plugin-sdk";
+import { pluginManager } from "@/core/plugins/PluginManager";
+
+export interface AlertablePlugin {
+    id: string;
+    name: string;
+    definitions: AlertFieldDefinition[];
+}
+
+/** All registered plugins that declare alert field definitions. */
+export function getAlertablePlugins(): AlertablePlugin[] {
+    return pluginManager
+        .getAllPlugins()
+        .map((managed) => managed.plugin)
+        .filter((plugin) => typeof plugin.getAlertDefinitions === "function")
+        .map((plugin) => ({
+            id: plugin.id,
+            name: plugin.name,
+            definitions: plugin.getAlertDefinitions?.() ?? [],
+        }))
+        .filter((entry) => entry.definitions.length > 0);
+}
+
+/** Definitions for one plugin id (used to label stored conditions), or [] when unknown. */
+export function getAlertDefinitionsFor(pluginId: string): AlertFieldDefinition[] {
+    return getAlertablePlugins().find((p) => p.id === pluginId)?.definitions ?? [];
+}

--- a/src/lib/alerts/api.ts
+++ b/src/lib/alerts/api.ts
@@ -1,0 +1,75 @@
+/**
+ * Client-side alert-rule API (P2, v1). Thin fetch wrappers over the alerts
+ * REST surface; consumed by the alerts store slice. All endpoints require a
+ * session (the app's own cookie).
+ */
+
+import type { AlertCondition } from "@worldwideview/wwv-plugin-sdk";
+
+export interface AlertRuleRecord {
+    id: string;
+    pluginId: string;
+    name: string;
+    condition: AlertCondition;
+    enabled: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface AlertMutationResult {
+    ok: boolean;
+    status: number;
+    error?: string;
+    rule?: AlertRuleRecord;
+}
+
+async function parseError(res: Response): Promise<string> {
+    try {
+        const body = (await res.json()) as { message?: string; error?: string };
+        return body.message ?? body.error ?? `Request failed (${res.status})`;
+    } catch {
+        return `Request failed (${res.status})`;
+    }
+}
+
+export async function fetchAlertRules(): Promise<AlertRuleRecord[]> {
+    const res = await fetch("/api/alerts", { cache: "no-store" });
+    if (!res.ok) throw new Error(await parseError(res));
+    const data = (await res.json()) as { rules?: AlertRuleRecord[] };
+    return data.rules ?? [];
+}
+
+export async function createAlertRule(input: {
+    pluginId: string;
+    name: string;
+    condition: AlertCondition;
+}): Promise<AlertMutationResult> {
+    const res = await fetch("/api/alerts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+    });
+    if (!res.ok) return { ok: false, status: res.status, error: await parseError(res) };
+    const data = (await res.json()) as { rule?: AlertRuleRecord };
+    return { ok: true, status: res.status, rule: data.rule };
+}
+
+export async function updateAlertRule(
+    id: string,
+    patch: { enabled?: boolean; name?: string; condition?: AlertCondition },
+): Promise<AlertMutationResult> {
+    const res = await fetch(`/api/alerts/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+    });
+    if (!res.ok) return { ok: false, status: res.status, error: await parseError(res) };
+    const data = (await res.json()) as { rule?: AlertRuleRecord };
+    return { ok: true, status: res.status, rule: data.rule };
+}
+
+export async function deleteAlertRule(id: string): Promise<AlertMutationResult> {
+    const res = await fetch(`/api/alerts/${id}`, { method: "DELETE" });
+    if (!res.ok) return { ok: false, status: res.status, error: await parseError(res) };
+    return { ok: true, status: res.status };
+}

--- a/src/lib/alerts/engine.ts
+++ b/src/lib/alerts/engine.ts
@@ -18,6 +18,20 @@ import { evaluateRule } from "./evaluate";
 export const DEDUPE_WINDOW_MS = 60_000;
 export const RULES_REFRESH_MS = 60_000;
 
+/**
+ * Engine refresh registry (UI integration): the alerts UI calls
+ * `requestAlertRulesRefresh()` after create/toggle/delete so the attached
+ * engine picks new/changed rules up immediately instead of waiting for the
+ * periodic refresh timer. SSR-safe: the handler is only registered inside
+ * `attachAlertEngine` (browser effect).
+ */
+type RefreshHandler = () => void;
+let refreshHandler: RefreshHandler | null = null;
+
+export function requestAlertRulesRefresh(): void {
+    refreshHandler?.();
+}
+
 /** Rule as loaded from the API (snapshot + server flags). */
 export interface RuleRecord extends AlertRuleSnapshot {
     enabled: boolean;
@@ -124,10 +138,13 @@ export function attachAlertEngine(
     void refreshRules();
     refreshTimer = setInterval(() => void refreshRules(), RULES_REFRESH_MS);
 
+    refreshHandler = refreshRules;
+
     return () => {
         unsubscribe();
         if (refreshTimer !== null) clearInterval(refreshTimer);
         lastFired.clear();
+        if (refreshHandler === refreshRules) refreshHandler = null;
     };
 }
 

--- a/src/lib/alerts/evaluate.test.ts
+++ b/src/lib/alerts/evaluate.test.ts
@@ -197,6 +197,36 @@ describe("evaluateCondition — entities and robustness", () => {
         )).toBe(true);
     });
 
+    it("resolves plugin-mapped fields from a realistic earthquake entity (properties bag)", () => {
+        // The earthquakes plugin maps magnitude/place/depth into entity.properties
+        // (mirroring FilterDefinition.propertyKey); the evaluator must see them there.
+        const quake: GeoEntity = {
+            id: "quakeml:us7000xyz",
+            pluginId: "earthquakes",
+            latitude: 63.1,
+            longitude: -151.5,
+            timestamp: new Date("2026-08-25T04:32:10Z"),
+            label: "M6.9 - Central Alaska",
+            properties: {
+                magnitude: 6.9,
+                place: "Central Alaska",
+                depth_km: 12,
+                felt: true,
+                status: "reviewed",
+            },
+        };
+
+        expect(evaluateCondition({ field: "magnitude", op: "gt", value: 6 }, quake)).toBe(true);
+        expect(evaluateCondition({ field: "magnitude", op: "lt", value: 6 }, quake)).toBe(false);
+        expect(evaluateCondition({ field: "place", op: "contains", value: "alaska" }, quake)).toBe(true);
+        expect(evaluateCondition({ field: "place", op: "eq", value: "Central Alaska" }, quake)).toBe(true);
+        expect(evaluateCondition({ field: "felt", op: "eq", value: true }, quake)).toBe(true);
+        expect(evaluateCondition({ field: "depth_km", op: "gt", value: 11 }, quake)).toBe(true);
+        expect(evaluateCondition({ field: "tsunami", op: "exists" }, quake)).toBe(false);
+        // A top-level-only field still resolves.
+        expect(evaluateCondition({ field: "latitude", op: "gt", value: 60 }, quake)).toBe(true);
+    });
+
     it("malformed condition object -> false", () => {
         expect(evaluateCondition({ field: "", op: "gt", value: 1 }, MAG_ENTITY)).toBe(false);
         expect(evaluateCondition({ field: "magnitude", op: "bogus" as never, value: 1 }, MAG_ENTITY)).toBe(false);

--- a/src/lib/alerts/format.test.ts
+++ b/src/lib/alerts/format.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import type { AlertFieldDefinition } from "@worldwideview/wwv-plugin-sdk";
+import {
+    DEFAULT_OPERATORS_BY_TYPE,
+    OPERATOR_LABELS,
+    formatCondition,
+    formatConditionShort,
+    isOperatorAllowed,
+    operatorsForField,
+} from "./format";
+
+const EQ_DEF: AlertFieldDefinition = { key: "magnitude", label: "Magnitude", type: "number" };
+
+describe("formatCondition", () => {
+    it("renders a numeric condition with the plugin's field label", () => {
+        expect(formatCondition({ field: "magnitude", op: "gt", value: 5 }, [EQ_DEF]))
+            .toBe("Magnitude greater than 5");
+    });
+
+    it("falls back to the raw field key when definitions are missing", () => {
+        expect(formatCondition({ field: "place", op: "eq", value: "Alaska" }, null))
+            .toBe("place equals \"Alaska\"");
+    });
+
+    it("quotes string values and renders booleans plainly", () => {
+        const defs: AlertFieldDefinition[] = [
+            { key: "place", label: "Place", type: "string" },
+            { key: "felt", label: "Felt", type: "boolean" },
+        ];
+        expect(formatCondition({ field: "place", op: "contains", value: "al" }, defs))
+            .toBe("Place contains \"al\"");
+        expect(formatCondition({ field: "felt", op: "eq", value: true }, defs))
+            .toBe("Felt equals true");
+    });
+
+    it("omits the value for the exists operator", () => {
+        expect(formatCondition({ field: "place", op: "exists" }, [{ key: "place", label: "Place", type: "string" }]))
+            .toBe("Place exists");
+    });
+
+    it("renders a safe message for malformed conditions", () => {
+        expect(formatCondition({ field: "", op: "gt", value: 1 }, null)).toBe("Invalid condition");
+        expect(formatCondition({ field: "x", op: "bogus" as never, value: 1 }, null)).toBe("Invalid condition");
+    });
+});
+
+describe("formatConditionShort", () => {
+    it("renders the raw key/op/value form", () => {
+        expect(formatConditionShort({ field: "magnitude", op: "gt", value: 5 })).toBe("magnitude gt 5");
+    });
+
+    it("omits value for exists", () => {
+        expect(formatConditionShort({ field: "place", op: "exists" })).toBe("place exists");
+    });
+});
+
+describe("operatorsForField / isOperatorAllowed", () => {
+    it("defaults operators per field type", () => {
+        expect(DEFAULT_OPERATORS_BY_TYPE.number).toEqual(["gt", "lt", "gte", "lte", "eq", "neq", "exists"]);
+        expect(DEFAULT_OPERATORS_BY_TYPE.string).toEqual(["eq", "neq", "contains", "exists"]);
+        expect(DEFAULT_OPERATORS_BY_TYPE.boolean).toEqual(["eq", "neq", "exists"]);
+        expect(OPERATOR_LABELS.gt).toBe("greater than");
+    });
+
+    it("uses the plugin's declared operators when provided", () => {
+        const field: AlertFieldDefinition = { key: "mag", label: "Mag", type: "number", operators: ["gt", "exists"] };
+        expect(operatorsForField(field)).toEqual(["gt", "exists"]);
+        expect(isOperatorAllowed(field, "gt")).toBe(true);
+        expect(isOperatorAllowed(field, "lt")).toBe(false);
+    });
+
+    it("rejects type-incompatible operators by default", () => {
+        expect(isOperatorAllowed({ type: "boolean" }, "gt")).toBe(false);
+        expect(isOperatorAllowed({ type: "boolean" }, "eq")).toBe(true);
+        expect(isOperatorAllowed({ type: "number" }, "contains")).toBe(false);
+        expect(isOperatorAllowed({ type: "string" }, "contains")).toBe(true);
+    });
+});

--- a/src/lib/alerts/format.ts
+++ b/src/lib/alerts/format.ts
@@ -1,0 +1,96 @@
+/**
+ * Human-readable rendering + operator rules for alert conditions (P2, v1).
+ * Pure helpers — no I/O — so the condition builder and rule list can share
+ * one source of truth for "which operators fit which field type".
+ */
+
+import type {
+    AlertCondition,
+    AlertFieldDefinition,
+    AlertFieldType,
+    AlertOperator,
+} from "@worldwideview/wwv-plugin-sdk";
+
+/** Operators available by default for a field type (when the plugin omits `operators`). */
+export const DEFAULT_OPERATORS_BY_TYPE: Record<AlertFieldType, AlertOperator[]> = {
+    number: ["gt", "lt", "gte", "lte", "eq", "neq", "exists"],
+    string: ["eq", "neq", "contains", "exists"],
+    boolean: ["eq", "neq", "exists"],
+};
+
+export const OPERATOR_LABELS: Record<AlertOperator, string> = {
+    gt: "greater than",
+    lt: "less than",
+    gte: "greater than or equal to",
+    lte: "less than or equal to",
+    eq: "equals",
+    neq: "does not equal",
+    contains: "contains",
+    exists: "exists",
+};
+
+/** Operators allowed for a field: the field's declared list, else the type defaults. */
+export function operatorsForField(field: Pick<AlertFieldDefinition, "type" | "operators">): AlertOperator[] {
+    return field.operators && field.operators.length > 0
+        ? field.operators
+        : DEFAULT_OPERATORS_BY_TYPE[field.type];
+}
+
+/** True when the operator is allowed for a field of this type. */
+export function isOperatorAllowed(
+    field: Pick<AlertFieldDefinition, "type" | "operators">,
+    op: AlertOperator,
+): boolean {
+    return operatorsForField(field).includes(op);
+}
+
+function renderValue(value: unknown): string {
+    if (typeof value === "string") return `"${value}"`;
+    if (typeof value === "boolean") return value ? "true" : "false";
+    if (value === null || value === undefined) return "";
+    return String(value);
+}
+
+/**
+ * Render a stored condition as human text, using the plugin's field labels
+ * when available (e.g. "Magnitude greater than 5"). Falls back to the raw
+ * field key when the plugin is unknown or not loaded.
+ */
+export function formatCondition(
+    condition: AlertCondition,
+    definitions?: AlertFieldDefinition[] | null,
+): string {
+    if (
+        !condition ||
+        typeof condition.field !== "string" ||
+        condition.field.trim() === "" ||
+        typeof condition.op !== "string" ||
+        !Object.prototype.hasOwnProperty.call(OPERATOR_LABELS, condition.op)
+    ) {
+        return "Invalid condition";
+    }
+    const definition = definitions?.find((d) => d.key === condition.field);
+    const fieldLabel = definition?.label ?? condition.field;
+    const opLabel = OPERATOR_LABELS[condition.op] ?? condition.op;
+
+    if (condition.op === "exists") {
+        return `${fieldLabel} ${opLabel}`;
+    }
+    return `${fieldLabel} ${opLabel} ${renderValue(condition.value)}`;
+}
+
+/** Short raw form used in compact rows/tooltips: "magnitude gt 5". */
+export function formatConditionShort(condition: AlertCondition): string {
+    if (
+        !condition ||
+        typeof condition.field !== "string" ||
+        condition.field.trim() === "" ||
+        typeof condition.op !== "string" ||
+        !Object.prototype.hasOwnProperty.call(OPERATOR_LABELS, condition.op)
+    ) {
+        return "Invalid condition";
+    }
+    return condition.op === "exists"
+        ? `${condition.field} ${condition.op}`
+        : `${condition.field} ${condition.op} ${renderValue(condition.value)}`;
+}

--- a/src/lib/alerts/knownPlugins.test.ts
+++ b/src/lib/alerts/knownPlugins.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getKnownPluginIds, isKnownPluginId } from "./knownPlugins";
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        installedPlugin: {
+            findMany: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/data-query/localSources", () => ({
+    getLocalSourceIds: vi.fn().mockResolvedValue(new Set<string>()),
+}));
+
+import { prisma } from "@/lib/db";
+import { getLocalSourceIds } from "@/lib/data-query/localSources";
+
+const mockInstalled = vi.mocked(prisma.installedPlugin.findMany);
+const mockLocalIds = vi.mocked(getLocalSourceIds);
+
+/** Full row shape the mocked prisma delegate returns (select: { pluginId } projects at runtime). */
+function installedRow(pluginId: string) {
+    return {
+        pluginId,
+        config: "{}",
+        id: `row-${pluginId}`,
+        enabled: true,
+        updatedAt: new Date(),
+        tenantId: null,
+        version: "1.0.0",
+        installedAt: new Date(),
+    };
+}
+
+/** Fetcher that returns no engine plugins (engine offline). */
+const noEngine: typeof fetch = async () =>
+    ({ ok: false, status: 500 }) as Response;
+
+describe("getKnownPluginIds", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockInstalled.mockResolvedValue([]);
+        mockLocalIds.mockResolvedValue(new Set<string>());
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("includes built-in alertable plugin ids", async () => {
+        const ids = await getKnownPluginIds(noEngine);
+        for (const id of ["earthquakes", "geojson", "iss", "weather"]) {
+            expect(ids.has(id)).toBe(true);
+        }
+    });
+
+    it("includes installed marketplace plugin ids from the DB", async () => {
+        mockInstalled.mockResolvedValue([
+            installedRow("e2e-alert-mock"),
+            installedRow("camera"),
+        ]);
+        const ids = await getKnownPluginIds(noEngine);
+        expect(ids.has("e2e-alert-mock")).toBe(true);
+        expect(ids.has("camera")).toBe(true);
+    });
+
+    it("includes local-registry plugin ids", async () => {
+        mockLocalIds.mockResolvedValue(new Set(["local-seeder-a"]));
+        const ids = await getKnownPluginIds(noEngine);
+        expect(ids.has("local-seeder-a")).toBe(true);
+    });
+
+    it("tolerates a DB failure without dropping the other sources", async () => {
+        mockInstalled.mockRejectedValue(new Error("db down"));
+        const ids = await getKnownPluginIds(noEngine);
+        expect(ids.has("earthquakes")).toBe(true);
+    });
+
+    it("isKnownPluginId resolves true for an installed plugin", async () => {
+        mockInstalled.mockResolvedValue([installedRow("e2e-alert-mock")]);
+        expect(await isKnownPluginId("e2e-alert-mock")).toBe(true);
+        expect(await isKnownPluginId("not-installed")).toBe(false);
+    });
+});

--- a/src/lib/alerts/knownPlugins.ts
+++ b/src/lib/alerts/knownPlugins.ts
@@ -7,9 +7,13 @@
  *      (graceful — unreachable engine degrades to the built-ins).
  *   3. Local-registry plugin ids (public/plugins-local manifests, see
  *      data-query/localSources).
+ *   4. Installed marketplace plugins (installed_plugins rows) — the same set
+ *      the client loads via /api/marketplace/load, so a rule can be created
+ *      for any plugin the user has installed.
  */
 
 import { getEngineUrl } from "@/lib/data-query/service";
+import { prisma } from "@/lib/db";
 
 /** Built-in plugin ids shipped in src/plugins (channel names are folder ids). */
 const BUILTIN_ALERTABLE_PLUGIN_IDS = ["earthquakes", "geojson", "iss", "weather"];
@@ -46,6 +50,13 @@ export async function getKnownPluginIds(
         }
     } catch {
         // Local registry unavailable (e.g. test env without public/plugins-local).
+    }
+
+    try {
+        const rows = await prisma.installedPlugin.findMany({ select: { pluginId: true } });
+        for (const row of rows) ids.add(row.pluginId);
+    } catch {
+        // DB unavailable — the other sources still validate.
     }
 
     return ids;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,2 +1,25 @@
 // Vitest setup file — intentionally empty after auth clean-up.
 // The vi.mock("@/lib/auth") line was removed along with auth.ts.
+
+/**
+ * jsdom in this vitest setup provides `localStorage` as an inert object with
+ * no methods; the UI store slice reads it at module init. Install a working
+ * in-memory implementation before any store import so store-backed component
+ * tests can run without a stubbed URL.
+ */
+if (typeof globalThis.localStorage === "undefined" || typeof globalThis.localStorage.getItem !== "function") {
+    const memory = new Map<string, string>();
+    const storage: Storage = {
+        get length() { return memory.size; },
+        clear: () => memory.clear(),
+        getItem: (key: string) => (memory.has(key) ? memory.get(key) as string : null),
+        key: (index: number) => Array.from(memory.keys())[index] ?? null,
+        removeItem: (key: string) => { memory.delete(key); },
+        setItem: (key: string, value: string) => { memory.set(key, String(value)); },
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+        value: storage,
+        configurable: true,
+        writable: true,
+    });
+}

--- a/tests/alerts.spec.ts
+++ b/tests/alerts.spec.ts
@@ -88,8 +88,28 @@ async function createRuleViaUi(page: Page, name: string): Promise<void> {
   await expect(page.getByTestId('alerts-list').getByText(name)).toBeVisible({ timeout: 20000 });
 }
 
+/**
+ * Delete every rule for the mock plugin so each test (and each CI retry)
+ * starts from an empty rules list. global.setup only cleans installed plugins
+ * and global.teardown only runs once after the whole suite, so without this
+ * a leftover rule from test 1 (or a failed retry) would make the toggle
+ * locator in test 2 resolve to multiple switches.
+ */
+async function cleanupMockRules(page: Page): Promise<void> {
+  const res = await page.request.get('/api/alerts');
+  if (!res.ok) throw new Error(`cleanup: GET /api/alerts -> ${res.status()}`);
+  const { rules } = (await res.json()) as { rules?: { id: string; pluginId: string }[] };
+  for (const rule of rules ?? []) {
+    if (rule.pluginId === MOCK_ID) {
+      const del = await page.request.delete(`/api/alerts/${rule.id}`);
+      if (!del.ok) throw new Error(`cleanup: DELETE /api/alerts/${rule.id} -> ${del.status()}`);
+    }
+  }
+}
+
 test.describe('Alert UI', () => {
   test.beforeEach(async ({ page }) => {
+    await cleanupMockRules(page);
     await page.goto('/');
     await openAlertsPanel(page);
   });
@@ -107,7 +127,8 @@ test.describe('Alert UI', () => {
     // Inject a MATCHING payload (magnitude 6.5 > 5) -> toast + badge.
     await injectPayload(page, [matchingPayload({})]);
     await expect(page.getByTestId('alert-toasts')).toBeVisible({ timeout: 20000 });
-    await expect(page.getByText('Magnitude over five')).toBeVisible({ timeout: 20000 });
+    // Scope to the toasts stack: the rule row in the list carries the same name.
+    await expect(page.getByTestId('alert-toasts').getByText('Magnitude over five')).toBeVisible({ timeout: 20000 });
     await expect(page.getByTestId('alerts-tab-badge')).toHaveText('1');
 
     // Inject a NON-matching payload (magnitude 2, different entity) -> no new

--- a/tests/alerts.spec.ts
+++ b/tests/alerts.spec.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-console */
+/**
+ * Alerts UI E2E: create a rule through the real UI against the
+ * `e2e-alert-mock` plugin (seeded in global.setup), then inject a matching
+ * payload through PluginManager -> dataBus and assert the toast + badge fire;
+ * inject a non-matching payload and assert nothing new fires. A second test
+ * disables a rule through the UI and asserts a would-be match stays silent.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const MOCK_ID = 'e2e-alert-mock';
+
+interface HostGlobals {
+  __WWV_HOST__?: {
+    useStore: {
+      getState: () => {
+        initLayer: (id: string, enabled: boolean) => void;
+      };
+    };
+    pluginManager: {
+      enablePlugin: (id: string) => Promise<void>;
+      fetchForPlugin: (id: string, timeRange: { start: Date; end: Date }) => Promise<void>;
+    };
+  };
+  __setE2eAlertMockPayload?: (entities: Record<string, unknown>[]) => void;
+}
+
+async function enableMockLayer(page: Page): Promise<void> {
+  await page.evaluate(async (id) => {
+    const w = globalThis as unknown as HostGlobals;
+    if (!w.__WWV_HOST__) throw new Error('__WWV_HOST__ missing');
+    w.__WWV_HOST__.useStore.getState().initLayer(id, true);
+    await w.__WWV_HOST__.pluginManager.enablePlugin(id);
+  }, MOCK_ID);
+}
+
+function matchingPayload(overrides: Record<string, unknown>) {
+  return {
+    id: 'matching-quake',
+    pluginId: MOCK_ID,
+    latitude: 61.2,
+    longitude: -149.4,
+    timestamp: new Date().toISOString(),
+    label: 'M6.5 Central Alaska',
+    properties: { magnitude: 6.5, place: 'Central Alaska', felt: true },
+    ...overrides,
+  };
+}
+
+async function injectPayload(page: Page, entities: Record<string, unknown>[]): Promise<void> {
+  await page.evaluate((payload) => {
+    (globalThis as unknown as HostGlobals).__setE2eAlertMockPayload?.(payload);
+  }, entities);
+  await page.evaluate(async (id) => {
+    const w = globalThis as unknown as HostGlobals;
+    if (!w.__WWV_HOST__) throw new Error('__WWV_HOST__ missing');
+    const range = { start: new Date(Date.now() - 60 * 60 * 1000), end: new Date() };
+    await w.__WWV_HOST__.pluginManager.fetchForPlugin(id, range);
+  }, MOCK_ID);
+}
+
+async function openAlertsPanel(page: Page): Promise<void> {
+  await page.waitForSelector('[data-testid="app-ready"]', { state: 'attached', timeout: 60000 });
+  const rightToggle = page.locator('[data-testid="panel-toggle-right"]');
+  if (await rightToggle.count() > 0) {
+    const isOpen = await rightToggle.evaluate((node) =>
+      node.classList.contains('panel-toggle-btn--open'));
+    if (!isOpen) await rightToggle.click();
+  }
+  await page.getByTestId('alerts-tab').click({ timeout: 20000 });
+  await expect(page.getByTestId('alerts-panel')).toBeVisible({ timeout: 30000 });
+}
+
+async function createRuleViaUi(page: Page, name: string): Promise<void> {
+  await page.getByTestId('alert-create-button').click();
+  const pluginSelect = page.getByTestId('alert-rule-plugin-select');
+  await expect(
+    pluginSelect.locator('option', { hasText: 'E2E Alert Mock' }),
+  ).toBeAttached({ timeout: 45000 });
+
+  await page.getByTestId('alert-rule-name-input').fill(name);
+  await pluginSelect.selectOption(MOCK_ID);
+  await page.getByTestId('alert-rule-field-select').selectOption('magnitude');
+  await page.getByTestId('alert-rule-op-select').selectOption('gt');
+  await page.getByTestId('alert-rule-value-input').fill('5');
+  await page.getByTestId('alert-rule-save').click();
+
+  await expect(page.getByTestId('alerts-list').getByText(name)).toBeVisible({ timeout: 20000 });
+}
+
+test.describe('Alert UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await openAlertsPanel(page);
+  });
+
+  test('creates a rule and fires a toast/badge on match but not on non-match', async ({ page }) => {
+    await expect(page.getByTestId('alerts-empty')).toBeVisible({ timeout: 30000 });
+    await createRuleViaUi(page, 'Magnitude over five');
+    await expect(page.getByTestId('alerts-list')).toContainText('greater than 5');
+
+    // Enable the mock layer so PluginManager can fetch data for it.
+    await enableMockLayer(page);
+    // Give the alert engine a beat to refresh its rule set after the POST.
+    await page.waitForTimeout(1000);
+
+    // Inject a MATCHING payload (magnitude 6.5 > 5) -> toast + badge.
+    await injectPayload(page, [matchingPayload({})]);
+    await expect(page.getByTestId('alert-toasts')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByText('Magnitude over five')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId('alerts-tab-badge')).toHaveText('1');
+
+    // Inject a NON-matching payload (magnitude 2, different entity) -> no new
+    // alert: badge stays at 1 and no toast mentions the quiet quake.
+    await injectPayload(page, [matchingPayload({
+      id: 'quiet-quake',
+      label: 'M2.0 Fiji',
+      properties: { magnitude: 2, place: 'Fiji', felt: false },
+    })]);
+    await page.waitForTimeout(2000);
+    await expect(page.getByTestId('alerts-tab-badge')).toHaveText('1');
+    await expect(page.getByTestId('alert-toasts')).not.toContainText('Fiji');
+  });
+
+  test('disabling a rule stops it from firing', async ({ page }) => {
+    // Create through the UI, then flip the enable switch off.
+    await createRuleViaUi(page, 'Will be disabled');
+    const toggle = page.getByTestId('alerts-list').locator('[role="switch"]');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await enableMockLayer(page);
+    await page.waitForTimeout(1000);
+
+    // A payload that WOULD match if the rule were active.
+    await injectPayload(page, [matchingPayload({})]);
+    await page.waitForTimeout(2000);
+
+    await expect(page.getByTestId('alert-toasts')).toHaveCount(0);
+    await expect(page.locator('[data-testid^="alert-toast-"]')).toHaveCount(0);
+    await expect(page.getByTestId('alerts-tab-badge')).toHaveCount(0);
+  });
+});

--- a/tests/fixtures/plugins-local/e2e-alert-mock/data.json
+++ b/tests/fixtures/plugins-local/e2e-alert-mock/data.json
@@ -1,0 +1,4 @@
+{
+  "type": "FeatureCollection",
+  "features": []
+}

--- a/tests/fixtures/plugins-local/e2e-alert-mock/plugin.json
+++ b/tests/fixtures/plugins-local/e2e-alert-mock/plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "e2e-alert-mock",
+  "name": "E2E Alert Mock",
+  "version": "1.0.0",
+  "localData": [
+    {
+      "name": "placeholder",
+      "type": "geojson",
+      "path": "plugins-local/e2e-alert-mock/data.json"
+    }
+  ]
+}

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -68,8 +68,20 @@ async function globalSetup(config: FullConfig) {
     // 2.5 Defensive Cleanup for Mock Plugin
     console.log(`[Setup] Cleaning up any existing mock plugins...`);
     await prisma.installedPlugin.deleteMany({
-        where: { pluginId: { in: ['e2e-mock-plugin', 'e2e-mock-bottom-panel'] } }
+        where: { pluginId: { in: ['e2e-mock-plugin', 'e2e-mock-bottom-panel', 'e2e-alert-mock'] } }
     });
+
+    // 2.6 Stage the alert mock's local-registry manifest. The alerts API
+    // validates rule pluginIds against the local registry, which scans
+    // public/plugins-local at runtime. The fixtures live in tests/fixtures
+    // (public/plugins-local is gitignored), so copy them into place here.
+    const stagingSrc = path.join(process.cwd(), 'tests', 'fixtures', 'plugins-local');
+    const stagingDest = path.join(process.cwd(), 'public', 'plugins-local');
+    fs.mkdirSync(path.join(stagingDest, 'e2e-alert-mock'), { recursive: true });
+    for (const file of fs.readdirSync(path.join(stagingSrc, 'e2e-alert-mock'))) {
+      fs.copyFileSync(path.join(stagingSrc, 'e2e-alert-mock', file), path.join(stagingDest, 'e2e-alert-mock', file));
+    }
+    console.log(`[Setup] Staged local-registry manifest for e2e-alert-mock.`);
 
     // 3. Clean up any orphaned user and create the test user
     console.log(`[Setup] Upserting test user: ${TEST_USER_EMAIL}`);
@@ -124,6 +136,17 @@ async function globalSetup(config: FullConfig) {
         pluginId: 'e2e-mock-bottom-panel',
         version: '1.0.0',
         config: bottomManifestStr,
+        enabled: true
+      }
+    });
+
+    const alertMockManifestPath = path.join(process.cwd(), 'public', 'e2e-fixtures', 'alert-mock-manifest.json');
+    const alertMockManifestStr = fs.readFileSync(alertMockManifestPath, 'utf-8');
+    await prisma.installedPlugin.create({
+      data: {
+        pluginId: 'e2e-alert-mock',
+        version: '1.0.0',
+        config: alertMockManifestStr,
         enabled: true
       }
     });
@@ -208,7 +231,7 @@ async function globalSetup(config: FullConfig) {
       // useMarketplaceSync doesn't hold them behind the approval dialog.
       // trustedPlugins.getApprovedUnverifiedIds() does JSON.parse(raw), so the
       // value must be a JSON array string of plugin IDs.
-      const approvedMockPlugins = JSON.stringify(['e2e-mock-plugin', 'e2e-mock-bottom-panel']);
+      const approvedMockPlugins = JSON.stringify(['e2e-mock-plugin', 'e2e-mock-bottom-panel', 'e2e-alert-mock']);
       const origin = new URL(baseURL).origin;
       const origins = [{
         origin,

--- a/tests/global.teardown.ts
+++ b/tests/global.teardown.ts
@@ -36,13 +36,29 @@ async function globalTeardown() {
   const prisma = new PrismaClient({ adapter });
   console.log(`[Teardown] Cleaning up test user: ${TEST_USER_EMAIL}`);
   try {
+      console.log(`[Teardown] Cleaning up alert mock rule + events...`);
+      await prisma.alertEvent.deleteMany({
+          where: { pluginId: 'e2e-alert-mock' }
+      });
+      await prisma.alertRule.deleteMany({
+          where: { pluginId: 'e2e-alert-mock' }
+      });
       console.log(`[Teardown] Cleaning up mock plugin...`);
+      await prisma.installedPlugin.deleteMany({
+          where: { pluginId: 'e2e-alert-mock' }
+      });
       await prisma.installedPlugin.deleteMany({
           where: { pluginId: 'e2e-mock-plugin' }
       });
       await prisma.betterAuthUser.deleteMany({
         where: { email: TEST_USER_EMAIL },
       });
+      // Remove the staged local-registry manifest directory (only the subdir
+      // global.setup created — never the whole public/plugins-local tree).
+      const pluginsLocal = path.join(process.cwd(), 'public', 'plugins-local', 'e2e-alert-mock');
+      if (fs.existsSync(pluginsLocal)) {
+        fs.rmSync(pluginsLocal, { recursive: true, force: true });
+      }
   } catch {
       console.error(`[Teardown] Failed to delete test user:`, e);
   } finally {

--- a/tests/smoke-alerts.spec.ts
+++ b/tests/smoke-alerts.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke: app boots and alert mock is listed', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('[data-testid="app-ready"]', { timeout: 60000 });
+  await expect(page.getByTestId('panel-toggle-right')).toBeVisible({ timeout: 20000 });
+});


### PR DESCRIPTION
Alert UI for the alert/conditions backend (#463): rules panel (list/create/enable/disable/delete), condition builder driven by plugin AlertFieldDefinitions (fields resolve properties-first per the evaluator contract), alertFired toasts + badge, API client + slice, format helpers, E2E spec with mock plugin. Rebased on current main.