### PR TITLE
fix: declare NEXT_PUBLIC_SENTRY_DSN as Dockerfile build ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED
 ARG NEXT_PUBLIC_WWV_BUILD_ID
 ARG NEXT_PUBLIC_WWV_BUILD_AT
+ARG NEXT_PUBLIC_SENTRY_DSN
 
 # Run our pregenerate schema swap script and then generate Prisma client
 RUN NEXT_PUBLIC_WWV_EDITION=$NEXT_PUBLIC_WWV_EDITION pnpm run generate
@@ -75,6 +76,7 @@ RUN set +e ; { \
         if [ -n "$NEXT_PUBLIC_SUPABASE_URL" ]; then echo "NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL" ; fi ; \
         if [ -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY" ; fi ; \
         if [ -n "$NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS" ]; then echo "NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS=$NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS" ; fi ; \
+        if [ -n "$NEXT_PUBLIC_SENTRY_DSN" ]; then echo "NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN" ; fi ; \
     } > /app/.env.production.local
 
 # Run Next.js build with Webpack cache mounted

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.65.40",
+  "version": "2.65.41",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
Follow-up to #473: the workflow passes NEXT_PUBLIC_SENTRY_DSN as a build arg, but the Dockerfile never declared the ARG or wrote it to .env.production.local, so the browser bundles had no DSN. This declares the ARG and writes it like every other NEXT_PUBLIC_* var (verified the new demo image bundles had zero DSN references).