### PR TITLE
fix: resolve edition at runtime via WWV_EDITION env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,17 @@ PROXY_HOST_ALLOWLIST=*
 NEXT_PUBLIC_DEMO_DEFAULT_PLUGINS=
 
 # Edition: "local" | "cloud" | "demo"
+#
+# Runtime edition (server-side, recommended for self-hosters).
+# Set this in a runtime .env on the prebuilt image to switch editions
+# WITHOUT rebuilding — the app resolves it at request time.
+# When unset/empty, the app falls back to the NEXT_PUBLIC_WWV_EDITION
+# build-time bake, then to "local".
+# WWV_EDITION=local
+
+# Edition bake (build-time only, for docker-publish :latest/:cloud/:demo).
+# Inlined into client bundles by next build; ignored at runtime when
+# WWV_EDITION above is set.
 NEXT_PUBLIC_WWV_EDITION=local
 
 # URL Overrides (defaults to production)

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,14 @@ ARG NEXT_PUBLIC_WWV_BUILD_ID
 ARG NEXT_PUBLIC_WWV_BUILD_AT
 ARG NEXT_PUBLIC_SENTRY_DSN
 
+# Runtime edition override. Defaults to the build-time bake so a container
+# started without WWV_EDITION behaves exactly like the image it was built
+# from. Operators can override it at runtime via a .env (docker compose
+# pass-through) — the app resolves WWV_EDITION at request time and falls
+# back to the NEXT_PUBLIC_ bake when it is unset.
+ARG WWV_EDITION=${NEXT_PUBLIC_WWV_EDITION}
+ENV WWV_EDITION=${WWV_EDITION}
+
 # Run our pregenerate schema swap script and then generate Prisma client
 RUN NEXT_PUBLIC_WWV_EDITION=$NEXT_PUBLIC_WWV_EDITION pnpm run generate
 
@@ -97,6 +105,10 @@ ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 ENV NODE_OPTIONS=--max-old-space-size=768
 ENV PORT=3000
+# Runtime edition — resolved by the app at request time. Set WWV_EDITION
+# at container runtime (e.g. a .env passed to docker compose) to switch
+# editions on the prebuilt image without rebuilding. When unset, the app
+# falls back to the NEXT_PUBLIC_WWV_EDITION build-time bake, then 'local'.
 # DATABASE_URL must be provided via environment variable (no default)
 # Example: postgresql://user:pass@host:5432/dbname
 ENV AUTH_TRUST_HOST=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       - "ENCRYPTION_MASTER_KEY=${ENCRYPTION_MASTER_KEY:-local_dev_encryption_key_change_in_prod}"
       - "WWV_DEMO_ADMIN_SECRET=${WWV_DEMO_ADMIN_SECRET:-}"
       - "WWV_BRIDGE_TOKEN=${WWV_BRIDGE_TOKEN:-}"
+      # Runtime edition override — resolved by the app at request time.
+      # Unset/empty falls back to the NEXT_PUBLIC_WWV_EDITION build-time bake.
+      - "WWV_EDITION=${WWV_EDITION:-}"
       - "DATABASE_URL=postgresql://postgres:postgres@db:5432/worldwideview?schema=public"
     depends_on:
       db:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,7 +160,7 @@ When multiple entities share a screen-space cluster (busy ports, busy airspaces)
 
 ## Edition System
 
-WorldWideView ships in three editions, controlled by the `NEXT_PUBLIC_WWV_EDITION` environment variable. Feature flags are derived from this in [`src/core/edition.ts`](../src/core/edition.ts).
+WorldWideView ships in three editions, controlled at runtime by the `WWV_EDITION` environment variable (server-side), with `NEXT_PUBLIC_WWV_EDITION` kept as the build-time bake for the docker-publish images and client bundles. Precedence: `WWV_EDITION` → `NEXT_PUBLIC_WWV_EDITION` → `local`. Feature flags are derived from this in [`src/core/edition.ts`](../src/core/edition.ts).
 
 | Edition | Auth | Use case |
 |---|---|---|

