### PR TITLE
fix: wait for PostgreSQL readiness before running prisma migrate deploy

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,98 @@ if [ -z "$DATABASE_URL" ]; then
   fi
 fi
 
+# ─── PostgreSQL readiness wait ───────────────────────────────
+# Wait for Postgres to accept connections before running `prisma
+# migrate deploy`. The shipped compose files gate the app with
+# depends_on: condition: service_healthy, but an operator compose
+# without that gating can crash-loop: migrate deploy fails while
+# Postgres is still starting, the entrypoint hard-exits, and
+# restart: unless-stopped retries forever.
+#
+# The runner image (node:26-alpine) has no pg_isready, so the
+# probe is a minimal Node Postgres handshake (SSLRequest +
+# StartupMessage) against the host/port parsed from DATABASE_URL.
+# Node is guaranteed to be present in the image.
+#
+# Tune with DB_WAIT_ATTEMPTS (default 30) and DB_WAIT_DELAY
+# (default 2s): roughly a 60s wait budget before a hard exit
+# (each probe attempt also has a 5s socket timeout).
+if [ -n "$DATABASE_URL" ]; then
+  DB_WAIT_ATTEMPTS="${DB_WAIT_ATTEMPTS:-30}"
+  DB_WAIT_DELAY="${DB_WAIT_DELAY:-2}"
+
+  DB_READY_PROBE='
+const net = require("net");
+const url = process.env.DATABASE_URL || "";
+const m = url.match(/^(?:[a-zA-Z0-9+]+):\/\/(?:([^:@/]*)(?::[^@/]*)?@)?(\[[^\]]*\]|[^:/?#]+)(?::(\d+))?/);
+if (!m) {
+  console.error("[entrypoint] Cannot parse DATABASE_URL for readiness probe");
+  process.exit(1);
+}
+const user = m[1] || "";
+const host = m[2].replace(/^\[|\]$/g, "");
+const port = m[3] ? Number(m[3]) : 5432;
+
+const sock = net.connect({ host, port });
+const fail = () => { sock.destroy(); process.exit(1); };
+sock.setTimeout(5000, fail);
+sock.once("error", fail);
+sock.once("end", fail);
+
+sock.once("connect", () => {
+  // Postgres only speaks after the client sends SSLRequest, so write
+  // it first. The server answers with one byte: 0x53 ("S", SSL
+  // required) or 0x4e ("N", plaintext ok). Either proves the
+  // Postgres listener is up.
+  const ssl = Buffer.alloc(8);
+  ssl.writeInt32BE(8, 0);
+  ssl.writeInt32BE(80877103, 4); // SSLRequest code
+  sock.write(ssl);
+  sock.once("data", (first) => {
+    if (first[0] === 0x53) { sock.destroy(); process.exit(0); }
+    if (first[0] !== 0x4e) { fail(); return; }
+    // No user in the URL: the listener is up, let prisma do the rest.
+    if (!user) { sock.destroy(); process.exit(0); }
+    // StartupMessage (protocol 3.0): key\0value\0 pairs + final \0 terminator.
+    // Length counts the whole packet including itself: 4 (length) + 4
+    // (protocol version) + params. Only the user is sent; no password
+    // (any AuthenticationRequest proves Postgres accepted the startup).
+    const userBuf = Buffer.from("user\u0000" + user + "\u0000\u0000", "utf8");
+    const total = 8 + userBuf.length;
+    const msg = Buffer.alloc(total);
+    msg.writeInt32BE(total, 0);
+    msg.writeInt32BE(196608, 4); // protocol 3.0
+    userBuf.copy(msg, 8);
+    sock.write(msg);
+    sock.once("data", (second) => {
+      // 0x52 = AuthenticationRequest, 0x4b = BackendKeyData (trust):
+      // Postgres accepted the connection. 0x45 = ErrorResponse, e.g.
+      // "the database system is starting up" (crash recovery).
+      if (second[0] === 0x52 || second[0] === 0x4b) { sock.destroy(); process.exit(0); }
+      fail();
+    });
+  });
+});
+'
+
+  db_ready() {
+    node -e "$DB_READY_PROBE"
+  }
+
+  attempt=0
+  while ! db_ready; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge "$DB_WAIT_ATTEMPTS" ]; then
+      echo "[entrypoint] PostgreSQL did not become ready after ${DB_WAIT_ATTEMPTS} attempts (${DB_WAIT_DELAY}s apart)." >&2
+      echo "[entrypoint] Check that the database is reachable at: $DATABASE_URL" >&2
+      exit 1
+    fi
+    echo "[entrypoint] PostgreSQL not ready yet (attempt ${attempt}/${DB_WAIT_ATTEMPTS}), retrying in ${DB_WAIT_DELAY}s..."
+    sleep "$DB_WAIT_DELAY"
+  done
+  echo "[entrypoint] PostgreSQL is accepting connections."
+fi
+
 echo "[entrypoint] Running database migrations..."
 set +e
 MIGRATE_OUT=$(prisma migrate deploy 2>&1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.67.0",
+"version": "2.67.0"
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-"version": "2.67.0"
+  "version": "2.67.0",
   "private": true,
   "license": "EL-2.0",
   "type": "module",


### PR DESCRIPTION
## What

Adds a PostgreSQL readiness wait/retry loop to `docker-entrypoint.sh` **before** `prisma migrate deploy` runs. Prevents container crash-loops when Postgres is not yet accepting connections (e.g. an operator compose without `depends_on: condition: service_healthy` gating).

## Why

The shipped compose files gate the app with `depends_on: condition: service_healthy`, but an operator compose without that gating can crash-loop: `prisma migrate deploy` fails while Postgres is still starting, the entrypoint hard-exits, and `restart: unless-stopped` retries forever. The existing P3005 auto-baseline logic is left intact.

## How it works

- **Probe**: the runner image (`node:26-alpine`) has no `pg_isready` (no postgresql-client), so the probe is a minimal Node raw-socket Postgres handshake: SSLRequest, then StartupMessage (user only, no password). Any `AuthenticationRequest` (`R`) or `BackendKeyData` (`K`) reply proves Postgres accepted the startup; SSL-required (`S`) also counts as ready. Node is guaranteed present in the image.
- **Retries**: `DB_WAIT_ATTEMPTS` (default 30) attempts, `DB_WAIT_DELAY` (default 2s) between attempts (~60s budget; each probe attempt also has a 5s socket timeout).
- **Logging**: clear `[entrypoint]` log lines on each retry and on success.
- **Failure**: hard `exit 1` with a message if the DB never becomes ready.
- **POSIX sh** compatible; no external deps beyond the image's existing Node.

## Verification

- `bash -n docker-entrypoint.sh` — PASS
- `sh -n` on the extracted wait block — PASS
- Functional tests (local): dead port -> bounded retries then hard exit 1 (PASS); protocol-correct mock PG -> ready on first try (PASS); delayed-start mock PG -> retries then proceeds (PASS); real local Postgres 16 (port 5433) -> ready (PASS)

**docker verification: needs manual run** — a real `docker compose up` with a fresh Postgres (no healthcheck gating) must be run to confirm end-to-end behavior in the container.