### PR TITLE
feat(mcp): add find_nearby_entities spatial proximity query tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.67.0",
+  "version": "2.68.0",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/app/api/mcp/proximityTools.test.ts
+++ b/src/app/api/mcp/proximityTools.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Proximity tool + service tests (PR 1).
+ *
+ * Covers:
+ *   - haversineDistanceKm math against known great-circle distances
+ *   - coordinate-based proximity search (nearest-first + distanceKm)
+ *   - entity-based proximity search (origin resolution + self-exclusion)
+ *   - origin_entity_not_found emptyReason
+ *   - radius cut-off and default radius
+ *   - targetPluginIds filtering and all-active-plugins fallback
+ *   - inline property filters
+ *   - limit truncation
+ *   - tool registration on an McpServer stub
+ *
+ * The data-query service and the heavy globe-state modules are mocked;
+ * discoveryHelpers keeps its REAL radiusKmToBbox while listStreamingPlugins
+ * is mocked (same pattern as discoveryTools.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SearchResult } from "@/lib/data-query/types";
+
+vi.mock("@/lib/data-query/service");
+vi.mock("@/lib/globeStateStore");
+vi.mock("@/lib/mcpSessionCatalog");
+vi.mock("@/lib/globeCommandQueue");
+vi.mock("@/app/api/mcp/discoveryHelpers", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/app/api/mcp/discoveryHelpers")>();
+    return {
+        ...actual,
+        listStreamingPlugins: vi.fn(),
+    };
+});
+
+import { getEntitiesInRegion, getEntityDetails, getPluginData } from "@/lib/data-query/service";
+import { listStreamingPlugins } from "@/app/api/mcp/discoveryHelpers";
+import {
+    haversineDistanceKm,
+    findNearbyEntities,
+    type FindNearbyResult,
+    type NearbyEntity,
+} from "@/lib/mcp/proximityService";
+import { registerProximityTools } from "./proximityTools";
+
+const mockGetEntitiesInRegion = vi.mocked(getEntitiesInRegion);
+const mockGetEntityDetails = vi.mocked(getEntityDetails);
+const mockGetPluginData = vi.mocked(getPluginData);
+const mockListStreamingPlugins = vi.mocked(listStreamingPlugins);
+
+// ---------------------------------------------------------------------------
+// Fake McpServer that captures handlers + schemas
+// ---------------------------------------------------------------------------
+const handlers: Record<string, (args: unknown) => Promise<unknown>> = {};
+const schemas: Record<string, { description: string; inputSchema?: Record<string, unknown> }> = {};
+const mockServer = {
+    registerTool: vi.fn(
+        (name: string, schema: { description: string; inputSchema?: Record<string, unknown> }, handler: (args: unknown) => Promise<unknown>) => {
+            handlers[name] = handler;
+            schemas[name] = schema;
+        },
+    ),
+};
+
+const ctx = { userId: "user-proximity-1" };
+
+// ---------------------------------------------------------------------------
+// Fixtures (real WGS84 coordinates, known great-circle distances)
+// ---------------------------------------------------------------------------
+const LONDON = { lat: 51.5074, lon: -0.1278 };
+const PARIS = { lat: 48.8566, lon: 2.3522 };
+const ROME = { lat: 41.9, lon: 12.5 };
+
+function regionEntity(id: string, pluginId: string, latitude: number, longitude: number): SearchResult {
+    return { id, pluginId, name: id, latitude, longitude };
+}
+
+const ba1London = regionEntity("BA1", "flights", 51.5, -0.12); // ~1 km from LONDON
+const af1Paris = regionEntity("AF1", "flights", PARIS.lat, PARIS.lon); // ~343.6 km from LONDON
+const dh1Berlin = regionEntity("DH1", "flights", 52.52, 13.405); // ~931.7 km from LONDON
+const ca1Rome = regionEntity("CA1", "flights", ROME.lat, ROME.lon); // ~1435.5 km from LONDON
+const ma1London = regionEntity("MA1", "maritime", 51.49, -0.1); // ~2.3 km from LONDON
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(handlers).forEach((k) => delete handlers[k]);
+    Object.keys(schemas).forEach((k) => delete schemas[k]);
+
+    mockGetEntitiesInRegion.mockResolvedValue({ entities: [] });
+    mockGetEntityDetails.mockResolvedValue({ data: null, emptyReason: "no_data_matches" });
+    mockGetPluginData.mockResolvedValue({ data: null, emptyReason: "plugin_not_streaming" });
+    mockListStreamingPlugins.mockResolvedValue({ plugins: [] });
+
+    registerProximityTools(mockServer as never, ctx);
+});
+
+// ---------------------------------------------------------------------------
+// Haversine math
+// ---------------------------------------------------------------------------
+describe("haversineDistanceKm", () => {
+    it("computes the known London->Paris great-circle distance (~343.6 km)", () => {
+        const d = haversineDistanceKm(LONDON.lat, LONDON.lon, PARIS.lat, PARIS.lon);
+        expect(Math.abs(d - 343.6)).toBeLessThan(3);
+    });
+
+    it("computes the known London->Rome great-circle distance (~1435.5 km)", () => {
+        const d = haversineDistanceKm(LONDON.lat, LONDON.lon, ROME.lat, ROME.lon);
+        expect(Math.abs(d - 1435.5)).toBeLessThan(5);
+    });
+
+    it("returns 0 for identical coordinates", () => {
+        expect(haversineDistanceKm(48.8566, 2.3522, 48.8566, 2.3522)).toBe(0);
+    });
+
+    it("is symmetric (A->B equals B->A)", () => {
+        const ab = haversineDistanceKm(LONDON.lat, LONDON.lon, PARIS.lat, PARIS.lon);
+        const ba = haversineDistanceKm(PARIS.lat, PARIS.lon, LONDON.lat, LONDON.lon);
+        expect(Math.abs(ab - ba)).toBeLessThan(1e-9);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Coordinate-based proximity search
+// ---------------------------------------------------------------------------
+function successOf(result: FindNearbyResult): Extract<FindNearbyResult, { success: true }> {
+    if (result.success !== true) {
+        throw new Error("expected a success result");
+    }
+    return result;
+}
+
+describe("findNearbyEntities -- coordinate-based", () => {
+    it("returns entities nearest-first with distanceKm matched to haversine math", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [dh1Berlin, af1Paris, ba1London], // deliberately unordered
+        });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 1000,
+                targetPluginIds: ["flights"],
+            }),
+        );
+
+        expect(result.center).toEqual({ latitude: LONDON.lat, longitude: LONDON.lon });
+        expect(result.radiusKm).toBe(1000);
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1", "AF1", "DH1"]);
+
+        const distances = result.entities.map((e) => e.distanceKm);
+        expect(distances).toEqual([...distances].sort((a, b) => a - b));
+        expect(Math.abs(distances[0] - haversineDistanceKm(LONDON.lat, LONDON.lon, 51.5, -0.12))).toBeLessThan(1e-9);
+        expect(Math.abs(distances[1] - 343.6)).toBeLessThan(3);
+        expect(Math.abs(distances[2] - 931.7)).toBeLessThan(5);
+    });
+
+    it("cuts off entities beyond radiusKm and keeps the ones inside", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [ba1London, af1Paris, ca1Rome],
+        });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 500,
+                targetPluginIds: ["flights"],
+            }),
+        );
+
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1", "AF1"]);
+        expect(result.entities.every((e) => e.distanceKm <= 500)).toBe(true);
+    });
+
+    it("defaults the radius to 50 km when radiusKm is omitted", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [ba1London, af1Paris],
+        });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                targetPluginIds: ["flights"],
+            }),
+        );
+
+        expect(result.radiusKm).toBe(50);
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1"]);
+    });
+
+    it("truncates to limit (nearest first)", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [ca1Rome, af1Paris, ba1London],
+        });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 2000,
+                targetPluginIds: ["flights"],
+                limit: 1,
+            }),
+        );
+
+        expect(result.count).toBe(1);
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1"]);
+    });
+
+    it("rejects a missing or partial coordinate center", async () => {
+        for (const opts of [{}, { lat: 51.5 }] as const) {
+            const result = await findNearbyEntities(opts);
+            expect(result.success).toBe(false);
+            if (!result.success && "error" in result) {
+                expect(result.error.length).toBeGreaterThan(0);
+            }
+        }
+        expect(mockGetEntitiesInRegion).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Entity-based proximity search
+// ---------------------------------------------------------------------------
+describe("findNearbyEntities -- entity-based", () => {
+    it("resolves the origin entity as the center and excludes it from results", async () => {
+        mockGetEntityDetails.mockResolvedValue({
+            data: {
+                id: "AF1",
+                pluginId: "flights",
+                latitude: PARIS.lat,
+                longitude: PARIS.lon,
+                timestamp: new Date(),
+                label: "AF1 Paris",
+                properties: {},
+            },
+        });
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [ba1London, af1Paris], // origin included in bbox -> must be excluded
+        });
+
+        const result = successOf(
+            await findNearbyEntities({
+                originPluginId: "flights",
+                originEntityId: "AF1",
+                radiusKm: 1000,
+                targetPluginIds: ["flights"],
+            }),
+        );
+
+        expect(result.center).toEqual({
+            latitude: PARIS.lat,
+            longitude: PARIS.lon,
+            originPluginId: "flights",
+            originEntityId: "AF1",
+            originLabel: "AF1 Paris",
+        });
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1"]);
+        expect(Math.abs(result.entities[0].distanceKm - 343.6)).toBeLessThan(3);
+    });
+
+    it("returns emptyReason origin_entity_not_found when the origin entity does not exist", async () => {
+        mockGetEntityDetails.mockResolvedValue({ data: null, emptyReason: "no_data_matches" });
+
+        const result = await findNearbyEntities({
+            originPluginId: "flights",
+            originEntityId: "NOPE",
+            radiusKm: 100,
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success && "emptyReason" in result) {
+            expect(result.emptyReason).toBe("origin_entity_not_found");
+        }
+        expect(result.count).toBe(0);
+        expect((result as { entities: unknown[] }).entities).toEqual([]);
+        expect(mockGetEntitiesInRegion).not.toHaveBeenCalled();
+    });
+
+    it("rejects a lone origin id (plugin + entity are required together)", async () => {
+        const result = await findNearbyEntities({ originEntityId: "AF1" });
+        expect(result.success).toBe(false);
+        if (!result.success && "error" in result) {
+            expect(result.error).toContain("together");
+        }
+    });
+
+    it("queries the bbox region with limit 200 for the target plugin", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({ entities: [ba1London] });
+
+        await findNearbyEntities({
+            lat: LONDON.lat,
+            lon: LONDON.lon,
+            radiusKm: 100,
+            targetPluginIds: ["flights"],
+        });
+
+        const regionArgs = mockGetEntitiesInRegion.mock.calls[0][0];
+        expect(regionArgs.pluginId).toBe("flights");
+        expect(regionArgs.limit).toBe(200);
+        expect(regionArgs.north).toBeGreaterThan(regionArgs.south);
+        expect(regionArgs.east).toBeGreaterThan(regionArgs.west);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin targeting
+// ---------------------------------------------------------------------------
+describe("findNearbyEntities -- plugin targeting", () => {
+    it("searches only the plugins listed in targetPluginIds", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({ entities: [ma1London] });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 100,
+                targetPluginIds: ["maritime"],
+            }),
+        );
+
+        expect(mockGetEntitiesInRegion).toHaveBeenCalledTimes(1);
+        expect(mockGetEntitiesInRegion.mock.calls[0][0].pluginId).toBe("maritime");
+        expect(result.entities.map((e) => e.id)).toEqual(["MA1"]);
+    });
+
+    it("searches all active streaming plugins when targetPluginIds is omitted", async () => {
+        mockListStreamingPlugins.mockResolvedValue({
+            plugins: [
+                { pluginId: "flights", pluginName: "flights", entityCount: 1, entityTypes: [], source: "engine" },
+                { pluginId: "maritime", pluginName: "maritime", entityCount: 1, entityTypes: [], source: "engine" },
+            ],
+        });
+        mockGetEntitiesInRegion
+            .mockResolvedValueOnce({ entities: [ba1London] })
+            .mockResolvedValueOnce({ entities: [ma1London] });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 100,
+            }),
+        );
+
+        expect(mockGetEntitiesInRegion).toHaveBeenCalledTimes(2);
+        const pluginIds = mockGetEntitiesInRegion.mock.calls.map((c) => c[0].pluginId).sort();
+        expect(pluginIds).toEqual(["flights", "maritime"]);
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1", "MA1"]); // merged, nearest-first
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Inline filters
+// ---------------------------------------------------------------------------
+describe("findNearbyEntities -- filters", () => {
+    it("keeps only candidates whose properties match all filters", async () => {
+        const airborne = { id: "BA1", pluginId: "flights", latitude: 51.5, longitude: -0.12, timestamp: new Date(), properties: { status: "airborne" } };
+        const landed = { id: "AF2", pluginId: "flights", latitude: 51.49, longitude: -0.1, timestamp: new Date(), properties: { status: "landed" } };
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [regionEntity("BA1", "flights", 51.5, -0.12), regionEntity("AF2", "flights", 51.49, -0.1)],
+        });
+        mockGetPluginData.mockResolvedValue({
+            data: { pluginId: "flights", entities: [airborne, landed], timestamp: new Date() },
+        });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 100,
+                targetPluginIds: ["flights"],
+                filters: { status: { type: "select", values: ["airborne"] } },
+            }),
+        );
+
+        expect(result.entities.map((e) => e.id)).toEqual(["BA1"]);
+        expect(mockGetPluginData).toHaveBeenCalledWith("flights");
+    });
+
+    it("returns no candidates when the filter snapshot is unavailable", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({ entities: [ba1London] });
+        mockGetPluginData.mockResolvedValue({ data: null, emptyReason: "plugin_not_streaming" });
+
+        const result = successOf(
+            await findNearbyEntities({
+                lat: LONDON.lat,
+                lon: LONDON.lon,
+                radiusKm: 100,
+                targetPluginIds: ["flights"],
+                filters: { status: { type: "select", values: ["airborne"] } },
+            }),
+        );
+
+        expect(result.entities).toEqual([]);
+        expect(result.count).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// MCP tool registration + handler surface
+// ---------------------------------------------------------------------------
+describe("find_nearby_entities tool registration", () => {
+    it("registers the tool with a descriptive schema", () => {
+        const schema = schemas["find_nearby_entities"];
+        expect(schema).toBeDefined();
+        expect(schema.description.length).toBeGreaterThan(0);
+        expect(schema.description).toContain("Example:");
+        expect(schema.description).toContain("emptyReason");
+
+        for (const key of ["lat", "lon", "originPluginId", "originEntityId", "radiusKm", "targetPluginIds", "limit", "filters"]) {
+            expect(schema.inputSchema).toHaveProperty(key);
+        }
+    });
+
+    it("serves a coordinate-based search through the handler with distanceKm annotations", async () => {
+        mockGetEntitiesInRegion.mockResolvedValue({
+            entities: [af1Paris, ba1London],
+        });
+
+        const raw = await handlers["find_nearby_entities"]({
+            lat: LONDON.lat,
+            lon: LONDON.lon,
+            radiusKm: 500,
+            targetPluginIds: ["flights"],
+        });
+        const body = JSON.parse(
+            (raw as { content: Array<{ text: string }> }).content[0].text,
+        ) as {
+            success: boolean;
+            center: { latitude: number; longitude: number };
+            radiusKm: number;
+            count: number;
+            entities: NearbyEntity[];
+        };
+
+        expect(body.success).toBe(true);
+        expect(body.center).toEqual({ latitude: LONDON.lat, longitude: LONDON.lon });
+        expect(body.radiusKm).toBe(500);
+        expect(body.count).toBe(2);
+        expect(body.entities.map((e) => e.id)).toEqual(["BA1", "AF1"]);
+        expect(typeof body.entities[0].distanceKm).toBe("number");
+    });
+
+    it("returns a structured error result when the search fails", async () => {
+        mockGetEntitiesInRegion.mockRejectedValue(new Error("engine down"));
+
+        const raw = await handlers["find_nearby_entities"]({
+            lat: LONDON.lat,
+            lon: LONDON.lon,
+            radiusKm: 500,
+            targetPluginIds: ["flights"],
+        });
+        const body = JSON.parse(
+            (raw as { content: Array<{ text: string }> }).content[0].text,
+        ) as { success: boolean; count: number; error: string };
+
+        expect(body.success).toBe(false);
+        expect(body.count).toBe(0);
+        expect(body.error).toBe("Proximity search failed");
+    });
+});

--- a/src/app/api/mcp/proximityTools.ts
+++ b/src/app/api/mcp/proximityTools.ts
@@ -1,0 +1,105 @@
+/**
+ * MCP Proximity Tool registrar (PR 1).
+ *
+ * Registers one server-side proximity tool:
+ *   find_nearby_entities -- nearest-entity search (coordinate- or entity-based)
+ *                           with true Haversine distance sorting and distanceKm
+ *                           annotations on every result.
+ *
+ * Security:
+ *   - userId comes ONLY from ctx (verified auth result); never from tool args.
+ *   - lat/lon are range-bound by zod; radiusKm/limit are bounded by zod AND
+ *     clamped again inside the service. originPluginId/originEntityId resolve
+ *     entities only through the data-query service layer (never raw engine
+ *     URLs), so plugin/entity ids can never reach the engine path.
+ */
+
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { latSchema, lonSchema } from "@/lib/mcp/coordinateSchemas";
+import { filterValueSchema } from "@/lib/mcp/filterSchemas";
+import { findNearbyEntities } from "@/lib/mcp/proximityService";
+
+type McpTextResult = { content: [{ type: "text"; text: string }] };
+
+function textResult(payload: unknown): McpTextResult {
+    return {
+        content: [{ type: "text", text: JSON.stringify(payload) }],
+    };
+}
+
+export function registerProximityTools(server: McpServer, _ctx: { userId: string }): void {
+    server.registerTool(
+        "find_nearby_entities",
+        {
+            description:
+                "Server-side proximity search for the nearest entities around a center, sorted by true Haversine great-circle distance (nearest first) with distanceKm on every result. " +
+                "This is a READ-ONLY data tool -- it does NOT require an active globe session. " +
+                "Provide the center either as coordinates (lat + lon) or as an existing entity (originPluginId + originEntityId, resolved server-side). " +
+                "radiusKm defaults to 50 (max 1000); entities farther than radiusKm are excluded. " +
+                "If targetPluginIds is omitted, every active streaming plugin is searched. " +
+                "Optional 'filters' apply inline property filters to candidates (independent of set_filter state). " +
+                "Returns emptyReason 'origin_entity_not_found' when the origin entity does not exist. " +
+                "Example: find_nearby_entities({ lat: 51.5074, lon: -0.1278, radiusKm: 100, targetPluginIds: ['flights'], limit: 10 }) " +
+                "Entity-based example: find_nearby_entities({ originPluginId: 'flights', originEntityId: 'BA123', radiusKm: 250 })",
+            inputSchema: {
+                lat: latSchema.describe("Center latitude [-90, 90]"),
+                lon: lonSchema.describe("Center longitude [-180, 180]"),
+                originPluginId: z
+                    .string()
+                    .optional()
+                    .describe("Plugin ID of origin entity to center search around (alternative to lat/lon)"),
+                originEntityId: z
+                    .string()
+                    .optional()
+                    .describe("Entity ID of origin entity to center search around (alternative to lat/lon)"),
+                radiusKm: z
+                    .number()
+                    .positive()
+                    .max(1000)
+                    .optional()
+                    .default(50)
+                    .describe("Search radius in kilometres (default 50, max 1000)"),
+                targetPluginIds: z
+                    .array(z.string())
+                    .optional()
+                    .describe("Optional list of plugin IDs to search within (e.g. ['flights', 'maritime']). If omitted, searches all active plugins."),
+                limit: z
+                    .number()
+                    .int()
+                    .positive()
+                    .max(100)
+                    .optional()
+                    .default(20)
+                    .describe("Maximum entities to return (default 20, max 100, nearest first)"),
+                filters: z
+                    .record(z.string(), filterValueSchema)
+                    .optional()
+                    .describe("Optional property filters applied to candidate entities"),
+            },
+        },
+        async (input) => {
+            try {
+                const result = await findNearbyEntities({
+                    lat: input.lat,
+                    lon: input.lon,
+                    originPluginId: input.originPluginId,
+                    originEntityId: input.originEntityId,
+                    radiusKm: input.radiusKm,
+                    targetPluginIds: input.targetPluginIds,
+                    limit: input.limit,
+                    filters: input.filters,
+                });
+                return textResult(result);
+            } catch (err) {
+                console.error("[proximityTools] find_nearby_entities failed:", err);
+                return textResult({
+                    success: false,
+                    entities: [],
+                    count: 0,
+                    error: "Proximity search failed",
+                });
+            }
+        },
+    );
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -47,6 +47,7 @@ import { registerGeocodingTools } from "./geocodingTools";
 import { registerFavoritesTools } from "./favoritesTools";
 import { registerFilterTools } from "./filterTools";
 import { registerDiscoveryTools } from "./discoveryTools";
+import { registerProximityTools } from "./proximityTools";
 
 // ---------------------------------------------------------------------------
 // Route segment config (TRANS-03)
@@ -178,6 +179,8 @@ async function handleMcpRequest(request: Request): Promise<Response> {
     registerFilterTools(server, { userId: authResult.userId });
     // Phase 29: discovery tools (list_available_plugins, get_globe_context, investigate_area)
     registerDiscoveryTools(server, { userId: authResult.userId });
+    // PR 1: proximity tool (find_nearby_entities -- server-side haversine search)
+    registerProximityTools(server, { userId: authResult.userId });
     // Phase 26: orientation prompts (INST-03, INST-04)
     await registerOrientationPrompts(server, { userId: authResult.userId });
 

--- a/src/lib/mcp/proximityService.ts
+++ b/src/lib/mcp/proximityService.ts
@@ -1,0 +1,263 @@
+/**
+ * Proximity search service for the MCP find_nearby_entities tool (PR 1).
+ *
+ * Provides:
+ *   haversineDistanceKm -- great-circle distance between two coordinates
+ *   findNearbyEntities  -- server-side proximity search (point-to-entities
+ *                          and entity-to-entities) with true Haversine
+ *                          distance sorting and per-entity distanceKm
+ *                          annotations.
+ *
+ * Candidate gathering per plugin:
+ *   1. Resolve the center (lat/lon or the origin entity via getEntityDetails).
+ *   2. Compute a bounding box with radiusKmToBbox and query candidate
+ *      entities via getEntitiesInRegion (per-plugin, capped at 200).
+ *   3. Optional inline filters are matched against the plugin snapshot
+ *      properties (RegionOptions carries no filter field), then candidates
+ *      are intersected by id.
+ *   4. Refine each candidate with haversine distance <= radiusKm, exclude the
+ *      origin entity itself for entity-based queries, sort nearest-first,
+ *      and truncate to limit.
+ *
+ * No `any`, no `@ts-ignore`. All external I/O is delegated to the data-query
+ * service and discovery helper imports below.
+ */
+
+import type { FilterValue } from "@/core/plugins/PluginTypes";
+import { matchFilterValue } from "@/core/filters/matchFilterValue";
+import type { SearchResult } from "@/lib/data-query/types";
+import {
+    getEntitiesInRegion,
+    getEntityDetails,
+    getPluginData,
+} from "@/lib/data-query/service";
+import {
+    listStreamingPlugins,
+    radiusKmToBbox,
+} from "@/app/api/mcp/discoveryHelpers";
+
+/** Mean Earth radius in kilometres used by the haversine formula. */
+const EARTH_RADIUS_KM = 6371;
+
+/** Default search radius when the caller does not specify one. */
+const DEFAULT_RADIUS_KM = 50;
+
+/** Upper bound for radiusKm (schema enforces it too; clamped defensively). */
+const MAX_RADIUS_KM = 1000;
+
+/** Default result cap when the caller does not specify a limit. */
+const DEFAULT_LIMIT = 20;
+
+/** Upper bound for the returned entity count. */
+const MAX_LIMIT = 100;
+
+/** Per-plugin candidate cap passed to the bbox region query. */
+const REGION_CANDIDATE_CAP = 200;
+
+/**
+ * Great-circle distance between two WGS84 coordinates in kilometres
+ * (haversine formula, Earth radius 6371 km).
+ */
+export function haversineDistanceKm(
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number,
+): number {
+    const toRad = (deg: number): number => (deg * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+        Math.sin(dLat / 2) ** 2 +
+        Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    // Clamp to [0, 1] so floating-point overshoot can never produce NaN.
+    return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(Math.min(a, 1)));
+}
+
+/** A region candidate annotated with its distance from the search center. */
+export interface NearbyEntity extends SearchResult {
+    distanceKm: number;
+}
+
+export interface FindNearbyOptions {
+    /** Center latitude [-90, 90] -- alternative to originPluginId/originEntityId. */
+    lat?: number;
+    /** Center longitude [-180, 180] -- alternative to originPluginId/originEntityId. */
+    lon?: number;
+    /** Plugin ID of the origin entity to center the search around. */
+    originPluginId?: string;
+    /** Entity ID of the origin entity to center the search around. */
+    originEntityId?: string;
+    /** Search radius in kilometres (default 50, max 1000). */
+    radiusKm?: number;
+    /** Optional plugin IDs to search within; when omitted, all active plugins. */
+    targetPluginIds?: string[];
+    /** Maximum entities to return (default 20, max 100, nearest first). */
+    limit?: number;
+    /** Optional inline property filters applied to candidate entities. */
+    filters?: Record<string, FilterValue>;
+}
+
+export type FindNearbySuccess = {
+    success: true;
+    center: {
+        latitude: number;
+        longitude: number;
+        originPluginId?: string;
+        originEntityId?: string;
+        originLabel?: string;
+    };
+    radiusKm: number;
+    count: number;
+    entities: NearbyEntity[];
+};
+
+export type FindNearbyResult =
+    | FindNearbySuccess
+    | { success: false; entities: []; count: 0; emptyReason: "origin_entity_not_found" }
+    | { success: false; entities: []; count: 0; error: string };
+
+/**
+ * Returns the ids of a plugin's entities whose properties match ALL provided
+ * filters. Returns null when the plugin snapshot is unavailable -- callers
+ * treat that as "no candidates" rather than an all-match fallback (matches
+ * the conservative empty semantics of the other data-query tools).
+ */
+async function filterMatchingEntityIds(
+    pluginId: string,
+    filters: Record<string, FilterValue>,
+): Promise<Set<string> | null> {
+    const snapshot = await getPluginData(pluginId);
+    if (snapshot.data === null) return null;
+
+    const entries = Object.entries(filters);
+    const ids = new Set<string>();
+    for (const entity of snapshot.data.entities) {
+        if (entries.every(([key, filter]) => matchFilterValue(entity.properties[key], filter))) {
+            ids.add(entity.id);
+        }
+    }
+    return ids;
+}
+
+/**
+ * Server-side proximity search: nearest-first entities around a center point
+ * (coordinates or an origin entity), sorted by true haversine distance with
+ * per-entity distanceKm.
+ */
+export async function findNearbyEntities(opts: FindNearbyOptions): Promise<FindNearbyResult> {
+    // ------------------------------------------------------------------
+    // Resolve the search center (coordinates or origin entity).
+    // ------------------------------------------------------------------
+    const hasOrigin = opts.originPluginId !== undefined || opts.originEntityId !== undefined;
+    if (hasOrigin) {
+        if (opts.originPluginId === undefined || opts.originEntityId === undefined) {
+            return {
+                success: false,
+                entities: [],
+                count: 0,
+                error: "originPluginId and originEntityId must be provided together",
+            };
+        }
+    } else if (opts.lat === undefined || opts.lon === undefined) {
+        return {
+            success: false,
+            entities: [],
+            count: 0,
+            error: "A center is required: provide lat + lon or originPluginId + originEntityId",
+        };
+    }
+
+    let centerLat: number;
+    let centerLon: number;
+    let originLabel: string | undefined;
+
+    if (opts.originPluginId !== undefined && opts.originEntityId !== undefined) {
+        const detail = await getEntityDetails(opts.originPluginId, opts.originEntityId);
+        if (detail.data === null) {
+            return { success: false, entities: [], count: 0, emptyReason: "origin_entity_not_found" };
+        }
+        centerLat = detail.data.latitude;
+        centerLon = detail.data.longitude;
+        originLabel = detail.data.label;
+    } else {
+        centerLat = opts.lat as number;
+        centerLon = opts.lon as number;
+    }
+
+    const radiusKm = Math.min(Math.max(opts.radiusKm ?? DEFAULT_RADIUS_KM, 0.001), MAX_RADIUS_KM);
+    const limit = Math.min(Math.max(opts.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+    // ------------------------------------------------------------------
+    // Resolve the target plugin set.
+    // ------------------------------------------------------------------
+    let pluginIds: string[];
+    if (opts.targetPluginIds !== undefined && opts.targetPluginIds.length > 0) {
+        pluginIds = Array.from(new Set(opts.targetPluginIds));
+    } else {
+        const plugins = await listStreamingPlugins();
+        pluginIds = plugins.plugins.map((p) => p.pluginId);
+    }
+
+    const bbox = radiusKmToBbox(centerLat, centerLon, radiusKm);
+    const isEntityCentered = opts.originEntityId !== undefined && opts.originPluginId !== undefined;
+
+    // ------------------------------------------------------------------
+    // Gather + refine candidates per plugin.
+    // ------------------------------------------------------------------
+    const found: NearbyEntity[] = [];
+    for (const pluginId of pluginIds) {
+        const region = await getEntitiesInRegion({
+            ...bbox,
+            pluginId,
+            limit: REGION_CANDIDATE_CAP,
+        });
+
+        let candidates = region.entities;
+        const filters = opts.filters;
+        if (filters !== undefined && Object.keys(filters).length > 0) {
+            const allowed = await filterMatchingEntityIds(pluginId, filters);
+            if (allowed === null) continue; // snapshot unavailable -> no candidates
+            candidates = candidates.filter((c) => allowed.has(c.id));
+        }
+
+        for (const candidate of candidates) {
+            if (
+                isEntityCentered &&
+                candidate.pluginId === opts.originPluginId &&
+                candidate.id === opts.originEntityId
+            ) {
+                continue; // never report the origin entity against itself
+            }
+            const distanceKm = haversineDistanceKm(
+                centerLat,
+                centerLon,
+                candidate.latitude,
+                candidate.longitude,
+            );
+            if (distanceKm > radiusKm) continue;
+            found.push({ ...candidate, distanceKm });
+        }
+    }
+
+    found.sort((a, b) => a.distanceKm - b.distanceKm);
+    const entities = found.slice(0, limit);
+
+    return {
+        success: true,
+        center: {
+            latitude: centerLat,
+            longitude: centerLon,
+            ...(isEntityCentered
+                ? {
+                      originPluginId: opts.originPluginId as string,
+                      originEntityId: opts.originEntityId as string,
+                      ...(originLabel !== undefined && { originLabel }),
+                  }
+                : {}),
+        },
+        radiusKm,
+        count: entities.length,
+        entities,
+    };
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -41,14 +41,14 @@ MENTAL MODEL
 
 CAPABILITIES
 - Globe command tools (require a live browser session): pan_globe, focus_entity, toggle_layer, set_timeline.
-- Data query tools (server-side, NO session required): search_entities, get_entities_in_region, get_entity_details, get_plugin_data.
+- Data query tools (server-side, NO session required): search_entities, get_entities_in_region, get_entity_details, get_plugin_data, find_nearby_entities.
 - Discovery tools: list_available_plugins, get_globe_context, investigate_area.
 - Filter tools: set_filter, clear_filter, get_plugin_filters.
 - Resources (read): globe://sessions, globe://state/{sessionId}, globe://layers.
 - Plugin tools (dynamic): extra tools named "<pluginId>__<toolName>" appear after a browser tab loads that plugin. This server is stateless; re-call tools/list to discover them after enabling a plugin.
 
 TWO TOOL CATEGORIES
-1. Data query tools (search_entities, get_entities_in_region, get_entity_details, get_plugin_data) run on the server and return real data WITHOUT a browser session. emptyReason values: "plugin_not_streaming" (plugin not active), "no_data_matches" (query ran, nothing matched).
+1. Data query tools (search_entities, get_entities_in_region, get_entity_details, get_plugin_data, find_nearby_entities) run on the server and return real data WITHOUT a browser session. emptyReason values: "plugin_not_streaming" (plugin not active), "no_data_matches" (query ran, nothing matched).
 2. Command tools (pan_globe, focus_entity, toggle_layer, set_timeline, set_filter, clear_filter) enqueue browser commands. They require an active globe session and return "no active globe session to control" when none exists.
 
 DATA AVAILABILITY


### PR DESCRIPTION
## Summary
Adds the \ind_nearby_entities\ tool to the WorldWideView MCP server for AI agents.

### Features
- **Dual search modes**:
  1. Coordinate-based: \{ lat, lon, radiusKm, targetPluginIds, limit, filters }\
  2. Entity-based: \{ originPluginId, originEntityId, radiusKm, targetPluginIds, limit, filters }\
- **Server-side Haversine distance calculation**:
  - Calculates true great-circle distance (Earth radius 6,371 km).
  - Automatically sorts nearest-first and annotates every result with \distanceKm\.
  - Excludes origin entity from entity-based searches.
- **Fast candidate bounding-box narrowing**: uses \adiusKmToBbox\ to narrow candidates via \getEntitiesInRegion\ before computing exact distances.
- **Inline property filters**: supports filtering candidates by plugin property values with snapshot intersection.
- **Discriminated error contracts**: returns \mptyReason: 'origin_entity_not_found'\ when an entity-based center does not exist.

### Verification
- 18 Vitest test files passing (313 tests total, including 20 new tests in \proximityTools.test.ts\).
- Strict TypeScript verification passed (\	sc --noEmit\ exit 0).