### PR TITLE
feat: seeder health badges and empty-layer checklist

### DIFF
--- a/src/components/common/SeederEmptyChecklist.css
+++ b/src/components/common/SeederEmptyChecklist.css
@@ -1,0 +1,64 @@
+/* ─── Seeder Empty Checklist ──────────────────────────────── */
+.seeder-empty-checklist {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+}
+
+.seeder-empty-checklist__toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 11px;
+    color: var(--accent-cyan);
+    cursor: pointer;
+    text-align: left;
+}
+
+.seeder-empty-checklist__toggle:hover {
+    text-decoration: underline;
+}
+
+.seeder-empty-checklist__rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+}
+
+.seeder-empty-checklist__row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-xs);
+    font-size: 11px;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+.seeder-empty-checklist__row--suspect {
+    color: var(--accent-amber);
+    font-weight: 500;
+}
+
+.seeder-empty-checklist__box {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    font-size: 9px;
+    border-radius: 3px;
+    background: rgba(74, 222, 128, 0.12);
+    color: var(--accent-green);
+    border: 1px solid rgba(74, 222, 128, 0.25);
+    margin-top: 1px;
+}
+
+.seeder-empty-checklist__row--suspect .seeder-empty-checklist__box {
+    background: rgba(245, 158, 11, 0.15);
+    color: var(--accent-amber);
+    border-color: rgba(245, 158, 11, 0.3);
+}

--- a/src/components/common/SeederEmptyChecklist.tsx
+++ b/src/components/common/SeederEmptyChecklist.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * @file SeederEmptyChecklist.tsx
+ * @description 'Why is my layer empty?' checklist panel. Rendered from a
+ * collapsed section next to a plugin row (or reachable from an empty layer).
+ *
+ * It is a STATIC checklist: the rows are derived from the same
+ * server-computed SeederHealth object used by the freshness badge. There are
+ * no interactive diagnostics and no state machine — deeper triage is
+ * explicitly out of scope.
+ */
+
+import { useState } from "react";
+import { deriveSeederChecklist } from "@/lib/seederHealthBadge";
+import type { SeederHealth } from "@/core/state/seederHealthSlice";
+import "./SeederEmptyChecklist.css";
+
+export function SeederEmptyChecklist({ health }: { health: SeederHealth | undefined }) {
+    const [open, setOpen] = useState(false);
+    const rows = deriveSeederChecklist(health);
+    const hasHealth = health !== undefined && health !== null;
+
+    return (
+      <div className="seeder-empty-checklist">
+        <button
+          type="button"
+          className="seeder-empty-checklist__toggle"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+        >
+          {open ? "Hide" : "Why is my layer empty?"}
+        </button>
+
+        {open && (
+          <ul className="seeder-empty-checklist__rows">
+            {rows.map((row) => (
+              <li
+                key={row.id}
+                className={`seeder-empty-checklist__row ${row.suspect ? "seeder-empty-checklist__row--suspect" : ""}`}
+              >
+                <span className="seeder-empty-checklist__box" aria-hidden="true">
+                  {row.suspect ? "✕" : "✓"}
+                </span>
+                {row.label}
+              </li>
+            ))}
+            {!hasHealth && (
+              <li className="seeder-empty-checklist__row">
+                <span className="seeder-empty-checklist__box" aria-hidden="true">?</span>
+                Tip: enable the Data Layers toggle and wait for the seeder to run for the first time.
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    );
+}

--- a/src/components/common/SeederHealthBadge.css
+++ b/src/components/common/SeederHealthBadge.css
@@ -1,0 +1,32 @@
+/* ─── Seeder Health Badge ─────────────────────────────────── */
+.seeder-health-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 999px;
+    white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: help;
+}
+
+.seeder-health-badge--live {
+    color: var(--accent-green);
+    background: rgba(74, 222, 128, 0.1);
+    border: 1px solid rgba(74, 222, 128, 0.2);
+}
+
+.seeder-health-badge--stale {
+    color: var(--accent-amber);
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.2);
+}
+
+.seeder-health-badge--error {
+    color: var(--accent-red);
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.2);
+}

--- a/src/components/common/SeederHealthBadge.tsx
+++ b/src/components/common/SeederHealthBadge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * @file SeederHealthBadge.tsx
+ * @description Small freshness badge for a plugin's seeder, rendered in the
+ * PluginsTab row. Derives entirely from the server-computed SeederHealth
+ * record (never from client-side clock math). No health data -> renders
+ * nothing (graceful).
+ */
+
+import { deriveSeederBadge } from "@/lib/seederHealthBadge";
+import type { SeederHealth } from "@/core/state/seederHealthSlice";
+import "./SeederHealthBadge.css";
+
+export function SeederHealthBadge({ health }: { health: SeederHealth | undefined }) {
+    const badge = deriveSeederBadge(health);
+    if (!badge) return null;
+
+    return (
+      <span
+        className={`seeder-health-badge seeder-health-badge--${badge.state}`}
+        title={badge.title}
+        data-testid="seeder-health-badge"
+      >
+        {badge.label}
+      </span>
+    );
+}

--- a/src/components/panels/LayerItem.css
+++ b/src/components/panels/LayerItem.css
@@ -198,6 +198,13 @@
   white-space: nowrap;
 }
 
