### PR TITLE
fix: standardize data engine port references 5001 to 5000

### DIFF
--- a/.agents/rules/garbage-collection.md
+++ b/.agents/rules/garbage-collection.md
@@ -28,7 +28,7 @@ When unsure of the tier, escalate to Tier B. Never attempt a refactor that requi
 | `anti-pattern` (console-log) | A | Stray `console.log(` in `.ts`/`.tsx` files |
 | `anti-pattern` (ts-ignore) | A | `@ts-ignore` suppressing a real type error |
 | `anti-pattern` (ts-nocheck) | A | `@ts-nocheck` disabling all type checking |
-| `anti-pattern` (hardcoded-url) | B | Hardcoded `localhost:5001`/`5000` engine URL |
+| `anti-pattern` (hardcoded-url) | B | Hardcoded `localhost:5000` engine URL |
 | `anti-pattern` (deprecated) | B | `@deprecated` symbol still active in production code |
 | `oversized-file` | B | Source file exceeding ~350 lines |
 | `orphaned-rule-ref` | B | Rule file references a path that no longer exists |

--- a/deploy/INFRA-CHECKLIST.md
+++ b/deploy/INFRA-CHECKLIST.md
@@ -54,11 +54,11 @@ are unenforceable.
   # WWV_DATA_ENGINE_URL=https://dataenginev2.worldwideview.dev/stream
   ```
   The engine listens on internal port 5000 (`PORT=5000` in
-  `deploy/production/docker-compose.engine.yml`) and publishes ports 5000/5001 on the
+  `deploy/production/docker-compose.engine.yml`) and publishes port 5000 on the
   host. The public URL `https://dataenginev2.worldwideview.dev` is reverse-proxied and
   needs no port. The code reads `WWV_DATA_ENGINE_URL` first in `getEngineUrl()`
   (`src/lib/data-query/service.ts`) and falls back to
-  `http://localhost:5001` when it is unset.
+  `http://localhost:5000` when it is unset.
   Replace `<engine-host-ip>` with the actual engine host IP or hostname visible from
   the `wwv` container.
 - [ ] If the app and engine containers share a Docker network, use the service name:

--- a/deploy/cloud/docker-compose.yml
+++ b/deploy/cloud/docker-compose.yml
@@ -55,10 +55,10 @@ services:
       REDIS_URL: "redis://:${REDIS_PASSWORD}@wwv-redis:6379"
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       # REST base URL for server-side MCP data queries (NOT the WebSocket /stream path).
-      # The engine publishes ports 5000/5001 on the host; the public URL
+      # The engine publishes port 5000 on the host; the public URL
       # https://dataenginev2.worldwideview.dev is reverse-proxied and needs no port.
       # Set to the actual engine host IP/hostname visible from this container.