--- a/docs/mcp-quickstart.md
+++ b/docs/mcp-quickstart.md
@@ -30,7 +30,7 @@ pnpm setup      # generates AUTH_SECRET and your local .env (required for API ke
 
 `pnpm setup` writes a random `AUTH_SECRET` into `.env`. In the local edition that same
 secret signs your MCP API keys, so this step is required before key generation will work.
-The edition defaults to `local` (`NEXT_PUBLIC_WWV_EDITION=local`).
+The edition defaults to `local` (`WWV_EDITION=local`, with fallback to the `NEXT_PUBLIC_WWV_EDITION` build-time bake).
 
 ---
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -21,7 +21,7 @@ The core value proposition of WorldWideView is mapping diverse, decoupled intell
 - **Styling:** Vanilla CSS (no Tailwind) — `src/app/globals.css` and `src/styles/theme-tokens.css`
 
 ## Platform Support
-Built as a highly portable Next.js container, it supports multiple deployment profiles controlled by `NEXT_PUBLIC_WWV_EDITION` (default: `local`).
+Built as a highly portable Next.js container, it supports multiple deployment profiles. The edition is resolved at runtime from `WWV_EDITION` (falls back to the `NEXT_PUBLIC_WWV_EDITION` build-time bake, then `local`), so self-hosters can switch editions on a prebuilt image via a runtime .env without rebuilding.
 - **Local (`local`)**: Self-hosted, full features, auth enabled.
 - **Cloud (`cloud`)**: Managed cloud instance, full features.
 - **Demo (`demo`)**: Public demo, auth disabled, optional admin via `WWV_DEMO_ADMIN_SECRET`.

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - "BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-default_secret_for_local_dev}"
       - "WWV_DEMO_ADMIN_SECRET=${WWV_DEMO_ADMIN_SECRET:-}"
       - "WWV_BRIDGE_TOKEN=${WWV_BRIDGE_TOKEN:-}"
+      # Runtime edition override — resolved by the app at request time.
+      # Unset/empty falls back to the NEXT_PUBLIC_WWV_EDITION build-time bake
+      # (the :latest image is built with the production bake).
+      - "WWV_EDITION=${WWV_EDITION:-}"
       - "DATABASE_URL=postgresql://postgres:postgres@db:5432/worldwideview?schema=public"
       - "REDIS_URL=redis://wwv-redis:6379"
     depends_on:

