### PR TITLE
chore(ci): allow manual dispatch of Docker Image CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Docker Image CI
 on:
   push:
     branches: ["main"]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.38",
+  "version": "2.65.39",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

The **Docker Image CI** run for the last merge (#469) failed at workflow registration (\startup_failure\ - 0 jobs, no log, not retryable), so the GHCR \:demo\ image was never rebuilt and the deployed demo still runs the pre-merge commit (6beafa60). The workflow only triggers on push to main, so there was no way to rebuild without a code change.

Adds \workflow_dispatch\ to the \on:\ block so the image pipeline can be re-triggered manually from the Actions tab.

## Change

- \.github/workflows/docker-publish.yml\: add \workflow_dispatch\ trigger (2 lines)
- \package.json\: 2.65.38 -> 2.65.39

Merging this also re-triggers a fresh Docker Image CI run on main, which will rebuild the \:demo\ image from the merged commit.