-      WWV_DATA_ENGINE_URL: ${WWV_DATA_ENGINE_URL:-http://<engine-host-ip>:5001}
+      WWV_DATA_ENGINE_URL: ${WWV_DATA_ENGINE_URL:-http://<engine-host-ip>:5000}
     ports:
       - "3001:3000"
     labels:

--- a/deploy/production/docker-compose.app.yml
+++ b/deploy/production/docker-compose.app.yml
@@ -20,7 +20,7 @@ services:
       # Provide the explicit public URL of the data engine for the frontend to use.
       - "NEXT_PUBLIC_WWV_PLUGIN_DATA_ENGINE_URL=https://dataenginev2.worldwideview.dev/stream"
       # REST base URL for server-side MCP data queries (NOT the WebSocket /stream path).
-      # getEngineUrl() reads this first and falls back to http://localhost:5001 when unset.
+      # getEngineUrl() reads this first and falls back to http://localhost:5000 when unset.
       # The public URL is network-topology-independent (verified reachable from app containers).
       - "WWV_DATA_ENGINE_URL=${WWV_DATA_ENGINE_URL:-https://dataenginev2.worldwideview.dev}"
       # Redis session/cache/rate-limit store.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,9 +106,9 @@ The `DataBus` is a custom typed pub/sub singleton (see [`src/core/data/DataBus.t
 
 The data engine ([`wwv-data-engine`](https://github.com/silvertakana/wwv-data-engine), public) is a **content-agnostic runner**. It discovers and executes seeder scripts from a configurable directory; the engine itself knows nothing about specific data sources.
 
-- **Local development**: The engine runs via Docker Compose on port 5001, reading seeders dynamically from `local-seeders/` (split into `community` and `private` tiers).
+- **Local development**: The engine runs via Docker Compose on port 5000, reading seeders dynamically from `local-seeders/` (split into `community` and `private` tiers).
 - **Production**: The engine container on Coolify downloads release bundles from `wwv-seeders-community` and an internal seeders package on startup, unzipping them into `/app/seeders`.
-- **Split-routing**: `resolveEngineUrl` prioritises the local dev engine (`ws://localhost:5001/stream`) for local testing — 12-Factor App methodology — and falls back to cloud-hosted endpoints (e.g. `wss://dataenginev2.worldwideview.dev/stream`) when nothing local is available.
+- **Split-routing**: `resolveEngineUrl` prioritises the local dev engine (`ws://localhost:5000/stream`) for local testing — 12-Factor App methodology — and falls back to cloud-hosted endpoints (e.g. `wss://dataenginev2.worldwideview.dev/stream`) when nothing local is available.
 
 ### Agnostic Frontend
 

--- a/docs/agent-bus.md
+++ b/docs/agent-bus.md
@@ -103,7 +103,7 @@ Edit `~/.claude/settings.json`:
       "args": ["/absolute/path/to/wwv-mcp/dist/index.js"],
       "env": {
         "WWV_BASE_URL": "https://your-wwv-host.example",
-        "WWV_ENGINE_URL": "http://localhost:5001"
+        "WWV_ENGINE_URL": "http://localhost:5000"
       }
     }
   }
@@ -120,7 +120,7 @@ Or, with Docker:
       "args": [
         "run", "-i", "--rm",
         "-e", "WWV_BASE_URL=http://host.docker.internal:3000",
-        "-e", "WWV_ENGINE_URL=http://host.docker.internal:5001",
+        "-e", "WWV_ENGINE_URL=http://host.docker.internal:5000",
         "szski/wwv-mcp:latest"
       ]
     }

--- a/docs/architecture/decisions/adr-0009-engine-direct-plugin-data-routing.md
+++ b/docs/architecture/decisions/adr-0009-engine-direct-plugin-data-routing.md
@@ -57,7 +57,7 @@ Live evidence settled the question: the engine (`dataenginev2.worldwideview.dev`
   - Per-plugin ticket scoping unimplemented (exchange drops `plugin_id`; JWT has no plugin claim; engine never checks scope).
   - No `Cache-Control` on `/api/<id>` (Cloudflare fronts but can't cache); rate limit mis-keyed (`fastify` no `trustProxy`).
 - Self-hosted globes can't yet redirect a plugin's WS `streamUrl` via env (hardcoded streamUrl outranks env in `resolveEngineUrl` resolution order) — unification is a follow-up.
-- `getEngineUrl()` (server-side `@/lib/data-query/service`) is a local-dev resolver (`http://localhost:5001`) and must NOT be used in globe route handlers; server-side engine calls use the env-chain pattern.
+- `getEngineUrl()` (server-side `@/lib/data-query/service`) is a local-dev resolver (`http://localhost:5000`) and must NOT be used in globe route handlers; server-side engine calls use the env-chain pattern.
 
 ## References
 - Review doc: internal research note `wwv-engine-direct-routing-review-2026-08-24.md` (maintainer-only, not tracked in this repo)

--- a/docs/plugin-advanced.md
+++ b/docs/plugin-advanced.md
@@ -41,7 +41,7 @@ Seeders within `local-seeders/` are strictly orchestrated within the pnpm worksp
 > [!TIP]
 > **Debugging WebSockets:** If your frontend isn't receiving data from your backend seeder:
 > 1. Check the `wwv-data-engine-v2` logs to ensure your seeder is publishing to Redis successfully.
-> 2. Verify the frontend is connected to the correct WebSocket endpoint. Local instances default to `ws://localhost:5001/stream`, while unrecognized plugins should explicitly define their own `streamUrl`, or fallback to the cloud at `wss://dataenginev2.worldwideview.dev/stream`.
+> 2. Verify the frontend is connected to the correct WebSocket endpoint. Local instances default to `ws://localhost:5000/stream`, while unrecognized plugins should explicitly define their own `streamUrl`, or fallback to the cloud at `wss://dataenginev2.worldwideview.dev/stream`.
 
 ## Advanced Cesium Rendering
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-"version": "2.65.37",
+"version": "2.65.38",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/packages/wwv-lib-incidents/src/index.test.ts
+++ b/packages/wwv-lib-incidents/src/index.test.ts
@@ -59,7 +59,7 @@ class MinimalIncidentPlugin extends BaseIncidentPlugin {
             apiBasePath: "/api/test-incident-plugin",
             // Test fixture: the plugin DECLARES its own streamUrl (agnostic-frontend
             // invariant). The literal is arbitrary — this suite never asserts on it.
-            streamUrl: "ws://localhost:5001/stream",
+            streamUrl: "ws://localhost:5000/stream",
             pollingIntervalMs: 0,
         };
     }

--- a/scripts/gc-scan.mjs
+++ b/scripts/gc-scan.mjs
@@ -167,7 +167,7 @@ const ANTI_PATTERNS = [
     globs: ['*.ts', '*.tsx'],
     pattern: 'localhost:500',
     excludePrefix: 'scripts/',
-    desc: 'hardcoded engine URL (localhost:5001/5000) — use env var or plugin streamUrl instead',
+    desc: 'hardcoded engine URL (localhost:5000) — use env var or plugin streamUrl instead',
   },
   {
     id: 'deprecated',

--- a/src/core/plugins/loaders/DeclarativePlugin.test.ts
+++ b/src/core/plugins/loaders/DeclarativePlugin.test.ts
@@ -125,7 +125,7 @@ describe("DeclarativePlugin", () => {
             edition: "local",
             // Host-injected value (PluginContext.getEngineUrl) — arbitrary for this test;
             // the plugin never consumes it. The address comes from the host, not the plugin.
-            getEngineUrl: () => "http://localhost:5001",
+            getEngineUrl: () => "http://localhost:5000",
         });
 
         const entities = await plugin.fetch({ start: new Date(), end: new Date() });


### PR DESCRIPTION
## Summary

Standardizes remaining data-engine port references from the legacy port **5001** to the canonical **5000** across code, test fixtures, deploy configs, and docs. Port 5001 was only the legacy-plugins port; the engine's canonical port is 5000 (already used by \esolveEngineUrl.ts\, \ngineManifest.ts\, and \src/lib/data-query/service.ts\).

## Changes

- **Test fixtures**: \src/core/plugins/loaders/DeclarativePlugin.test.ts\ (host-injected \getEngineUrl\), \packages/wwv-lib-incidents/src/index.test.ts\ (declared \streamUrl\)
- **Docs**: \docs/ARCHITECTURE.md\ (engine port + WS stream URL), \docs/plugin-advanced.md\, \docs/agent-bus.md\ (WWV_ENGINE_URL examples), \docs/architecture/decisions/adr-0009-...md\ (\getEngineUrl\ resolver example)
- **Deploy configs / infra docs**: \deploy/cloud/docker-compose.yml\, \deploy/production/docker-compose.app.yml\, \deploy/INFRA-CHECKLIST.md\
- **GC bot charter**: \scripts/gc-scan.mjs\ desc + \.agents/rules/garbage-collection.md\ row (pattern \localhost:500\ unchanged)
- **Version**: \2.65.37\ → \2.65.38\ (patch, per fix-type commit)

## Out of scope (verified no change needed)

- \src/lib/data-query/service.ts\ already defaults to \'5000'\ on main
- Remaining \5001\ occurrences are geographic data only: coordinates in \public/*.geojson\ / \public/*.json\ / \src/core/data/countries.ts\ (lat \-11.875001\), OSM/Insecam IDs — not ports

## Verification (local)

- \pnpm exec tsc --noEmit\ — pass
- \pnpm lint\ — 0 errors (306 pre-existing warnings)
- \pnpm test\ — 135 files / 1364 tests pass (run with \--hookTimeout=60000\; the default 10s hook flaked once in \etter-auth.test.ts\ dynamic import under heavy machine load — passes standalone and under a realistic timeout; CI runs \itest run --coverage || true\)
- \pnpm build\ — not run locally (heavy); CI \uild\ job runs it (ci.yml), including prisma migrate diff + Docker local build