--- a/src/app/api/build/route.ts
+++ b/src/app/api/build/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
+import { getEdition } from "@/core/edition";
 
 /**
  * GET /api/build
@@ -36,7 +37,7 @@ export async function GET() {
         public_flags: {
             agent_bus_enabled:
                 process.env.NEXT_PUBLIC_WWV_AGENT_BUS_ENABLED === "true",
-            edition: process.env.NEXT_PUBLIC_WWV_EDITION ?? null,
+            edition: getEdition(),
         },
     });
 }

--- a/src/app/api/globe/commands/route.ts
+++ b/src/app/api/globe/commands/route.ts
@@ -18,7 +18,7 @@ import { getServerSession } from "@/lib/ba-session";
 import { authenticateApiKey } from "@/lib/apiKeyAuth";
 import { drainGlobeCommands } from "@/lib/globeCommandQueue";
 import { globeCommandsLimiter, getClientIp } from "@/lib/rateLimiters";
-import { resolveEdition } from "@/core/edition";
+import { getEdition } from "@/core/edition";
 
 const SESSION_ID_RE = /^[0-9a-f-]{36}$/i;
 
@@ -26,7 +26,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     const limited = globeCommandsLimiter.check(getClientIp(request));
     if (limited) return limited as NextResponse;
 
-    const currentEdition = resolveEdition(process.env.NEXT_PUBLIC_WWV_EDITION);
+    const currentEdition = getEdition();
     if (currentEdition === "demo") {
         return NextResponse.json({ error: "Demo mode" }, { status: 403 });
     }

--- a/src/app/api/globe/commands/stream/route.ts
+++ b/src/app/api/globe/commands/stream/route.ts
@@ -22,7 +22,7 @@ import { getServerSession } from "@/lib/ba-session";
 import { authenticateApiKey } from "@/lib/apiKeyAuth";
 import { drainGlobeCommands } from "@/lib/globeCommandQueue";
 import { globeCommandsStreamLimiter, getClientIp } from "@/lib/rateLimiters";
-import { resolveEdition } from "@/core/edition";
+import { getEdition } from "@/core/edition";
 
 const SESSION_ID_RE = /^[0-9a-f-]{36}$/i;
 const POLL_INTERVAL_MS = 200;
@@ -46,7 +46,7 @@ export async function GET(request: Request): Promise<Response> {
     if (limited) return limited as Response;
 
     // Gate 2: demo edition -- read env at request time so vi.stubEnv works in tests
-    const currentEdition = resolveEdition(process.env.NEXT_PUBLIC_WWV_EDITION);
+    const currentEdition = getEdition();
     if (currentEdition === "demo") {
         return NextResponse.json({ error: "Demo mode" }, { status: 403 }) as Response;
     }

--- a/src/app/api/v1/entities/region/route.ts
+++ b/src/app/api/v1/entities/region/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "@/lib/ba-session";
 import { authenticateApiKey } from "@/lib/apiKeyAuth";
 import { getEntitiesInRegion } from "@/lib/data-query/service";
-import { resolveEdition } from "@/core/edition";
+import { getEdition } from "@/core/edition";
 
 export async function GET(request: NextRequest) {
-    const currentEdition = resolveEdition(process.env.NEXT_PUBLIC_WWV_EDITION);
+    const currentEdition = getEdition();
     if (currentEdition === "demo") {
         return NextResponse.json({ error: "Demo mode" }, { status: 403 });
     }

--- a/src/app/api/v1/entities/search/route.ts
+++ b/src/app/api/v1/entities/search/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "@/lib/ba-session";
 import { authenticateApiKey } from "@/lib/apiKeyAuth";
 import { searchEntities } from "@/lib/data-query/service";
-import { resolveEdition } from "@/core/edition";
+import { resolveEdition as getEdition } from "@/core/edition";
 
 export async function GET(request: NextRequest) {
-    const currentEdition = resolveEdition(process.env.NEXT_PUBLIC_WWV_EDITION);
+    const currentEdition = getEdition();
     if (currentEdition === "demo") {
         return NextResponse.json({ error: "Demo mode" }, { status: 403 });
     }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from "next/script";
 import "./globals.css";
 import "@/styles/hud-animations.css";
 import { LegalFooter } from "@/components/layout/LegalFooter";
+import { edition } from "@/core/edition";
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -27,7 +28,7 @@ export default function RootLayout({
         {process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID && (
           <meta name="google-adsense-account" content={process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID} />
         )}
-        {process.env.NEXT_PUBLIC_WWV_EDITION === "demo" && process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID && (
+        {edition === "demo" && process.env.NEXT_PUBLIC_ADSENSE_CLIENT_ID && (
           <Script
             id="adsbygoogle"
             async

--- a/src/core/edition.test.ts
+++ b/src/core/edition.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { resolveEdition } from "./edition";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { resolveEdition, resolveServerEdition, getEdition } from "./edition";
 import type { Edition } from "./edition";
 
 describe("resolveEdition", () => {
@@ -37,6 +37,72 @@ describe("resolveEdition", () => {
         for (const val of invalid) {
             expect(resolveEdition(val)).toBe("local" satisfies Edition);
         }
+    });
+});
+
+describe("resolveServerEdition (runtime resolution)", () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    beforeEach(() => {
+        vi.resetModules();
+        process.env = { ...ORIGINAL_ENV };
+        delete process.env.WWV_EDITION;
+        delete process.env.NEXT_PUBLIC_WWV_EDITION;
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it("falls back to 'local' when no edition env var is set", async () => {
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("local");
+    });
+
+    it("uses the runtime WWV_EDITION when set", async () => {
+        vi.stubEnv("WWV_EDITION", "demo");
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("demo");
+    });
+
+    it("lets the runtime WWV_EDITION override the build-time NEXT_PUBLIC_ bake", async () => {
+        vi.stubEnv("NEXT_PUBLIC_WWV_EDITION", "cloud");
+        vi.stubEnv("WWV_EDITION", "demo");
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("demo");
+    });
+
+    it("falls back to the NEXT_PUBLIC_ bake when WWV_EDITION is unset", async () => {
+        vi.stubEnv("NEXT_PUBLIC_WWV_EDITION", "cloud");
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("cloud");
+    });
+
+    it("ignores an empty WWV_EDITION and falls back to the bake", async () => {
+        vi.stubEnv("WWV_EDITION", "");
+        vi.stubEnv("NEXT_PUBLIC_WWV_EDITION", "demo");
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("demo");
+    });
+
+    it("falls back to 'local' for an invalid runtime value", async () => {
+        vi.stubEnv("WWV_EDITION", "staging");
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("local");
+    });
+
+    it("is case-insensitive and trims whitespace", async () => {
+        vi.stubEnv("WWV_EDITION", "  CLOUD  ");
+        const { resolveServerEdition: rs } = await import("./edition");
+        expect(rs()).toBe("cloud");
+    });
+
+    it("getEdition() re-reads env on every call (request-time freshness)", async () => {
+        vi.stubEnv("WWV_EDITION", "demo");
+        const { getEdition: ge } = await import("./edition");
+        expect(ge()).toBe("demo");
+        vi.stubEnv("WWV_EDITION", "local");
+        expect(ge()).toBe("local");
     });
 });
 

--- a/src/core/edition.ts
+++ b/src/core/edition.ts
@@ -1,11 +1,19 @@
 /**
  * Edition detection module.
  *
- * Reads NEXT_PUBLIC_WWV_EDITION from the environment and exposes
- * typed constants + feature-flag helpers for the rest of the codebase.
+ * The edition is resolved from the environment at RUNTIME on the server,
+ * so self-hosters can pull the prebuilt image and switch editions via a
+ * runtime .env without rebuilding.
  *
- * Use the NEXT_PUBLIC_ prefix so the value is available on both
- * server and client (Next.js inlines it at build time).
+ * Precedence (server-side, evaluated at request/module-load time):
+ *   1. WWV_EDITION            — runtime env var (settable in a runtime .env)
+ *   2. NEXT_PUBLIC_WWV_EDITION — build-time baked value (kept for the
+ *                                docker-publish :latest/:cloud/:demo builds)
+ *   3. "local"                — fallback when both are unset/invalid
+ *
+ * Client bundles still receive the NEXT_PUBLIC_ build-time bake; server
+ * code should prefer `getEdition()` / `resolveServerEdition()` so runtime
+ * overrides apply.
  */
 
 // ---------------------------------------------------------------------------
