### PR TITLE
feat: per-layer entity budgets with stable deterministic thinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.67.0",
+"version": "2.67.0"
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-"version": "2.67.0"
+  "version": "2.67.0",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/components/layout/DataBusSubscriber.budget.test.tsx
+++ b/src/components/layout/DataBusSubscriber.budget.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { DataBusSubscriber } from "./DataBusSubscriber";
+import { dataBus } from "@/core/data/DataBus";
+import { useStore } from "@/core/state/store";
+import type { GeoEntity } from "@/core/plugins/PluginTypes";
+
+vi.mock("@/core/plugins/PluginManager", () => ({
+    pluginManager: {
+        setCacheMaxAge: vi.fn(),
+        getManifest: vi.fn(() => undefined),
+        getAllPlugins: vi.fn(() => []),
+    },
+}));
+
+vi.mock("@/core/data/WsClient", () => ({
+    wsClient: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+}));
+
+vi.mock("@/core/data/resolveEngineUrl", () => ({
+    resolveEngineUrl: vi.fn(() => "http://localhost:5000"),
+}));
+
+vi.mock("@/core/data/engineManifest", () => ({
+    fetchLocalEngineManifest: vi.fn(),
+}));
+
+function makeEntities(n: number, pluginId = "budget-plugin"): GeoEntity[] {
+    return Array.from({ length: n }, (_, i) => ({
+        id: `${pluginId}-${i}`,
+        pluginId,
+        latitude: 0,
+        longitude: 0,
+        timestamp: new Date("2026-01-01T00:00:00Z"),
+        properties: {},
+    }));
+}
+
+describe("DataBusSubscriber entity budget", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const { entitiesByPlugin, layers, dataConfig } = useStore.getState();
+        // Reset relevant store state without full teardown of other slices.
+        for (const key of Object.keys(entitiesByPlugin)) {
+            useStore.getState().clearEntities(key);
+        }
+        for (const key of Object.keys(layers)) {
+            useStore.getState().removeLayer(key);
+        }
+        if (Object.keys(dataConfig.pluginSettings).length > 0) {
+            useStore.setState({ dataConfig: { ...dataConfig, pluginSettings: {} } });
+        }
+    });
+
+    it("stores the thinned subset and records budget state when a feed exceeds the budget", async () => {
+        render(<DataBusSubscriber />);
+        const entities = makeEntities(6000);
+        const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+        dataBus.emit("dataUpdated", { pluginId: "budget-plugin", entities });
+
+        await waitFor(() => {
+            const state = useStore.getState();
+            expect(state.entitiesByPlugin["budget-plugin"]).toHaveLength(5000);
+            expect(state.layers["budget-plugin"].entityCount).toBe(6000);
+            expect(state.layers["budget-plugin"].budgetExceeded).toBe(true);
+            expect(state.layers["budget-plugin"].renderedCount).toBe(5000);
+            expect(state.layers["budget-plugin"].budgetCap).toBe(5000);
+        });
+        expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("exceeded entity budget"));
+        debugSpy.mockRestore();
+    });
+
+    it("passes feeds within budget through untouched with no exceeded flag", async () => {
+        render(<DataBusSubscriber />);
+        const entities = makeEntities(10);
+
+        dataBus.emit("dataUpdated", { pluginId: "budget-plugin", entities });
+
+        await waitFor(() => {
+            const state = useStore.getState();
+            expect(state.entitiesByPlugin["budget-plugin"]).toHaveLength(10);
+            expect(state.layers["budget-plugin"].budgetExceeded).toBe(false);
+            expect(state.layers["budget-plugin"].renderedCount).toBe(10);
+            expect(state.layers["budget-plugin"].entityCount).toBe(10);
+        });
+    });
+
+    it("honors a per-layer entityBudget plugin setting", async () => {
+        useStore.getState().updatePluginSettings("budget-plugin", { entityBudget: 100 });
+        render(<DataBusSubscriber />);
+        const entities = makeEntities(250);
+
+        dataBus.emit("dataUpdated", { pluginId: "budget-plugin", entities });
+
+        await waitFor(() => {
+            const state = useStore.getState();
+            expect(state.entitiesByPlugin["budget-plugin"]).toHaveLength(100);
+            expect(state.layers["budget-plugin"].budgetCap).toBe(100);
+            expect(state.layers["budget-plugin"].entityCount).toBe(250);
+        });
+    });
+});

