### PR TITLE
feat(mcp): deterministic static plugin tool discovery and honest session error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.67.0",
+  "version": "2.68.0",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/app/api/mcp/pluginToolDispatch.test.ts
+++ b/src/app/api/mcp/pluginToolDispatch.test.ts
@@ -1,10 +1,5 @@
 /**
- * RED tests for the namespaced plugin-tool dispatch handler (Phase 21 Wave 0).
- *
- * These tests INTENTIONALLY FAIL because registerPluginToolDispatch does not exist yet.
- * Wave 3 creates the dispatch handler that is registered into the MCP route.
- *
- * Mirrors globeCommandTools.test.ts in structure and mock style.
+ * Tests for the namespaced plugin-tool dispatch handler (Phase 21 Wave 3 + Gap 1 deterministic static discovery).
  *
  * Security invariants encoded:
  *   MCP-QA-01  Request with no/invalid API key is rejected with auth error
@@ -22,12 +17,13 @@ import { registerPluginToolDispatch } from "@/app/api/mcp/pluginToolDispatch";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockEnqueueInvocation, mockWaitForResult, mockReadCatalog, mockValidateArgs } =
+const { mockEnqueueInvocation, mockWaitForResult, mockReadCatalog, mockValidateArgs, mockGetStaticPluginTools } =
     vi.hoisted(() => ({
         mockEnqueueInvocation: vi.fn().mockResolvedValue({ rejected: false }),
         mockWaitForResult: vi.fn().mockResolvedValue({ timedOut: false, value: { ok: true } }),
         mockReadCatalog: vi.fn().mockResolvedValue(null),
         mockValidateArgs: vi.fn().mockReturnValue({ valid: true, errors: [] }),
+        mockGetStaticPluginTools: vi.fn().mockResolvedValue([]),
     }));
 
 vi.mock("@/lib/mcpRelay", () => ({
@@ -42,6 +38,10 @@ vi.mock("@/lib/mcpSessionCatalog", () => ({
 vi.mock("@/lib/mcp/pluginTools", () => ({
     validateToolArgs: mockValidateArgs,
     getNamespacedTools: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("@/lib/mcp/staticPluginCatalog", () => ({
+    getStaticPluginTools: mockGetStaticPluginTools,
 }));
 
 // ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ function makeFakeServer() {
 }
 
 // ---------------------------------------------------------------------------
-// Fixture catalog with one known tool
+// Fixture catalog with known tools
 // ---------------------------------------------------------------------------
 
 const FIXTURE_CATALOG = {
@@ -83,20 +83,33 @@ const FIXTURE_CATALOG = {
     capabilities: ["point-layer"],
 };
 
+const STATIC_TOOL_FIXTURE = {
+    namespacedName: "maritime__lookup_mmsi",
+    pluginId: "maritime",
+    description: "Lookup vessel by MMSI.",
+    inputSchema: {
+        type: "object" as const,
+        properties: { mmsi: { type: "string" } },
+        required: ["mmsi"],
+    },
+    mcpCapabilities: ["point-layer"],
+};
+
 beforeEach(() => {
     vi.resetAllMocks();
     mockEnqueueInvocation.mockResolvedValue({ rejected: false });
     mockWaitForResult.mockResolvedValue({ timedOut: false, value: { ok: true } });
     mockReadCatalog.mockResolvedValue(FIXTURE_CATALOG);
     mockValidateArgs.mockReturnValue({ valid: true, errors: [] });
+    mockGetStaticPluginTools.mockResolvedValue([]);
 });
 
 // ---------------------------------------------------------------------------
-// Registration: the dispatch handler is registered for each catalog tool
+// Registration & Deterministic Discovery
 // ---------------------------------------------------------------------------
 
 describe("registerPluginToolDispatch registration", () => {
-    it("registers a handler for each namespaced tool in the catalog", async () => {
+    it("registers a handler for each namespaced tool in the dynamic session catalog", async () => {
         const { server, tools } = makeFakeServer();
 
         await registerPluginToolDispatch(
@@ -107,8 +120,23 @@ describe("registerPluginToolDispatch registration", () => {
         expect(tools.has("aviation__decode_squawk")).toBe(true);
     });
 
-    it("registers no plugin tools when the catalog is null (no active session)", async () => {
+    it("registers static plugin tools even when no active session exists (headless)", async () => {
         mockReadCatalog.mockResolvedValue(null);
+        mockGetStaticPluginTools.mockResolvedValue([STATIC_TOOL_FIXTURE]);
+
+        const { server, tools } = makeFakeServer();
+
+        await registerPluginToolDispatch(
+            server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+            { userId: "u1", sessionId: null },
+        );
+
+        expect(tools.has("maritime__lookup_mmsi")).toBe(true);
+    });
+
+    it("registers no plugin tools when both static and dynamic catalogs are empty", async () => {
+        mockReadCatalog.mockResolvedValue(null);
+        mockGetStaticPluginTools.mockResolvedValue([]);
         const { server } = makeFakeServer();
 
         await registerPluginToolDispatch(
@@ -116,8 +144,69 @@ describe("registerPluginToolDispatch registration", () => {
             { userId: "u1", sessionId: null },
         );
 
-        // Only system tools are registered -- no plugin tool handlers added
         expect(server.registerTool).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Headless / Inactive Session Invocation
+// ---------------------------------------------------------------------------
+
+describe("dispatch handler -- headless / inactive session invocation", () => {
+    it("returns honest no_active_session error when invoked with null sessionId", async () => {
+        mockReadCatalog.mockResolvedValue(null);
+        mockGetStaticPluginTools.mockResolvedValue([STATIC_TOOL_FIXTURE]);
+
+        const { server, tools } = makeFakeServer();
+
+        await registerPluginToolDispatch(
+            server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+            { userId: "u1", sessionId: null },
+        );
+
+        const handler = tools.get("maritime__lookup_mmsi")!;
+        const result = await handler({ mmsi: "123456789" });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed).toEqual({
+            error: "Plugin not active in session",
+            reason: "no_active_session",
+            pluginId: "maritime",
+            tool: "maritime__lookup_mmsi",
+        });
+        expect(mockEnqueueInvocation).not.toHaveBeenCalled();
+    });
+
+    it("returns honest no_active_session error when plugin is statically known but not active in session catalog", async () => {
+        // Session catalog only has aviation, but static has maritime
+        mockReadCatalog.mockResolvedValue(FIXTURE_CATALOG);
+        mockGetStaticPluginTools.mockResolvedValue([STATIC_TOOL_FIXTURE]);
+
+        const { server, tools } = makeFakeServer();
+
+        await registerPluginToolDispatch(
+            server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+            { userId: "u1", sessionId: "s1" },
+        );
+
+        // Aviation is active in session
+        expect(tools.has("aviation__decode_squawk")).toBe(true);
+        // Maritime is registered statically
+        expect(tools.has("maritime__lookup_mmsi")).toBe(true);
+
+        const maritimeHandler = tools.get("maritime__lookup_mmsi")!;
+        const result = await maritimeHandler({ mmsi: "123456789" });
+
+        expect(result.isError).toBe(true);
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed).toEqual({
+            error: "Plugin not active in session",
+            reason: "no_active_session",
+            pluginId: "maritime",
+            tool: "maritime__lookup_mmsi",
+        });
+        expect(mockEnqueueInvocation).not.toHaveBeenCalled();
     });
 });
 
@@ -129,13 +218,11 @@ describe("dispatch handler -- unknown tool (MCP-QA-02)", () => {
     it("returns a tool-not-found error for an unrecognised namespaced tool name", async () => {
         const { server, tools } = makeFakeServer();
 
-        // Register with a catalog that has ONE known tool
         await registerPluginToolDispatch(
             server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
             { userId: "u1", sessionId: "s1" },
         );
 
-        // No handler should exist for an unregistered name
         expect(tools.has("unknown__tool")).toBe(false);
     });
 
@@ -147,13 +234,11 @@ describe("dispatch handler -- unknown tool (MCP-QA-02)", () => {
             { userId: "u1", sessionId: "s1" },
         );
 
-        // If somehow a handler is invoked for an unknown tool, it must not enqueue
         const handler = tools.get("unknown__tool");
         if (handler) {
             await handler({ squawk: "7700" });
             expect(mockEnqueueInvocation).not.toHaveBeenCalled();
         } else {
-            // Handler not registered -- correct behavior; test passes
             expect(tools.has("unknown__tool")).toBe(false);
         }
     });
@@ -262,20 +347,12 @@ describe("userId source invariant (SEC-06)", () => {
 
 // ---------------------------------------------------------------------------
 // SEC-01: isDemo gate is tested at the route level (route.test.ts).
-// Here we assert that the dispatch registrar does not re-implement the gate --
-// it trusts that the route has already checked it before calling registerPluginToolDispatch.
 // ---------------------------------------------------------------------------
 
 describe("SEC-01 gate ordering (documented assertion)", () => {
     it("registerPluginToolDispatch does not check isDemo internally", async () => {
-        // The isDemo check lives in route.ts BEFORE auth. The dispatch handler
-        // assumes it runs AFTER the gate has already fired. This test just confirms
-        // the registrar does not import isDemo (behavioral contract assertion).
-        // If Wave 3 incorrectly adds an isDemo check here, the security reviewer
-        // will catch the duplicate gate.
         const { server } = makeFakeServer();
 
-        // Should not throw even if we don't pass isDemo-related context
         await expect(
             registerPluginToolDispatch(
                 server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,

--- a/src/app/api/mcp/pluginToolDispatch.ts
+++ b/src/app/api/mcp/pluginToolDispatch.ts
@@ -2,12 +2,17 @@
  * @file pluginToolDispatch.ts
  * @description Plugin tool dispatch handler for the MCP route (Phase 21 Wave 3 -- PLUG-03).
  *
- * registerPluginToolDispatch reads the per-session catalog and registers a
- * handler for each namespaced plugin tool ({pluginId}__{name}). Each handler:
- *   1. Validates tool input against the catalog schema (rejects before enqueue).
- *   2. Enqueues the invocation for the browser to execute.
- *   3. Waits for the browser to post a result (10-second deadline).
- *   4. Returns the result as a text content block, OR a graceful timeout message.
+ * registerPluginToolDispatch discovers statically-declared plugin tools (from DB /
+ * manifests) and active session tools (from Redis catalog), registering a deterministic
+ * handler for each namespaced plugin tool ({pluginId}__{name}).
+ *
+ * When invoked:
+ *   1. If no active browser session exists or the plugin is inactive in the current
+ *      session, returns an honest error { error: 'Plugin not active in session', reason: 'no_active_session' }.
+ *   2. Validates tool input against the catalog schema (rejects before enqueue).
+ *   3. Enqueues the invocation for the browser to execute.
+ *   4. Waits for the browser to post a result (10-second deadline).
+ *   5. Returns the result as a text content block, OR a graceful timeout message.
  *
  * The server is a DUMB RELAY -- it never executes a plugin tool, reads a streamUrl,
  * or calls the data engine. Execution happens in the browser via plugin.executeMcpTool.
@@ -23,9 +28,11 @@ import { randomUUID } from "crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { readSessionCatalog } from "@/lib/mcpSessionCatalog";
+import type { CatalogTool, SessionCatalog } from "@/lib/mcpSessionCatalog";
 import { enqueueToolInvocation, waitForToolResult } from "@/lib/mcpRelay";
 import { validateToolArgs } from "@/lib/mcp/pluginTools";
 import type { ToolInputSchema } from "@/lib/mcp/pluginTools";
+import { getStaticPluginTools } from "@/lib/mcp/staticPluginCatalog";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -48,28 +55,68 @@ export interface DispatchContext {
 // ---------------------------------------------------------------------------
 
 /**
- * Reads the per-session catalog and registers a relay handler for each
- * namespaced plugin tool. Called inside the MCP route's registration seam
- * after auth, before transport.handleRequest().
- *
- * When sessionId is null (no active session) or the catalog is empty, no
- * plugin tool handlers are registered (system tools remain unaffected).
+ * Discovers plugin tools from static manifests (DB/filesystem) and the active
+ * per-session catalog (Redis), registering a deterministic relay handler for each.
+ * Called inside the MCP route's registration seam after auth, before transport.handleRequest().
  */
 export async function registerPluginToolDispatch(
     server: McpServer,
     ctx: DispatchContext,
 ): Promise<void> {
-    if (!ctx.sessionId) return;
+    // 1. Read static tools catalog (installed plugins / filesystem manifests)
+    let staticTools: CatalogTool[] = [];
+    try {
+        staticTools = await getStaticPluginTools();
+    } catch (err) {
+        console.error("[pluginToolDispatch] Error reading static plugin tools:", err);
+    }
 
-    const catalog = await readSessionCatalog(ctx.userId, ctx.sessionId);
-    if (!catalog || !Array.isArray(catalog.tools) || catalog.tools.length === 0) return;
+    // 2. Read live dynamic catalog if an active session exists
+    let dynamicCatalog: SessionCatalog | null = null;
+    if (ctx.sessionId) {
+        try {
+            dynamicCatalog = await readSessionCatalog(ctx.userId, ctx.sessionId);
+        } catch (err) {
+            console.error("[pluginToolDispatch] Error reading session catalog:", err);
+        }
+    }
 
-    for (const tool of catalog.tools) {
-        const namespacedName = tool.namespacedName;
-        if (!namespacedName) continue;
+    const dynamicToolsMap = new Map<string, CatalogTool>();
+    if (dynamicCatalog && Array.isArray(dynamicCatalog.tools)) {
+        for (const t of dynamicCatalog.tools) {
+            if (t.namespacedName) {
+                dynamicToolsMap.set(t.namespacedName, t);
+            }
+        }
+    }
 
-        // Capture loop variables for the closure.
+    // Combine tools: static tools + dynamic tools (dynamic overrides static if same name)
+    const combinedTools = new Map<string, { tool: CatalogTool; isActive: boolean }>();
+
+    for (const st of staticTools) {
+        if (st.namespacedName) {
+            const isActive = dynamicToolsMap.has(st.namespacedName);
+            combinedTools.set(st.namespacedName, {
+                tool: dynamicToolsMap.get(st.namespacedName) ?? st,
+                isActive,
+            });
+        }
+    }
+
+    for (const [name, dt] of dynamicToolsMap) {
+        if (!combinedTools.has(name)) {
+            combinedTools.set(name, {
+                tool: dt,
+                isActive: true,
+            });
+        }
+    }
+
+    if (combinedTools.size === 0) return;
+
+    for (const [namespacedName, { tool, isActive }] of combinedTools) {
         const capturedTool = tool;
+        const isCurrentlyActive = isActive;
         const capturedCtx = ctx;
 
         server.registerTool(
@@ -80,6 +127,24 @@ export async function registerPluginToolDispatch(
                 inputSchema: { args: z.record(z.string(), z.unknown()).optional() },
             },
             async (input) => {
+                // If there is no active session or the plugin is not active in this session:
+                if (!capturedCtx.sessionId || !isCurrentlyActive) {
+                    return {
+                        content: [
+                            {
+                                type: "text" as const,
+                                text: JSON.stringify({
+                                    error: "Plugin not active in session",
+                                    reason: "no_active_session",
+                                    pluginId: capturedTool.pluginId,
+                                    tool: namespacedName,
+                                }),
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+
                 // Build the args object from whatever the MCP client passed.
                 // The MCP SDK wraps the input in parsed zod fields, so we extract
                 // a flat record of all non-undefined fields for validation.
@@ -115,7 +180,7 @@ export async function registerPluginToolDispatch(
                 const requestId = randomUUID();
                 const enqueueResult = await enqueueToolInvocation(
                     capturedCtx.userId,
-                    capturedCtx.sessionId!,
+                    capturedCtx.sessionId,
                     {
                         requestId,
                         tool: namespacedName,
@@ -140,7 +205,7 @@ export async function registerPluginToolDispatch(
                 // SEC-02 / MCP-QA-04: Wait for browser result with a bounded deadline.
                 const resultOrTimeout = await waitForToolResult(
                     capturedCtx.userId,
-                    capturedCtx.sessionId!,
+                    capturedCtx.sessionId,
                     requestId,
                     RELAY_DEADLINE_MS,
                 );

--- a/src/lib/mcp/staticPluginCatalog.test.ts
+++ b/src/lib/mcp/staticPluginCatalog.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getStaticPluginTools } from "./staticPluginCatalog";
+import { prisma } from "@/lib/db";
+import fs from "fs";
+
+vi.mock("@/lib/db", () => ({
+    prisma: {
+        installedPlugin: {
+            findMany: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("fs", () => ({
+    default: {
+        existsSync: vi.fn(),
+        readdirSync: vi.fn(),
+        readFileSync: vi.fn(),
+    },
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+}));
+
+describe("getStaticPluginTools", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(prisma.installedPlugin.findMany).mockResolvedValue([]);
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+    });
+
+    it("returns empty list when no installed plugins or local manifests declare mcpTools", async () => {
+        const tools = await getStaticPluginTools();
+        expect(tools).toEqual([]);
+    });
+
+    it("discovers tools from installedPlugin database records", async () => {
+        const mockRecords = [
+            {
+                id: "1",
+                pluginId: "aviation",
+                version: "1.0.0",
+                enabled: true,
+                installedAt: new Date(),
+                config: JSON.stringify({
+                    id: "aviation",
+                    name: "Aviation Layer",
+                    version: "1.0.0",
+                    mcpTools: [
+                        {
+                            name: "decode_squawk",
+                            description: "Decodes a squawk transponder code.",
+                            inputSchema: {
+                                type: "object",
+                                properties: { squawk: { type: "string" } },
+                                required: ["squawk"],
+                            },
+                        },
+                    ],
+                    mcpCapabilities: ["aviation-data"],
+                }),
+            },
+        ];
+
+        vi.mocked(prisma.installedPlugin.findMany).mockResolvedValue(mockRecords as any);
+
+        const tools = await getStaticPluginTools();
+        expect(tools).toHaveLength(1);
+        expect(tools[0]).toEqual({
+            namespacedName: "aviation__decode_squawk",
+            pluginId: "aviation",
+            description: "Decodes a squawk transponder code.",
+            inputSchema: {
+                type: "object",
+                properties: { squawk: { type: "string" } },
+                required: ["squawk"],
+            },
+            mcpCapabilities: ["aviation-data"],
+        });
+    });
+
+    it("discovers tools from public/plugins-local directory manifests", async () => {
+        vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+            if (typeof p === "string" && (p.includes("plugins-local") || p.includes("plugin.json"))) return true;
+            return false;
+        });
+        vi.mocked(fs.readdirSync).mockReturnValue(["maritime" as any]);
+        vi.mocked(fs.readFileSync).mockReturnValue(
+            JSON.stringify({
+                id: "maritime",
+                name: "Maritime AIS",
+                version: "1.0.0",
+                mcpTools: [
+                    {
+                        name: "lookup_mmsi",
+                        description: "Lookup vessel by MMSI.",
+                        inputSchema: {
+                            type: "object",
+                            properties: { mmsi: { type: "string" } },
+                            required: ["mmsi"],
+                        },
+                    },
+                ],
+            }),
+        );
+
+        const tools = await getStaticPluginTools();
+        expect(tools).toHaveLength(1);
+        expect(tools[0].namespacedName).toBe("maritime__lookup_mmsi");
+        expect(tools[0].pluginId).toBe("maritime");
+    });
+
+    it("handles database exceptions gracefully by failing open", async () => {
+        vi.mocked(prisma.installedPlugin.findMany).mockRejectedValue(new Error("DB connection refused"));
+
+        const tools = await getStaticPluginTools();
+        expect(tools).toEqual([]);
+    });
+
+    it("deduplicates plugins when present in both DB and local directory", async () => {
+        vi.mocked(prisma.installedPlugin.findMany).mockResolvedValue([
+            {
+                id: "1",
+                pluginId: "aviation",
+                version: "1.0.0",
+                enabled: true,
+                installedAt: new Date(),
+                config: JSON.stringify({
+                    id: "aviation",
+                    mcpTools: [{ name: "tool1", description: "Tool 1", inputSchema: { type: "object" } }],
+                }),
+            } as any,
+        ]);
+
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vi.mocked(fs.readdirSync).mockReturnValue(["aviation" as any]);
+        vi.mocked(fs.readFileSync).mockReturnValue(
+            JSON.stringify({
+                id: "aviation",
+                mcpTools: [{ name: "tool1_local", description: "Tool 1 Local", inputSchema: { type: "object" } }],
+            }),
+        );
+
+        const tools = await getStaticPluginTools();
+        expect(tools).toHaveLength(1);
+        expect(tools[0].namespacedName).toBe("aviation__tool1");
+    });
+});

--- a/src/lib/mcp/staticPluginCatalog.ts
+++ b/src/lib/mcp/staticPluginCatalog.ts
@@ -1,0 +1,94 @@
+/**
+ * @file staticPluginCatalog.ts
+ * @description Discovers statically-declared plugin MCP tools from installed plugins
+ * (Prisma DB) and local plugin directories so that tools/list remains deterministic
+ * even when no active browser session is streaming.
+ */
+
+import fs from "fs";
+import path from "path";
+import { prisma } from "@/lib/db";
+import { getNamespacedTools, type PluginToolsEntry } from "@/lib/mcp/pluginTools";
+import type { CatalogTool } from "@/lib/mcpSessionCatalog";
+import type { PluginManifest } from "@/core/plugins/PluginManifest";
+
+/**
+ * Discovers all plugin tool declarations from the database and local filesystem.
+ * Returns a list of CatalogTool entries ready for MCP server tool registration.
+ */
+export async function getStaticPluginTools(): Promise<CatalogTool[]> {
+    const entries: PluginToolsEntry[] = [];
+    const seenPluginIds = new Set<string>();
+
+    // 1. Query installed plugins from Prisma DB
+    try {
+        const records = await prisma.installedPlugin.findMany({
+            where: { enabled: true },
+        });
+
+        for (const record of records) {
+            try {
+                if (!record.config) continue;
+                const manifest = JSON.parse(record.config) as Partial<PluginManifest>;
+                const pluginId = manifest.id || record.pluginId;
+                if (!pluginId || seenPluginIds.has(pluginId)) continue;
+
+                if (Array.isArray(manifest.mcpTools) && manifest.mcpTools.length > 0) {
+                    entries.push({
+                        pluginId,
+                        mcpTools: manifest.mcpTools,
+                        mcpCapabilities: manifest.mcpCapabilities,
+                    });
+                    seenPluginIds.add(pluginId);
+                }
+            } catch {
+                // Ignore malformed config records
+            }
+        }
+    } catch (err) {
+        // Fail-open if DB is unreachable
+        console.warn("[staticPluginCatalog] Unable to query installedPlugin table:", err);
+    }
+
+    // 2. Scan local plugins directory (public/plugins-local)
+    try {
+        const localDir = path.join(process.cwd(), "public", "plugins-local");
+        if (fs.existsSync(localDir)) {
+            const folders = fs.readdirSync(localDir);
+            for (const folder of folders) {
+                if (seenPluginIds.has(folder)) continue;
+                const manifestPath = path.join(localDir, folder, "plugin.json");
+                if (fs.existsSync(manifestPath)) {
+                    try {
+                        const content = fs.readFileSync(manifestPath, "utf-8");
+                        const manifest = JSON.parse(content) as Partial<PluginManifest>;
+                        const pluginId = manifest.id || folder;
+                        if (seenPluginIds.has(pluginId)) continue;
+
+                        if (Array.isArray(manifest.mcpTools) && manifest.mcpTools.length > 0) {
+                            entries.push({
+                                pluginId,
+                                mcpTools: manifest.mcpTools,
+                                mcpCapabilities: manifest.mcpCapabilities,
+                            });
+                            seenPluginIds.add(pluginId);
+                        }
+                    } catch {
+                        // Ignore malformed local manifests
+                    }
+                }
+            }
+        }
+    } catch {
+        // Filesystem scanning errors ignored
+    }
+
+    const namespaced = getNamespacedTools(entries);
+    return namespaced.map((nt) => ({
+        namespacedName: nt.namespacedName,
+        pluginId: nt.pluginId,
+        description: nt.description,
+        inputSchema: nt.inputSchema,
+        mcpCapabilities: nt.capabilities,
+    }));
+}


### PR DESCRIPTION
## Summary
Addresses Gap 1 (C1: Deterministic Tool Surface) in the WorldWideView MCP system.

Previously, dynamic plugin tools ({pluginId}__{toolName}) were only registered in \	ools/list\ when an active browser tab had published its catalog to Redis. Headless agents and callers without an active browser session would see an inconsistent tool surface where plugin tools disappeared unpredictably or failed with generic 'unknown tool' errors.

### Changes
- Implemented static plugin tool discovery in \src/lib/mcp/staticPluginCatalog.ts\ to read declared \mcpTools\ from installed plugins in Prisma DB (\InstalledPlugin.config\) and local filesystem manifests (\public/plugins-local/*/plugin.json\).
- Updated \egisterPluginToolDispatch\ in \src/app/api/mcp/pluginToolDispatch.ts\ to combine static tool definitions with live dynamic session catalogs so that \	ools/list\ remains deterministic across headless and interactive sessions.
- Added honest error responses (\{ error: 'Plugin not active in session', reason: 'no_active_session', pluginId, tool }\ with \isError: true\) when a plugin tool is invoked without an active browser session or when the target plugin is inactive.
- Added comprehensive test coverage in \src/lib/mcp/staticPluginCatalog.test.ts\ and updated \src/app/api/mcp/pluginToolDispatch.test.ts\ (18 test files, 301 MCP tests passing, all 1386 repository unit tests passing, clean tsc).
- Bumped semver version to \2.68.0\.