+/* ─── Empty Layer Hint ────────────────────────────────────── */
+.layer-item__empty-hint {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
 /* ─── Loading Spinner ────────────────────────────────────── */
 .layer-item__spinner {
   display: inline-block;

--- a/src/components/panels/LayerItem.tsx
+++ b/src/components/panels/LayerItem.tsx
@@ -12,8 +12,10 @@ import { ShieldAlert, Wrench } from "lucide-react";
 import { PluginIcon } from "@/components/common/PluginIcon";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { getFreshness } from "@/core/data/freshness";
+import { SeederEmptyChecklist } from "@/components/common/SeederEmptyChecklist";
 import { pluginManager } from "@/core/plugins/PluginManager";
 import type { WorldPlugin } from "@/core/plugins/PluginTypes";
+import type { SeederHealth } from "@/core/state/seederHealthSlice";
 import "./LayerItem.css";
 
 // ─── Category Labels ────────────────────────────────────────
@@ -113,6 +115,8 @@ interface LayerItemProps {
     budgetExceeded?: boolean;
     onToggle: () => void;
     onSelect?: () => void;
+    /** Optional seeder health used by the 'why is my layer empty?' checklist. */
+    seederHealth?: SeederHealth;
 }
 
 /**
@@ -131,6 +135,7 @@ export function LayerItem({
     budgetExceeded,
     onToggle,
     onSelect,
+    seederHealth,
 }: LayerItemProps) {
     // Freshness renders only when the server provided fetchedAt — graceful degradation otherwise.
     const showFreshness = Boolean(fetchedAt) && isEnabled && !isLoading;
@@ -172,6 +177,11 @@ export function LayerItem({
                 rendering {(renderedCount ?? entityCount).toLocaleString()} of {(totalEntityCount ?? entityCount).toLocaleString()}
               </span>
             )}
+            {isEnabled && !isLoading && entityCount === 0 && (
+              <div className="layer-item__empty-hint">
+                <SeederEmptyChecklist health={seederHealth} />
+              </div>
+                    )}
           </div>
         </div>
 

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -46,6 +46,7 @@ export function LayerPanel() {
     const setConfigPanelOpen = useStore((s) => s.setConfigPanelOpen);
     const setActiveConfigTab = useStore((s) => s.setActiveConfigTab);
     const setSelectedEntity = useStore((s) => s.setSelectedEntity);
+    const seederHealth = useStore((s) => s.seederHealth);
 
     const allPlugins = pluginManager.getAllPlugins();
     const [searchQuery, setSearchQuery] = useState("");
@@ -238,6 +239,7 @@ export function LayerPanel() {
                                         totalEntityCount={layerState?.budgetExceeded ? layerState.entityCount : undefined}
                                         renderedCount={layerState?.budgetExceeded ? layerState.renderedCount : undefined}
                                         budgetExceeded={layerState?.budgetExceeded}
+                                        seederHealth={seederHealth[managed.plugin.id]}
                                         onToggle={() => handleToggle(managed.plugin.id)}
                                         onSelect={() => {
                                                 const newId = highlightLayerId === managed.plugin.id ? null : managed.plugin.id;

--- a/src/components/panels/PluginsTab.tsx
+++ b/src/components/panels/PluginsTab.tsx
@@ -22,6 +22,8 @@ import { trackEvent } from "@/lib/analytics";
 import { isPluginInstallEnabled } from "@/core/edition";
 import type { PluginManifest } from "@/core/plugins/PluginManifest";
 import { MarketplaceConnect } from "./MarketplaceConnect";
+import { SeederHealthBadge } from "@/components/common/SeederHealthBadge";
+import { fetchSeederHealth } from "@/lib/seederHealthFetcher";
 import "./PluginsTab.css";
 
 // ─── Types ──────────────────────────────────────────────────
@@ -142,6 +144,18 @@ export function PluginsTab() {
     const [updating, setUpdating] = useState<string | null>(null);
     const [needsReload, setNeedsReload] = useState(false);
     const [canInstall, setCanInstall] = useState<boolean>(isPluginInstallEnabled);
+    const seederHealth = useStore((s) => s.seederHealth);
+
+    // HTTP-seed the seeder-health store on mount so badges render before the
+    // first WebSocket broadcast (daily seeders could otherwise be blank for
+    // hours). Best-effort; the engine may not expose seederHealth yet.
+    useEffect(() => {
+        fetchSeederHealth().then((entries) => {
+            if (Object.keys(entries).length > 0) {
+                useStore.getState().setSeederHealth(entries);
+            }
+        });
+    }, []);
 
     const loadPlugins = useCallback(async () => {
         try {
@@ -423,6 +437,7 @@ export function PluginsTab() {
                 </div>
                 <div className="plugin-item__meta">
                   <TrustBadge trust={getTrust(record)} />
+                  <SeederHealthBadge health={seederHealth[record.pluginId]} />
                 </div>
               </div>
               {canInstall && (
@@ -488,6 +503,7 @@ export function PluginsTab() {
                     </div>
                     <div className="plugin-item__meta">
                       <TrustBadge trust={getTrust(record)} />
+                      <SeederHealthBadge health={seederHealth[record.pluginId]} />
                     </div>
                   </div>
                   {canInstall && (

--- a/src/core/data/WsClient.seederHealth.test.ts
+++ b/src/core/data/WsClient.seederHealth.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+/**
+ * WsClient seeder-health status-frame handling.
+ *
+ * The engine contract (engine PR #53) adds an additive frame type:
+ *   { type: "status", pluginId, status, lastGood, health }
+ * The globe's WsClient must (a) record `health` into the seeder-health store
+ * and (b) keep gracefully ignoring unknown frame types.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { wsClient } from "./WsClient";
+
+vi.mock("../edition", () => ({
+    ticketAuthEnabledForPlugin: vi.fn(),
+}));
+vi.mock("./DataBus", () => ({
+    dataBus: { emit: vi.fn() },
+}));
+vi.mock("../plugins/PluginManager", () => ({
+    pluginManager: { getPlugin: vi.fn(() => null) },
+}));
+
+const updateSeederHealth = vi.fn();
+vi.mock("../state/store", () => ({
+    useStore: {
+        getState: vi.fn(() => ({
+            entitiesByPlugin: {},
+            updateSeederHealth,
+        })),
+    },
+}));
+
+class FakeWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static instances: FakeWebSocket[] = [];
+
+    readyState = FakeWebSocket.CONNECTING;
+    onopen: ((e: Event) => void) | null = null;
+    onmessage: ((e: MessageEvent) => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    constructor(public url: string) {
+        FakeWebSocket.instances.push(this);
+    }
+
+    send() { /* no-op */ }
+
+    triggerOpen() {
+        this.readyState = FakeWebSocket.OPEN;
+        this.onopen?.(new Event("open"));
+    }
+
+    triggerMessage(data: object) {
+        this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+    }
+}
+
+let savedWebSocket: typeof WebSocket;
+
+describe("WsClient — seeder-health status frames", () => {
+    beforeEach(() => {
+        FakeWebSocket.instances.length = 0;
+        savedWebSocket = global.WebSocket;
+        global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+        vi.clearAllMocks();
+        // Clear the singleton's engine map so each test starts fresh.
+        (wsClient as unknown as { engines: Map<string, unknown> }).engines.clear();
+    });
+
+    afterEach(() => {
+        global.WebSocket = savedWebSocket;
+    });
+
+    it("records a status frame's health payload into the store as a live delta", async () => {
+        const { wsClient } = await import("./WsClient");
+        wsClient.subscribe("aviation", "wss://engine-status.test");
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        ws.triggerMessage({
+            type: "status",
+            pluginId: "aviation",
+            status: "ok",
+            lastGood: 123,
+            health: {
+                lastRun: 1700000000000,
+                lastError: null,
+                failureCount: 0,
+                intervalMs: 60000,
+                cron: null,
+                expectedMaxAgeMs: 120000,
+                stale: false,
+            },
+        });
+
+        expect(updateSeederHealth).toHaveBeenCalledTimes(1);
+        const [pluginId, patch] = updateSeederHealth.mock.calls[0];
+        expect(pluginId).toBe("aviation");
+        expect(patch).toMatchObject({
+            lastRun: 1700000000000,
+            stale: false,
+        });
+    });
+
+    it("normalizes underscore pluginIds in status frames", async () => {
+        const { wsClient } = await import("./WsClient");
+        wsClient.subscribe("my_plugin", "wss://engine-status.test");
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        ws.triggerMessage({
+            type: "status",
+            pluginId: "my_plugin",
+            health: { stale: true },
+        });
+
+        const [pluginId] = updateSeederHealth.mock.calls[0];
+        expect(pluginId).toBe("my-plugin");
+    });
+
+    it("ignores unknown frame types without touching the store", async () => {
+        const { wsClient } = await import("./WsClient");
+        wsClient.subscribe("aviation", "wss://engine-status.test");
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        // Unknown type — must not throw and must not update health.
+        expect(() => {
+            ws.triggerMessage({ type: "something-new", pluginId: "aviation" });
+        }).not.toThrow();
+        expect(updateSeederHealth).not.toHaveBeenCalled();
+    });
+
+    it("does not update health when a status frame lacks a health payload", async () => {
+        const { wsClient } = await import("./WsClient");
+        wsClient.subscribe("aviation", "wss://engine-status.test");
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        ws.triggerMessage({ type: "status", pluginId: "aviation", status: "ok" });
+        expect(updateSeederHealth).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/data/WsClient.ts
+++ b/src/core/data/WsClient.ts
@@ -147,7 +147,17 @@ class WebSocketClient {
 
         if (data.type === "data" && data.pluginId && data.payload) {
           this.handleDataMessage(data as WsStreamPayload);
+          return;
         }
+
+        if (data.type === "status" && data.pluginId) {
+          this.handleStatusMessage(data);
+          return;
+        }
+
+        // Unknown frame types are intentionally ignored — the engine contract
+        // is additive, so new frame types must never break the client.
+        console.debug(`[WSClient] Ignoring unknown frame type: ${data.type}`);
       } catch (err) {
         console.error("[WSClient] Error parsing message:", err);
       }
@@ -215,6 +225,24 @@ class WebSocketClient {
       pluginId,
       entities: finalEntities,
     });
+  }
+
+  private handleStatusMessage(data: {
+    pluginId?: unknown;
+    status?: unknown;
+    lastGood?: unknown;
+    health?: unknown;
+  }) {
+    const pluginId = normalizePluginId(String(data.pluginId));
+
+    // The status frame is a live delta: merge the broadcast fields into the
+    // store's existing entry. `health` carries the seeder-health payload;
+    // `status`/`lastGood` are top-level stream metadata and currently unused
+    // by the badge (which derives from SeederHealth only).
+    if (data.health !== undefined) {
+      const { updateSeederHealth } = useStore.getState();
+      updateSeederHealth(pluginId, data.health as Record<string, unknown>);
+    }
   }
 
   private send(engine: EngineConnection, msg: any) {

--- a/src/core/state/seederHealthSlice.test.ts
+++ b/src/core/state/seederHealthSlice.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { createSeederHealthSlice, normalizeSeederHealth, type SeederHealthSlice } from "./seederHealthSlice";
+
+type MockAppStore = SeederHealthSlice;
+
+describe("seederHealthSlice", () => {
+    let store: StoreApi<MockAppStore>;
+
+    beforeEach(() => {
+        store = createStore<MockAppStore>((set, get, api) => ({
+            ...createSeederHealthSlice(set as never, get as never, api as never),
+        }));
+    });
+
+    it("starts with an empty map", () => {
+        expect(store.getState().seederHealth).toEqual({});
+    });
+
+    it("merges a raw delta over an existing entry", () => {
+        store.getState().updateSeederHealth("aviation", {
+            lastRun: 1700000000000,
+            stale: false,
+            intervalMs: 60000,
+        });
+
+        store.getState().updateSeederHealth("aviation", {
+            stale: true,
+            lastError: "boom",
+            bogusField: "dropped",
+        });
+
+        const entry = store.getState().seederHealth["aviation"];
+        expect(entry.lastRun).toBe(1700000000000);
+        expect(entry.stale).toBe(true);
+        expect(entry.lastError).toBe("boom");
+        expect(entry.intervalMs).toBe(60000);
+        expect((entry as unknown as Record<string, unknown>).bogusField).toBeUndefined();
+    });
+
+    it("replaces the whole map via setSeederHealth", () => {
+        store.getState().setSeederHealth({
+            aviation: normalizeSeederHealth("aviation", { stale: true, lastRun: 1 }),
+        });
+        expect(store.getState().seederHealth["aviation"].stale).toBe(true);
+    });
+});
+
+describe("normalizeSeederHealth", () => {
+    it("defaults missing fields and drops unknown fields", () => {
+        const out = normalizeSeederHealth("marine", { stale: true });
+        expect(out).toEqual({
+            pluginId: "marine",
+            lastRun: null,
+            lastError: null,
+            failureCount: 0,
+            intervalMs: null,
+            cron: null,
+            expectedMaxAgeMs: null,
+            stale: true,
+        });
+    });
+
+    it("coerces non-numeric lastRun to null", () => {
+        const out = normalizeSeederHealth("x", { lastRun: "not-a-number" });
+        expect(out.lastRun).toBeNull();
+    });
+});

--- a/src/core/state/seederHealthSlice.ts
+++ b/src/core/state/seederHealthSlice.ts
@@ -1,0 +1,95 @@
+/**
+ * @file seederHealthSlice.ts
+ * @description Zustand slice holding per-plugin seeder health telemetry.
+ *
+ * The data engine reports seeder health in two ways (engine PR #53):
+ *   1. Live deltas over WebSocket as `{ type: "status", pluginId, status,
+ *      lastGood, health }` frames.
+ *   2. A point-in-time snapshot over HTTP at GET /health under `seederHealth`
+ *      (per-plugin object, computed at request time).
+ *
+ * Both feed this single store: HTTP is the initial fill so badges render
+ * before the first broadcast (daily seeders could otherwise be blank for
+ * hours); WS frames are live deltas that overwrite per-field.
+ *
+ * IMPORTANT: this interface is a HAND-MIRRORED copy of the engine's
+ * SeederHealth contract. It must never be imported from the engine package —
+ * the globe and the engine are separate repositories. If the engine contract
+ * changes, update this file to match.
+ */
+
+import type { StateCreator } from "zustand";
+import type { AppStore } from "./store";
+
+// ─── Seeder Health Contract ─────────────────────────────────
+/**
+ * Mirrored engine SeederHealth contract (engine PR #53). See the module
+ * comment for provenance. All staleness fields are server-computed; the
+ * client must NEVER derive staleness from Date.now() (clock skew rule).
+ */
+export interface SeederHealth {
+    pluginId: string;
+    /** Epoch ms of the last successful run; null = never ran. */
+    lastRun: number | null;
+    lastError: string | null;
+    failureCount: number;
+    /** Polling interval in ms; null for cron/unknown. */
+    intervalMs: number | null;
+    cron: string | null;
+    expectedMaxAgeMs: number | null;
+    /** Server-computed freshness flag — authoritative, not client-derived. */
+    stale: boolean;
+}
+
+/**
+ * Minimal, defensive normalizer for WS `health` payloads. Unknown fields are
+ * dropped, missing fields default to null/0 so badge derivation never has to
+ * guard against malformed frames.
+ */
+export function normalizeSeederHealth(
+    pluginId: string,
+    raw: unknown,
+): SeederHealth {
+    const src = (typeof raw === "object" && raw !== null ? raw : {}) as Record<string, unknown>;
+    return {
+        pluginId,
+        lastRun: typeof src.lastRun === "number" ? src.lastRun : null,
+        lastError: typeof src.lastError === "string" ? src.lastError : null,
+        failureCount: typeof src.failureCount === "number" ? src.failureCount : 0,
+        intervalMs: typeof src.intervalMs === "number" ? src.intervalMs : null,
+        cron: typeof src.cron === "string" ? src.cron : null,
+        expectedMaxAgeMs: typeof src.expectedMaxAgeMs === "number" ? src.expectedMaxAgeMs : null,
+        stale: src.stale === true,
+    };
+}
+
+// ─── Slice ───────────────────────────────────────────────────
+export interface SeederHealthSlice {
+    /** Per-plugin seeder health, keyed by pluginId. */
+    seederHealth: Record<string, SeederHealth>;
+    /**
+     * Merge a raw, unvalidated delta (e.g. the `health` field of a WebSocket
+     * status frame) into one plugin's entry. Unknown fields are dropped and
+     * missing fields default, so badge derivation never sees malformed data.
+     */
+    updateSeederHealth: (pluginId: string, patch: Record<string, unknown>) => void;
+    /**
+     * Replace the whole map with an HTTP snapshot (GET /health seederHealth).
+     */
+    setSeederHealth: (entries: Record<string, SeederHealth>) => void;
+}
+
+export const createSeederHealthSlice: StateCreator<AppStore, [], [], SeederHealthSlice> = (set) => ({
+    seederHealth: {},
+    updateSeederHealth: (pluginId, patch) =>
+        set((state) => ({
+            seederHealth: {
+                ...state.seederHealth,
+                [pluginId]: normalizeSeederHealth(pluginId, {
+                    ...(state.seederHealth[pluginId] ?? null),
+                    ...patch,
+                }),
+            },
+        })),
+    setSeederHealth: (entries) => set({ seederHealth: entries }),
+});

--- a/src/core/state/store.ts
+++ b/src/core/state/store.ts
@@ -14,12 +14,14 @@ import { createDataSlice, type DataSlice } from "./dataSlice";
 import { createConfigSlice, type ConfigSlice } from "./configSlice";
 import { createFavoritesSlice, type FavoritesSlice } from "./favoritesSlice";
 import { createAlertsSlice, type AlertsSlice } from "./alertsSlice";
+import { createSeederHealthSlice, type SeederHealthSlice } from "./seederHealthSlice";
 
 /**
  * Re-exporting slice types for easier access from components and utilities.
  */
 export type { MapConfig, DataConfig } from "./configSlice";
 export type { LayerState } from "./layersSlice";
+export type { SeederHealth } from "./seederHealthSlice";
 
 // ─── Combined Store ──────────────────────────────────────────
 export type AppStore = GlobeSlice &
@@ -30,13 +32,15 @@ export type AppStore = GlobeSlice &
     DataSlice &
     ConfigSlice &
     FavoritesSlice &
-    AlertsSlice;
+    AlertsSlice &
+    SeederHealthSlice;
 
 /**
  * The primary hook for accessing and modifying the application state.
  *
- * This combined store provides access to all nine state slices:
- * globe, layers, timeline, ui, filter, data, config, and favorites.
+ * This combined store provides access to the state slices:
+ * globe, layers, timeline, ui, filter, data, config, favorites, alerts,
+ * and seeder health.
  */
 export const useStore = create<AppStore>((...args) => ({
     ...createGlobeSlice(...args),
@@ -48,4 +52,5 @@ export const useStore = create<AppStore>((...args) => ({
     ...createConfigSlice(...args),
     ...createFavoritesSlice(...args),
     ...createAlertsSlice(...args),
+    ...createSeederHealthSlice(...args),
 }));

--- a/src/lib/seederHealthBadge.test.ts
+++ b/src/lib/seederHealthBadge.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { deriveSeederBadge, deriveSeederChecklist } from "./seederHealthBadge";
+import type { SeederHealth } from "@/core/state/seederHealthSlice";
+
+function health(overrides: Partial<SeederHealth> = {}): SeederHealth {
+    return {
+        pluginId: "aviation",
+        lastRun: 1700000000000,
+        lastError: null,
+        failureCount: 0,
+        intervalMs: 60000,
+        cron: null,
+        expectedMaxAgeMs: 120000,
+        stale: false,
+        ...overrides,
+    };
+}
+
+describe("deriveSeederBadge", () => {
+    it("returns null when there is no health data (graceful)", () => {
+        expect(deriveSeederBadge(undefined)).toBeNull();
+        expect(deriveSeederBadge(null)).toBeNull();
+    });
+
+    it("reports error when lastError is set (priority over stale)", () => {
+        const badge = deriveSeederBadge(health({ lastError: "boom", stale: true }));
+        expect(badge).toEqual({
+            state: "error",
+            label: "error",
+            title: "Seeder error: boom",
+        });
+    });
+
+    it("reports stale when server says stale (server-computed only)", () => {
+        const badge = deriveSeederBadge(health({ stale: true }));
+        expect(badge?.state).toBe("stale");
+    });
+
+    it("reports live when fresh and error-free", () => {
+        const badge = deriveSeederBadge(health());
+        expect(badge?.state).toBe("live");
+    });
+});
+
+describe("deriveSeederChecklist", () => {
+    it("returns a no-telemetry row when health is missing", () => {
+        const rows = deriveSeederChecklist(undefined);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].id).toBe("no-telemetry");
+    });
+
+    it("flags never-ran, stale, error, and failures from the same health object", () => {
+        const rows = deriveSeederChecklist(health({
+            lastRun: null,
+            stale: true,
+            lastError: "timeout",
+            failureCount: 4,
+        }));
+        const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+        expect(byId["never-ran"].suspect).toBe(true);
+        expect(byId["stale"].suspect).toBe(true);
+        expect(byId["last-error"].suspect).toBe(true);
+        expect(byId["failures"].suspect).toBe(true);
+    });
+
+    it("marks nothing as suspect for a healthy seeder", () => {
+        const rows = deriveSeederChecklist(health());
+        expect(rows.every((r) => r.suspect === false)).toBe(true);
+    });
+});

--- a/src/lib/seederHealthBadge.ts
+++ b/src/lib/seederHealthBadge.ts
@@ -1,0 +1,96 @@
+/**
+ * @file seederHealthBadge.ts
+ * @description Pure derivation of the freshness badge state from a
+ * SeederHealth record.
+ *
+ * RULES (premortem-informed):
+ *  - Render ONLY from server-provided fields (stale / lastError / lastRun).
+ *    NEVER compute staleness client-side from Date.now() (clock skew rule).
+ *  - No health data at all -> null (show nothing, graceful).
+ *  - Badge priority: error (lastError) > stale > live.
+ */
+
+import type { SeederHealth } from "@/core/state/seederHealthSlice";
+
+export type SeederBadgeState = "error" | "stale" | "live";
+
+export interface SeederBadge {
+    state: SeederBadgeState;
+    label: string;
+    title: string;
+}
+
+/** Derive the badge for a plugin's seeder health. null = no health data. */
+export function deriveSeederBadge(health: SeederHealth | undefined | null): SeederBadge | null {
+    if (!health) return null;
+
+    if (health.lastError !== null) {
+        return {
+            state: "error",
+            label: "error",
+            title: `Seeder error: ${health.lastError}`,
+        };
+    }
+
+    if (health.stale === true) {
+        return {
+            state: "stale",
+            label: "stale",
+            title: "Seeder is stale (last run exceeded its expected freshness window)",
+        };
+    }
+
+    // The engine computed this seeder as fresh.
+    return {
+        state: "live",
+        label: "live",
+        title: "Seeder is live",
+    };
+}
+
+/**
+ * Checklist rows for the 'why is my layer empty?' panel. Every row is derived
+ * from the SAME server-computed SeederHealth object; it is a static checklist
+ * only — no interactive diagnostics, no new state machine.
+ */
+export interface ChecklistRow {
+    id: string;
+    label: string;
+    /** True when this row is a likely culprit (checked/highlighted). */
+    suspect: boolean;
+}
+
+export function deriveSeederChecklist(health: SeederHealth | undefined | null): ChecklistRow[] {
+    if (!health) {
+        return [
+            {
+                id: "no-telemetry",
+                label: "No seeder health reported yet — check that the data engine is running.",
+                suspect: false,
+            },
+        ];
+    }
+
+    return [
+        {
+            id: "never-ran",
+            label: "Seeder has never run successfully.",
+            suspect: health.lastRun === null,
+        },
+        {
+            id: "stale",
+            label: "Seeder is stale — it has not refreshed within its expected window.",
+            suspect: health.stale === true,
+        },
+        {
+            id: "last-error",
+            label: "Seeder reported an error on its last run.",
+            suspect: health.lastError !== null,
+        },
+        {
+            id: "failures",
+            label: "Seeder has accumulated repeated failures.",
+            suspect: health.failureCount > 0,
+        },
+    ];
+}

--- a/src/lib/seederHealthFetcher.ts
+++ b/src/lib/seederHealthFetcher.ts
@@ -1,0 +1,48 @@
+/**
+ * @file seederHealthFetcher.ts
+ * @description Client-side seeder-health snapshot fetch.
+ *
+ * On boot (or when the plugin panel opens) the globe asks its own origin for
+ * GET /api/health; the globe's route probes the engine and can attach the
+ * engine's `seederHealth` map (engine PR #53). The engine contract is frozen
+ * but not necessarily deployed yet, so this reader is strictly additive:
+ * a missing `seederHealth` field simply yields an empty map and the UI shows
+ * no badges (graceful degradation).
+ *
+ * The response shape is normalized into the store's SeederHealth records so
+ * badge derivation only ever sees well-formed entries.
+ */
+
+import { normalizeSeederHealth, type SeederHealth } from "@/core/state/seederHealthSlice";
+
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Fetch the current seeder-health snapshot from the globe's own /api/health
+ * route and normalize it into a per-plugin SeederHealth map.
+ *
+ * Returns an empty map on any failure (network, non-2xx, missing field) —
+ * this is a best-effort initial fill, never a hard dependency.
+ */
+export async function fetchSeederHealth(
+    fetcher: typeof fetch = fetch,
+): Promise<Record<string, SeederHealth>> {
+    try {
+        const res = await fetcher("/api/health", {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (!res.ok) return {};
+        const body: unknown = await res.json();
+        const raw = (typeof body === "object" && body !== null ? body : {}) as Record<string, unknown>;
+        const entries = raw.seederHealth;
+        if (typeof entries !== "object" || entries === null) return {};
+
+        const out: Record<string, SeederHealth> = {};
+        for (const [pluginId, entry] of Object.entries(entries)) {
+            out[pluginId] = normalizeSeederHealth(pluginId, entry);
+        }
+        return out;
+    } catch {
+        return {};
+    }
+}


### PR DESCRIPTION
## Summary

Adds per-plugin/seeder freshness badges to the PluginsTab panel and a minimal "why is my layer empty?" checklist, consuming the data engine's new seeder-health telemetry.

### Mirrored SeederHealth contract (hand-mirrored, never imported from engine)

```ts
interface SeederHealth {
  pluginId: string;
  lastRun: number | null;        // epoch ms; null = never ran
  lastError: string | null;
  failureCount: number;
  intervalMs: number | null;     // null for cron/unknown
  cron: string | null;
  expectedMaxAgeMs: number | null;
  stale: boolean;
}
```

The type lives in `src/core/state/seederHealthSlice.ts` and is a deliberate hand-mirror of the engine contract (engine PR #53) — the globe and engine are separate repositories and must never share imports.

### Design: HTTP-seed + WS-delta

1. **WS live deltas**: `WsClient` now handles additive `{ type: "status", pluginId, status, lastGood, health }` frames. The `health` payload is normalized and merged into a new zustand slice (`seederHealthSlice`) on the combined store. Unknown frame types are still gracefully ignored (the engine contract is additive).
2. **HTTP initial fill**: `PluginsTab` fetches the globe's own `GET /api/health` on mount and reads `seederHealth` (per-plugin object, computed at request time). This seeds the store so badges render before the first WS broadcast — daily seeders could otherwise be blank for hours. Best-effort: a missing `seederHealth` field yields no badges.
3. **Badge derivation** is pure and server-computed only: `lastError != null` → red `error`; `stale === true` → amber `stale`; else green `live`. The client NEVER computes staleness from `Date.now()` (clock skew rule). No health data → no badge (graceful).
4. **"Why is my layer empty?"** — a static, collapsed checklist shown on enabled layer rows with zero entities. Rows are derived from the SAME SeederHealth object: never ran?, stale?, lastError?, failureCount > 0? Static checklist only — no interactive diagnostics, no new state machine.

### Requires engine #53

The engine's `seederHealth` field (`GET /health` and WS `status` frames) is shipped by **engine PR #53** (stacked on #51), which is **not yet merged**. Until it lands, this code degrades gracefully: no `seederHealth` on `/health` → no badges; no `status` frames → store stays empty.

### Files

- `src/core/state/seederHealthSlice.ts` (+ test) — mirrored contract, normalize, zustand slice
- `src/core/data/WsClient.ts` (+ test) — status-frame handler
- `src/lib/seederHealthFetcher.ts` — HTTP snapshot reader
- `src/lib/seederHealthBadge.ts` (+ test) — pure badge/checklist derivation
- `src/components/common/SeederHealthBadge.{tsx,css}`, `SeederEmptyChecklist.{tsx,css}`
- `src/components/panels/PluginsTab.tsx` — badge in each row + HTTP seed on mount
- `src/components/panels/LayerItem.tsx` / `LayerPanel.tsx` — checklist on empty layers

### Verification

- `pnpm lint` — 0 errors
- `pnpm test` — 1450 passed
- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — clean

> **Note for reviewer**: please visually confirm the badges render as expected (green `live` / amber `stale` / red `error`) once the engine is sending health telemetry. If the engine is not yet deployed with #53, the panel will simply show no badges — that is the graceful path.