--- a/src/components/layout/DataBusSubscriber.tsx
+++ b/src/components/layout/DataBusSubscriber.tsx
@@ -14,6 +14,7 @@ import { pluginManager } from "@/core/plugins/PluginManager";
 import { wsClient } from "@/core/data/WsClient";
 import { resolveEngineUrl } from "@/core/data/resolveEngineUrl";
 import { fetchLocalEngineManifest } from "@/core/data/engineManifest";
+import { applyEntityBudget, resolveLayerBudget } from "@/core/data/entityBudget";
 
 /**
  * @component DataBusSubscriber
@@ -24,6 +25,7 @@ export function DataBusSubscriber() {
     const setPollingInterval = useStore((s) => s.setPollingInterval);
     const setEntities = useStore((s) => s.setEntities);
     const setEntityCount = useStore((s) => s.setEntityCount);
+    const setLayerBudget = useStore((s) => s.setLayerBudget);
     const clearEntities = useStore((s) => s.clearEntities);
     const removeLayer = useStore((s) => s.removeLayer);
     const setLayerLoading = useStore((s) => s.setLayerLoading);
@@ -50,8 +52,19 @@ export function DataBusSubscriber() {
             // Defer the state updates by one tick to prevent React "Maximum update depth exceeded"
             // errors during massive synchronous plugin loads (e.g. at boot).
             setTimeout(() => {
-                setEntities(pluginId, entities);
-                setEntityCount(pluginId, entities.length);
+                // Per-layer entity budget: truncate at the data layer (before the
+                // store) so renderer primitive cleanup never fights truncation.
+                const { pluginSettings } = useStore.getState().dataConfig;
+                const budget = resolveLayerBudget(pluginId, pluginSettings);
+                const { kept, budgetExceeded, totalCount } = applyEntityBudget(entities, budget);
+                if (budgetExceeded) {
+                    console.debug(
+                        `[DataBusSubscriber] Layer "${pluginId}" exceeded entity budget: rendering ${kept.length} of ${totalCount} (cap ${budget}).`
+                    );
+                }
+                setEntities(pluginId, kept);
+                setEntityCount(pluginId, totalCount);
+                setLayerBudget(pluginId, { budgetCap: budget, renderedCount: kept.length, budgetExceeded });
             }, 0);
         });
 
@@ -98,7 +111,7 @@ export function DataBusSubscriber() {
             unsubLoading();
             unsubError();
         };
-    }, [setPollingInterval, setEntities, setEntityCount, clearEntities, removeLayer, setLayerLoading, showErrorToast]);
+    }, [setPollingInterval, setEntities, setEntityCount, setLayerBudget, clearEntities, removeLayer, setLayerLoading, showErrorToast]);
 
     return null;
 }

--- a/src/components/panels/LayerItem.css
+++ b/src/components/panels/LayerItem.css
@@ -160,7 +160,6 @@
   border-radius: var(--radius-sm);
 }
 
-<<<<<<< HEAD
 /* ─── Freshness Badge ────────────────────────────────────── */
 /* Shows the server-clock time the latest snapshot was fetched. */
 .layer-item__freshness {

--- a/src/components/panels/LayerItem.css
+++ b/src/components/panels/LayerItem.css
@@ -160,6 +160,7 @@
   border-radius: var(--radius-sm);
 }
 
+<<<<<<< HEAD
 /* ─── Freshness Badge ────────────────────────────────────── */
 /* Shows the server-clock time the latest snapshot was fetched. */
 .layer-item__freshness {
@@ -184,6 +185,18 @@
 .layer-item__freshness--stale {
   color: #f87171;
   background: rgba(248, 113, 113, 0.08);
+}
+
+/* ─── Budget Badge ───────────────────────────────────────── */
+.layer-item__budget-badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
 }
 
 /* ─── Loading Spinner ────────────────────────────────────── */

--- a/src/components/panels/LayerItem.tsx
+++ b/src/components/panels/LayerItem.tsx
@@ -105,6 +105,12 @@ interface LayerItemProps {
     entityCount: number;
     fetchedAt?: string;
     isSelected?: boolean;
+    /** Total entities received for this layer (pre-budget). */
+    totalEntityCount?: number;
+    /** Entities actually rendering after budget thinning. */
+    renderedCount?: number;
+    /** True when the layer's feed exceeded its entity budget. */
+    budgetExceeded?: boolean;
     onToggle: () => void;
     onSelect?: () => void;
 }