@@ -30,10 +38,33 @@ export function resolveEdition(raw?: string): Edition {
     return "local";
 }
 
+/**
+ * Server-side runtime edition resolution.
+ *
+ * Reads `WWV_EDITION` first (runtime, settable via a runtime .env on the
+ * prebuilt image), then falls back to the build-time baked
+ * `NEXT_PUBLIC_WWV_EDITION`. Never inlined into client bundles — call this
+ * only from server code (route handlers, middleware, instrumentation).
+ */
+export function resolveServerEdition(): Edition {
+    const runtime = process.env.WWV_EDITION;
+    if (runtime !== undefined && runtime.trim() !== "") {
+        return resolveEdition(runtime);
+    }
+    return resolveEdition(process.env.NEXT_PUBLIC_WWV_EDITION);
+}
+
 /** Current deployment edition — determined once at module load. */
-export const edition: Edition = resolveEdition(
-    process.env.NEXT_PUBLIC_WWV_EDITION,
-);
+export const edition: Edition = resolveServerEdition();
+
+/**
+ * Fresh edition lookup for request-scoped server code.
+ * Unlike the module-load `edition` constant, this re-reads the env on every
+ * call, so tests (vi.stubEnv) and runtime .env overrides apply immediately.
+ */
+export function getEdition(): Edition {
+    return resolveServerEdition();
+}
 
 // ---------------------------------------------------------------------------
 // Boolean helpers

