### PR TITLE
fix: remove Google 3D missing-key error toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.37",
+  "version": "2.65.38",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/core/globe/hooks/useViewerInitialization.ts
+++ b/src/core/globe/hooks/useViewerInitialization.ts
@@ -115,7 +115,6 @@ export function useViewerInitialization(sceneSettings: any) {
                     googleLoaded = true;
                 } catch (err: any) {
                     console.error("[GlobeView] Failed to initialize Google 3D Tiles:", err);
-                    useStore.getState().showErrorToast?.("3D terrain requires a Google Maps API key. Falling back to 2D imagery.");
                 }
             }
 
@@ -125,9 +124,6 @@ export function useViewerInitialization(sceneSettings: any) {
                        // -> Ion (needs a token) -> OSM but never verifies tile loading, so with
                        // no Google key / no ion token / no Bing key the viewport stays dark.
                        useStore.getState().updateMapConfig({ fallbackLayerId: "osm" });
-                 }
-                 if (!activeKey || activeKey.length < 20) {
-                     useStore.getState().showErrorToast?.("Google Maps 3D is not available. No valid API key configured.");
                  }
                  clearTimeout(globalTimeout);
                  fireGlobeReady();


### PR DESCRIPTION
## Summary

Removes the two user-facing error toasts that pop up at globe startup when no valid Google Maps API key is configured:

- `Google Maps 3D is not available. No valid API key configured.`
- `3D terrain requires a Google Maps API key. Falling back to 2D imagery.`

These were added in #367 and alarm end users even though the globe degrades gracefully. The base layer already falls back to the tokenless OSM basemap (`fallbackLayerId: 'osm'`) and the imagery picker shows the active fallback state. Operators still get the root cause via `console.error`.

## Change

- `src/core/globe/hooks/useViewerInitialization.ts`: delete the two `showErrorToast` calls (4 lines). Silent OSM fallback, `clearTimeout`/`fireGlobeReady` and the console error all remain.
- `package.json`: 2.65.37 -> 2.65.38 (patch).

No other `showErrorToast` callers touch this path (feedback dialog, plugin load failures keep their notifications).

## Test plan

- [x] `pnpm lint` - 0 errors
- [x] `pnpm test` - 144 files / 1434 tests passed
- [x] `pnpm build` - production build succeeds
- [ ] CI on this PR
- [ ] Redeploy live instance to clear the popup for users