@@ -120,6 +126,9 @@ export function LayerItem({
     entityCount,
     fetchedAt,
     isSelected,
+    totalEntityCount,
+    renderedCount,
+    budgetExceeded,
     onToggle,
     onSelect,
 }: LayerItemProps) {
@@ -154,6 +163,14 @@ export function LayerItem({
                   {freshness.label}
                 </span>
               </Tooltip>
+            )}
+            {isEnabled && !isLoading && budgetExceeded && (
+              <span
+                className="layer-item__budget-badge"
+                aria-label="Entity budget exceeded"
+              >
+                rendering {(renderedCount ?? entityCount).toLocaleString()} of {(totalEntityCount ?? entityCount).toLocaleString()}
+              </span>
             )}
           </div>
         </div>

--- a/src/components/panels/LayerPanel.tsx
+++ b/src/components/panels/LayerPanel.tsx
@@ -224,6 +224,7 @@ export function LayerPanel() {
                                     const isLoading = layers[managed.plugin.id]?.loading || false;
                                     const count = (entitiesByPlugin[managed.plugin.id] || []).length;
                                     const fetchedAt = layers[managed.plugin.id]?.fetchedAt;
+                                    const layerState = layers[managed.plugin.id];
 
                                     return (
                                       <LayerItem
@@ -234,6 +235,9 @@ export function LayerPanel() {
                                         entityCount={count}
                                         fetchedAt={fetchedAt}
                                         isSelected={highlightLayerId === managed.plugin.id}
+                                        totalEntityCount={layerState?.budgetExceeded ? layerState.entityCount : undefined}
+                                        renderedCount={layerState?.budgetExceeded ? layerState.renderedCount : undefined}
+                                        budgetExceeded={layerState?.budgetExceeded}
                                         onToggle={() => handleToggle(managed.plugin.id)}
                                         onSelect={() => {
                                                 const newId = highlightLayerId === managed.plugin.id ? null : managed.plugin.id;

--- a/src/core/data/entityBudget.test.ts
+++ b/src/core/data/entityBudget.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { applyEntityBudget, resolveLayerBudget, GLOBAL_LAYER_ENTITY_BUDGET, DEFAULT_LAYER_ENTITY_BUDGET } from "./entityBudget";
+import type { GeoEntity } from "@/core/plugins/PluginTypes";
+
+function makeEntity(id: string): GeoEntity {
+    return {
+        id,
+        pluginId: "test-plugin",
+        latitude: 0,
+        longitude: 0,
+        timestamp: new Date("2026-01-01T00:00:00Z"),
+        properties: {},
+    };
+}
+
+function makeEntities(n: number): GeoEntity[] {
+    return Array.from({ length: n }, (_, i) => makeEntity(`entity-${i}`));
+}
+
+describe("applyEntityBudget", () => {
+    it("passes through unchanged when budget is not exceeded", () => {
+        const entities = makeEntities(100);
+        const result = applyEntityBudget(entities, 5000);
+        expect(result.kept).toBe(entities);
+        expect(result.budgetExceeded).toBe(false);
+        expect(result.totalCount).toBe(100);
+        expect(result.budgetCap).toBe(5000);
+    });
+
+    it("thins to exactly the budget", () => {
+        const entities = makeEntities(300);
+        const result = applyEntityBudget(entities, 100);
+        expect(result.kept).toHaveLength(100);
+        expect(result.budgetExceeded).toBe(true);
+        expect(result.totalCount).toBe(300);
+    });
+
+    it("is deterministic: same input produces the same subset", () => {
+        const entities = makeEntities(300);
+        const a = applyEntityBudget(entities, 100);
+        const b = applyEntityBudget([...entities], 100);
+        expect(a.kept.map((e) => e.id)).toEqual(b.kept.map((e) => e.id));
+    });
+
+    it("is order-independent: same membership in a different order yields the same subset of ids", () => {
+        const entities = makeEntities(300);
+        const reversed = [...entities].reverse();
+        const a = applyEntityBudget(entities, 100).kept.map((e) => e.id).sort();
+        const b = applyEntityBudget(reversed, 100).kept.map((e) => e.id).sort();
+        expect(a).toEqual(b);
+    });
+
+    it("keeps a stable subset across ticks when membership is unchanged", () => {
+        const tick1 = makeEntities(300);
+        const result1 = applyEntityBudget(tick1, 100);
+        // Simulate a new WS tick: same entities, perturbed order and refreshed payloads.
+        const tick2 = [...tick1].reverse().map((e) => ({ ...e, timestamp: new Date() }));
+        const result2 = applyEntityBudget(tick2, 100);
+        const ids1 = new Set(result1.kept.map((e) => e.id));
+        const ids2 = new Set(result2.kept.map((e) => e.id));
+        expect(ids1).toEqual(ids2);
+    });
+
+    it("admits a new member only through a new deterministic draw when membership changes", () => {
+        const base = makeEntities(300);
+        const keptBefore = new Set(applyEntityBudget(base, 100).kept.map((e) => e.id));
+        // Re-run with identical membership: subset never changes between ticks.
+        expect(new Set(applyEntityBudget(base, 100).kept.map((e) => e.id))).toEqual(keptBefore);
+        // Adding one member is a membership change; the budget still holds and the
+        // subset is again deterministic for the new membership.
+        const grown = [...base, makeEntity("newcomer")];
+        const grownResult = applyEntityBudget(grown, 100);
+        expect(grownResult.kept).toHaveLength(100);
+        expect(new Set(applyEntityBudget(grown, 100).kept.map((e) => e.id))).toEqual(
+            new Set(grownResult.kept.map((e) => e.id))
+        );
+    });
+
+    it("does not systematically drop the tail (newest) of the feed", () => {
+        const entities = makeEntities(1000);
+        const kept = new Set(applyEntityBudget(entities, 100).kept.map((e) => e.id));
+        // Entities from the last 10% of the feed must still be represented.
+        const tail = entities.slice(-100);
+        const tailSurvivors = tail.filter((e) => kept.has(e.id)).length;
+        expect(tailSurvivors).toBeGreaterThan(0);
+    });
+
+    it("preserves original feed order in the kept array", () => {
+        const entities = makeEntities(200);
+        const kept = applyEntityBudget(entities, 50).kept;
+        const positions = kept.map((e) => entities.indexOf(e));
+        expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    });
+});
+
+describe("resolveLayerBudget", () => {
+    it("falls back to the global default without per-layer settings", () => {
+        expect(resolveLayerBudget("p", {})).toBe(GLOBAL_LAYER_ENTITY_BUDGET);
+        expect(GLOBAL_LAYER_ENTITY_BUDGET).toBe(DEFAULT_LAYER_ENTITY_BUDGET);
+    });
+
+    it("prefers a valid per-layer setting", () => {
+        expect(resolveLayerBudget("p", { p: { entityBudget: 250 } })).toBe(250);
+    });
+
+    it("ignores invalid per-layer settings", () => {
+        expect(resolveLayerBudget("p", { p: { entityBudget: -5 } })).toBe(GLOBAL_LAYER_ENTITY_BUDGET);
+        expect(resolveLayerBudget("p", { p: { entityBudget: "many" } })).toBe(GLOBAL_LAYER_ENTITY_BUDGET);
+    });
+});

--- a/src/core/data/entityBudget.ts
+++ b/src/core/data/entityBudget.ts
@@ -1,0 +1,136 @@
+/**
+ * @file entityBudget.ts
+ * @description Per-layer entity budget with stable deterministic thinning.
+ * Applied at the data layer (before entities enter the store) so the renderer
+ * never fights primitive cleanup against truncation churn.
+ */
+
+import type { GeoEntity } from "@/core/plugins/PluginTypes";
+
+// ─── Budget Defaults ─────────────────────────────────────────
+
+/**
+ * Default per-layer entity budget. Matches the chunked-rendering design point
+ * (10k+ datasets chunked at 500) with generous headroom; telemetry from
+ * budget-exceeded logs will inform tightening this default later.
+ */
+export const DEFAULT_LAYER_ENTITY_BUDGET = 5000;
+
+/** Environment override for the global default (parsed once at module load). */
+const ENV_BUDGET = Number(process.env.NEXT_PUBLIC_LAYER_ENTITY_BUDGET);
+
+/**
+ * Global fallback budget: env override when set to a positive integer,
+ * otherwise the built-in default.
+ */
+export const GLOBAL_LAYER_ENTITY_BUDGET =
+    Number.isFinite(ENV_BUDGET) && ENV_BUDGET > 0 ? Math.floor(ENV_BUDGET) : DEFAULT_LAYER_ENTITY_BUDGET;
+
+// ─── Deterministic Thinning ──────────────────────────────────
+
+/**
+ * FNV-1a 32-bit hash of an entity id. Pure and stable across sessions,
+ * platforms, and feed orderings.
+ */
+function hashId(id: string): number {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < id.length; i++) {
+        hash ^= id.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193);
+    }
+    // Normalize to [0, 1) so budgets compare against a uniform score.
+    return (hash >>> 0) / 0x100000000;
+}
+
+/** Per-entity deterministic score, memoized by id to keep repeated ticks cheap. */
+const scoreCache = new Map<string, number>();
+
+function entityScore(id: string): number {
+    let score = scoreCache.get(id);
+    if (score === undefined) {
+        score = hashId(id);
+        // Bound the cache so long-running sessions with churning feeds do not leak.
+        if (scoreCache.size > 50000) scoreCache.clear();
+        scoreCache.set(id, score);
+    }
+    return score;
+}
+
+/**
+ * Result of applying an entity budget to an incoming feed.
+ */
+export interface BudgetResult {
+    /** The entities that survived the budget (original feed order preserved). */
+    kept: GeoEntity[];
+    /** Whether the budget removed anything. */
+    budgetExceeded: boolean;
+    /** Total entities received before thinning. */
+    totalCount: number;
+    /** The effective budget that was applied. */
+    budgetCap: number;
+}
+
+/**
+ * Applies a per-layer entity budget with stable, spatially-uniform thinning.
+ *
+ * The thinning keeps the `budget` entities with the lowest deterministic hash
+ * score of their id. Like dealing every aircraft in the sky a fixed lottery
+ * ticket number at birth: no matter how often the list is re-read or reordered,
+ * the same ticket numbers win, so the visible fleet stops flickering between
+ * ticks. A membership change naturally alters which tickets are in the draw,
+ * which is the only legitimate reason for the subset to change. Feed order
+ * (newest-first vs oldest-first) never affects who wins, so the newest
+ * aircraft are never systematically dropped.
+ *
+ * @param entities Incoming entities for one plugin.
+ * @param budget Maximum number of entities to keep (> 0).
+ */
+export function applyEntityBudget(entities: GeoEntity[], budget: number): BudgetResult {
+    const totalCount = entities.length;
+    const budgetCap = budget > 0 ? Math.floor(budget) : GLOBAL_LAYER_ENTITY_BUDGET;
+
+    if (totalCount <= budgetCap) {
+        return { kept: entities, budgetExceeded: false, totalCount, budgetCap };
+    }
+
+    // Find the score threshold that admits exactly `budgetCap` entities:
+    // scores are effectively uniform in [0,1), so the winners are spread
+    // uniformly across the dataset rather than clustered (no tail-drop).
+    const scores = entities.map((e) => entityScore(e.id));
+    const sorted = [...scores].sort((a, b) => a - b);
+    const threshold = sorted[budgetCap - 1];
+
+    const kept: GeoEntity[] = [];
+    let admittedByThreshold = 0;
+    for (let i = 0; i < entities.length; i++) {
+        if (scores[i] < threshold) {
+            kept.push(entities[i]);
+            admittedByThreshold++;
+        }
+    }
+    // Fill the remaining slots with entities sitting exactly on the threshold
+    // (hash collisions), in feed order, to land exactly on the budget.
+    if (admittedByThreshold < budgetCap) {
+        for (let i = 0; i < entities.length && admittedByThreshold < budgetCap; i++) {
+            if (scores[i] === threshold) {
+                kept.push(entities[i]);
+                admittedByThreshold++;
+            }
+        }
+    }
+
+    return { kept, budgetExceeded: true, totalCount, budgetCap };
+}
+
+/**
+ * Resolves the effective budget for a plugin: per-layer setting first
+ * (`dataConfig.pluginSettings[pluginId].entityBudget`), then the global
+ * env-configurable default.
+ */
+export function resolveLayerBudget(pluginId: string, pluginSettings: Record<string, Record<string, unknown>>): number {
+    const perLayer = pluginSettings[pluginId]?.entityBudget;
+    if (typeof perLayer === "number" && Number.isFinite(perLayer) && perLayer > 0) {
+        return Math.floor(perLayer);
+    }
+    return GLOBAL_LAYER_ENTITY_BUDGET;
+}

--- a/src/core/state/layersSlice.ts
+++ b/src/core/state/layersSlice.ts
@@ -19,6 +19,12 @@ export interface LayerState {
     loading: boolean;
     /** Server-provided ISO timestamp of the last snapshot received for this layer, if any. */
     fetchedAt?: string;
+    /** The effective entity budget applied to this layer (set when data arrives). */
+    budgetCap?: number;
+    /** How many entities actually render after budget thinning. */
+    renderedCount?: number;
+    /** True when the incoming feed exceeded the budget and was thinned. */
+    budgetExceeded?: boolean;
 }
 
 /**
@@ -37,6 +43,8 @@ export interface LayersSlice {
     setLayerLoading: (pluginId: string, loading: boolean) => void;
     /** Records the server-provided fetchedAt of the latest snapshot for freshness display. */
     setLayerFetchedAt: (pluginId: string, fetchedAt: string | undefined) => void;
+    /** Records budget thinning outcome for a layer (never-silent truncation surfacing). */
+    setLayerBudget: (pluginId: string, budget: { budgetCap: number; renderedCount: number; budgetExceeded: boolean }) => void;
     /** Initializes a new layer entry in the state if it doesn't already exist. */
     initLayer: (pluginId: string, defaultEnabled?: boolean) => void;
     /** Completely removes a layer from the state. */
@@ -76,6 +84,12 @@ export const createLayersSlice: StateCreator<AppStore, [], [], LayersSlice> = (s
             layers: {
                 ...state.layers,
                 [pluginId]: { ...state.layers[pluginId], fetchedAt },
+            },
+        })),
+    setLayerBudget: (pluginId, budget) => set((state) => ({
+            layers: {
+                ...state.layers,
+                [pluginId]: { ...state.layers[pluginId], ...budget },
             },
         })),
     initLayer: (pluginId, defaultEnabled = false) => set((state) => ({


### PR DESCRIPTION
## Summary

Per-layer entity budgets that stop a single runaway layer from degrading the whole globe, with stable deterministic thinning applied at the **data layer** (before entities enter the store), surfaced in the UI.

## Design

- **Truncation point**: `DataBusSubscriber` applies the budget in the `dataUpdated` handler, keyed by pluginId, before `setEntities`/`setEntityCount` reach the zustand store. The renderer (`EntityRenderer.ts` / `useEntityRendering.ts`) is untouched: budgeting upstream of the store means primitive cleanup never fights truncation churn.
- **Thinning algorithm** (`src/core/data/entityBudget.ts`): each entity gets a deterministic FNV-1a hash score of its id (memoized); when a feed exceeds its budget, the `budget` lowest-scoring ids survive, in original feed order. Like dealing every aircraft a fixed lottery ticket at birth: the same tickets win every tick, so the visible fleet never flickers, and feed order (newest-first vs oldest-first) never decides who gets dropped, so the newest entities are never systematically sacrificed. A membership change naturally re-runs the draw, which is the only legitimate reason for the subset to change. No tail-drop anywhere.
- **Never silent**: `LayerState` gains `budgetCap`, `renderedCount`, and `budgetExceeded`; `LayerItem` shows an amber "rendering X of Y" badge in the footer when the budget bites.
- **Config surface**: default budget of 5000 per layer (matching the chunked-rendering design point), global override via `NEXT_PUBLIC_LAYER_ENTITY_BUDGET`, and per-layer override via the existing plugin settings mechanism (`dataConfig.pluginSettings[pluginId].entityBudget`). A dedicated per-layer settings UI control is not included here (PARTIAL) to avoid colliding with open PRs #477/#478 in this area.

## Telemetry

Every budget-exceeded tick logs via `console.debug` (layer id, rendered/total/cap). This telemetry is how the real default gets chosen later, so please leave these logs in place.

## Tests

- `entityBudget.test.ts`: determinism (same input -> same subset), order-independence, stability across simulated WS ticks, membership-change behavior, no tail-drop, exact budget fill, passthrough when under budget, budget resolution precedence.
- `DataBusSubscriber.budget.test.tsx`: end-to-end truncation through the real store (thinned `entitiesByPlugin`, total `entityCount`, `renderedCount`/`budgetExceeded`/`budgetCap` set, per-layer setting honored).

## Merge notes

Expect rebase friction with #477/#478 (LayerItem/LayerPanel/layersSlice); edits there are minimal and additive (optional props + one conditional badge row + one slice action). Merge after those PRs. `pnpm lint`, `pnpm test` (146 files / 1448 tests), and `pnpm build` all pass.
