### PR TITLE
feat: wire Sentry/GlitchTip DSN into builds and env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,19 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_DATABASE_URL=
 
+# Sentry Error Monitoring via GlitchTip (REQUIRED for error monitoring)
+# NEXT_PUBLIC_SENTRY_DSN contains only the public key (safe to commit and to
+# hardcode as a Docker build arg in .github/workflows/docker-publish.yml).
+# Server/edge errors go straight to GlitchTip; browser errors are relayed
+# through /api/glitchtip-tunnel using the GLITCHTIP_* vars below.
+NEXT_PUBLIC_SENTRY_DSN=https://fe938b72990e47609929a94eeed1c6da@sentry.worldwideview.dev/2
+
+# GlitchTip relay credentials (server-side, required for the tunnel route)
+GLITCHTIP_SERVER_URL=https://sentry.worldwideview.dev
+GLITCHTIP_PROJECT_ID=2
+# Project secret: see internal CREDENTIALS.md (never commit the real value)
+GLITCHTIP_SECRET_KEY=<your-glitchtip-project-secret>
+
 # OpenSky Network — multi-account credential rotation
 # Comma-separated clientId:clientSecret pairs.
 # Example: OPENSKY_CREDENTIALS=acct1-id:acct1-secret,acct2-id:acct2-secret

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,6 +54,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_WWV_EDITION=${{ vars.NEXT_PUBLIC_WWV_EDITION || 'local' }}
+            NEXT_PUBLIC_SENTRY_DSN=https://fe938b72990e47609929a94eeed1c6da@sentry.worldwideview.dev/2
             NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
             NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
             NEXT_PUBLIC_BING_MAPS_KEY=${{ secrets.NEXT_PUBLIC_BING_MAPS_KEY }}
@@ -146,6 +147,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_WWV_EDITION=${{ vars.NEXT_PUBLIC_WWV_EDITION || 'local' }}
+            NEXT_PUBLIC_SENTRY_DSN=https://fe938b72990e47609929a94eeed1c6da@sentry.worldwideview.dev/2
             NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
             NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
             NEXT_PUBLIC_BING_MAPS_KEY=${{ secrets.NEXT_PUBLIC_BING_MAPS_KEY }}
@@ -238,6 +240,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_WWV_EDITION=cloud
+            NEXT_PUBLIC_SENTRY_DSN=https://fe938b72990e47609929a94eeed1c6da@sentry.worldwideview.dev/2
             NEXT_PUBLIC_WWV_TENANT_DOMAIN=.cloud-wwv.dev
             NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
             NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
@@ -402,6 +405,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_WWV_EDITION=demo
+            NEXT_PUBLIC_SENTRY_DSN=https://fe938b72990e47609929a94eeed1c6da@sentry.worldwideview.dev/2
             NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS=iranwarlive,satellite,gps-jamming
             NEXT_PUBLIC_CESIUM_ION_TOKEN=${{ secrets.NEXT_PUBLIC_CESIUM_ION_TOKEN }}
             NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.39",
+  "version": "2.65.40",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

The Sentry SDK is already fully wired (`src/sentry.{server,edge,client}.config.ts`, `src/app/api/glitchtip-tunnel/route.ts` relay client envelopes to the self-hosted GlitchTip at `https://sentry.worldwideview.dev`, project id 2). This PR makes error monitoring actually work in builds and documents the env contract:

1. **`docker-publish.yml`**: bake `NEXT_PUBLIC_SENTRY_DSN` as a build arg into all four image targets this workflow builds — `latest` (prod amd64), `prod arm64`, `cloud`, and `demo`. NEXT_PUBLIC_ vars are inlined at build time; the DSN carries only the public key so it is safe to hardcode alongside the other build args.
2. **`.env.example`**: document `NEXT_PUBLIC_SENTRY_DSN` (REQUIRED for error monitoring) plus the relay credentials `GLITCHTIP_SERVER_URL`, `GLITCHTIP_PROJECT_ID`, and `GLITCHTIP_SECRET_KEY` (placeholder only — real value lives in internal CREDENTIALS.md).
3. **`package.json`**: patch bump `2.65.39` → `2.65.40` (repo convention).

## Verification

- Workflow YAML parses (`yaml.safe_load`)
- DSN present in all 4 build jobs' build-args
- `pnpm exec tsc --noEmit` — pass
- `pnpm lint` — 0 errors (309 pre-existing warnings)
- `pnpm test` — 144 files / 1434 tests pass

Not merged; created for review.