--- a/src/core/hooks/useMarketplaceSync.test.tsx
+++ b/src/core/hooks/useMarketplaceSync.test.tsx
@@ -108,7 +108,7 @@ vi.mock("@/lib/marketplace/trustedPlugins", () => ({
 vi.mock("@/core/plugins/pluginPreferences", () => ({
     getDisabledPluginIds: () => new Set<string>(),
 }));
-vi.mock("@/core/edition", () => ({ isDemo: false }));
+vi.mock("@/core/edition", () => ({ isDemo: false, edition: "local", getEdition: () => "local" }));
 
 const MANIFESTS: PluginManifest[] = [
     {

--- a/src/core/plugins/PluginManager.ts
+++ b/src/core/plugins/PluginManager.ts
@@ -15,6 +15,7 @@ import { trackEvent } from "@/lib/analytics";
 import { resolveEngineUrl } from "@/core/data/resolveEngineUrl";
 import { fetchLocalEngineManifest } from "@/core/data/engineManifest";
 import { pluginRegistry } from "@/core/plugins/PluginRegistry";
+import { getEdition } from "@/core/edition";
 
 /**
  * ManagedPlugin represents the internal state and instance of a registered data source.
@@ -117,7 +118,7 @@ class PluginManager {
             if (v && !envVars[k]) envVars[k] = v;
         }
 
-        const edition = (process.env.NEXT_PUBLIC_WWV_EDITION || "local") as "local" | "cloud" | "demo";
+        const edition = getEdition();
 
         if (Object.keys(envVars).length > 0) {
             console.debug(`[PluginManager] Injected ${Object.keys(envVars).length} custom env vars into "${plugin.id}"`);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,8 @@
 import * as Sentry from "@sentry/nextjs";
+import { getEdition } from "@/core/edition";
 
 export async function register() {
+  const edition = getEdition();
   if (process.env.NEXT_RUNTIME === "nodejs") {
     if (!process.env.ENCRYPTION_MASTER_KEY && !process.env.MARKETPLACE_API_KEY) {
       throw new Error("[startup] ENCRYPTION_MASTER_KEY is not set. The server cannot start without it.");
@@ -8,16 +10,16 @@ export async function register() {
     if (!process.env.BETTER_AUTH_SECRET) {
       throw new Error("[startup] BETTER_AUTH_SECRET is not set. Better Auth requires it to sign session cookies. Generate one with `openssl rand -base64 32` and add `BETTER_AUTH_SECRET=<your-secret>` to your .env file. See .env.example for all required variables.");
     }
-    if (process.env.NEXT_PUBLIC_WWV_EDITION === "demo" && !process.env.MARKETPLACE_API_KEY) {
+    if (edition === "demo" && !process.env.MARKETPLACE_API_KEY) {
       throw new Error("[startup] DEMO EDITION requires MARKETPLACE_API_KEY. Set it in env vars and restart.");
     }
-    if (process.env.NEXT_PUBLIC_WWV_EDITION === "cloud" && process.env.MARKETPLACE_API_KEY) {
+    if (edition === "cloud" && process.env.MARKETPLACE_API_KEY) {
       console.warn(
         "[startup] WARNING: MARKETPLACE_API_KEY is set on edition=cloud. " +
         "All users will share the same credential. Unset this env var if unintended."
       );
     }
-    if (process.env.MARKETPLACE_API_KEY && process.env.NEXT_PUBLIC_WWV_EDITION !== "demo" && process.env.NEXT_PUBLIC_WWV_EDITION !== "cloud") {
+    if (process.env.MARKETPLACE_API_KEY && edition !== "demo" && edition !== "cloud") {
       console.log("[startup] Using MARKETPLACE_API_KEY credential source (env var path).");
     }
     await import("./sentry.server.config");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { isDemo } from "@/core/edition";
+import { isDemo, getEdition } from "@/core/edition";
 import { hasBetterAuthCookie } from "@/lib/proxy-auth";
 
 const HUB_REDIRECT_URL = process.env.NEXT_PUBLIC_HUB_REDIRECT_URL ?? "https://worldwideview.dev/hub"
@@ -100,7 +100,7 @@ export default async function proxy(req: NextRequest) {
     // Extract subdomain if on cloud
     const hostname = req.headers.get("host") || "";
     let tenantSubdomain = null;
-    const isCloudDeploy = process.env.NEXT_PUBLIC_WWV_EDITION === "cloud";
+    const isCloudDeploy = getEdition() === "cloud";
 
     if (isCloudDeploy) {
         const isApp = hostname.includes(TENANT_DOMAIN) || hostname.includes(".localhost");


### PR DESCRIPTION
## What

Un-bakes the deployment edition (`local` / `cloud` / `demo`). The edition is now resolved at RUNTIME on the server from a non-`NEXT_PUBLIC_` env var, so self-hosters can pull the prebuilt `:latest` image and switch editions via a runtime `.env` — no rebuild required.

### Before

`src/core/edition.ts` resolved the edition once at module load from `process.env.NEXT_PUBLIC_WWV_EDITION`. That var is a Dockerfile build ARG, inlined into the bundle by `next build`. A self-hoster pulling `ghcr.io/silvertakana/worldwideview:latest` and setting `NEXT_PUBLIC_WWV_EDITION=demo` in a runtime `.env` silently stayed on the baked value (`local`) — the `:demo` tag was the only way to get demo behavior.

### After

New runtime resolution chain (server-side):

```
WWV_EDITION  (runtime env, settable in a runtime .env)
  → NEXT_PUBLIC_WWV_EDITION  (build-time bake, kept for the docker-publish :latest/:cloud/:demo builds)
  → "local"  (fallback when unset/invalid)
```

- `src/core/edition.ts` gains `resolveServerEdition()` (reads `WWV_EDITION` first, then the bake) and `getEdition()` (fresh per-request lookup for route handlers). The module-load `edition` constant now uses the same resolution, so all existing `isDemo`/`isCloud`/`isLocal` feature-flag consumers behave identically.
- Per-request demo gates (`/api/v1/entities/search`, `/api/v1/entities/region`, `/api/globe/commands`, `/api/globe/commands/stream`) now call `getEdition()` instead of reading the bake inline, so runtime overrides apply per request.
- Server-side env readers normalized to the resolved value: `src/proxy.ts` (cloud tenant routing), `src/instrumentation.ts` (startup gates), `src/app/layout.tsx` (demo AdSense gate), `src/app/api/build/route.ts` (diagnostics), `src/core/plugins/PluginManager.ts` (plugin context edition).
- `Dockerfile`: new `ARG WWV_EDITION` (defaults to the `NEXT_PUBLIC_WWV_EDITION` bake) + `ENV WWV_EDITION` in the runner stage, so the runtime var is present in the container and operators can override it.
- `docker-compose.yml` and `self-host/docker-compose.yml`: `WWV_EDITION=${WWV_EDITION:-}` runtime pass-through.
- `.env.example` + `docs/ARCHITECTURE.md`, `docs/project-overview.md`, `docs/mcp-quickstart.md`: document the precedence and the runtime var.

## Backward compatibility

- Unset `WWV_EDITION` → falls back to the `NEXT_PUBLIC_WWV_EDITION` bake, then `local`. Identical behavior to before for every existing deployment (production/cloud/demo tag builds, local dev).
- The docker-publish workflow still passes `NEXT_PUBLIC_WWV_EDITION` as a build arg for `:latest`, `:cloud`, and `:demo` — untouched.
- `resolveEdition()` (pure) is unchanged; all existing tests and shallow `vi.mock("@/core/edition")` mocks keep working (one test mock extended with the new exports it needs).

## Tests

Added unit tests in `src/core/edition.test.ts` covering: env unset → `local`, runtime `WWV_EDITION` set → that value, runtime override of the bake, bake fallback, empty runtime var → bake, invalid value → `local`, case/whitespace handling, and `getEdition()` request-time freshness.

## Verification

- `pnpm lint` — 0 errors
- `pnpm test` — 144 files / 1442 tests pass
- `pnpm build` — success

docker verification: needs manual run