### PR TITLE
docs: repair stale path references in rule files (#419)

### DIFF
--- a/.agents/rules/data-engine-architecture.md
+++ b/.agents/rules/data-engine-architecture.md
@@ -30,7 +30,7 @@ In production, the `wwv-data-engine-v2` does NOT mount the local file system. In
 4. It then runs a single **workspace-aware `pnpm install --prod`**. This ensures all custom unbundled dependencies declared by the extracted plugins are downloaded directly into the container and properly linked together.
 ## 5. Namespace Separation Rule
 
-To prevent collisions and `404` or `ERR_MODULE_NOT_FOUND` errors, seeders **MUST NOT** exist simultaneously in both the community (`wwv-seeders`, cloned to a `local-seeders/community/` directory when developing locally; these are nested git clones created by worktree hooks, not tracked in the main repo) and private (`wwv-seeders-private`, cloned to `local-seeders/private/` the same way) repositories. Namespace overlaps will cause module resolution failures when the V2 engine attempts to load them. Private seeders have priority.
+To prevent collisions and `404` or `ERR_MODULE_NOT_FOUND` errors, seeders **MUST NOT** exist simultaneously in both the community (`wwv-seeders`, cloned manually to `local-seeders/community/` when developing locally; it is an independent nested git repo, gitignored from this one — the directory does not exist in a fresh clone until you create it) and private (`wwv-seeders-private`, cloned manually to `local-seeders/private/` the same way) repositories. Namespace overlaps will cause module resolution failures when the V2 engine attempts to load them. Private seeders have priority.
 
 ## 6. Plugin ID Contract — Single Source of Truth
 


### PR DESCRIPTION
Fixes the rule-file path references flagged in #419.

## Findings
The 2026-08-17 scan flagged 3 files / 7 refs. Verified against current `origin/main`:

- `.agents/rules/monorepo-workflow.md` and `.agents/rules/plugin-architecture.md` were removed from the public repo in #456 (untracked as internal-only), so 5 of the 7 flagged refs no longer exist to repair.
- `.agents/rules/data-engine-architecture.md` survived and contained one false claim: that `local-seeders/community/` and `local-seeders/private/` are "nested git clones created by worktree hooks". The hook config (`.config/wt.toml`) was untracked from the public repo in #456, so no in-repo mechanism creates these directories anymore.

## Repairs
| File | Dead claim | Fix |
|---|---|---|
| `.agents/rules/data-engine-architecture.md` | `local-seeders/community/` + `local-seeders/private/` "created by worktree hooks, not tracked in the main repo" | Reworded: clones are made manually; they are independent nested git repos, gitignored from this one, and do not exist in a fresh clone until created |

The `local-seeders/<tier>/packages/<pluginId>` layout itself is code-verified (`packages/wwv-cli/src/commands/create.ts` scaffolds it; `packages/wwv-cli/test/create.test.mjs` asserts it), so the paths were kept and only the false provenance claim was corrected.

## Verification
- Every path reference in the repaired file re-checked against `origin/main` with `git cat-file -e`: all exist or are accurately described as gitignored nested clones.
- `pnpm lint`: PASS (0 errors; 309 pre-existing warnings). Build does not cover `.agents/rules/` docs (Next.js app build), so a link/path spot-check report is provided instead.
- No semver bump: repo precedent (#444, #440) shows `docs:`-only commits do not bump `package.json`.
