### PR TITLE
feat(mcp): add get_regional_analytics for spatial aggregation and density clustering

### DIFF
--- a/src/app/api/mcp/regionalAnalyticsTools.test.ts
+++ b/src/app/api/mcp/regionalAnalyticsTools.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerRegionalAnalyticsTools } from "./regionalAnalyticsTools";
+import { getRegionalAnalytics } from "@/lib/mcp/regionalAnalyticsService";
+
+vi.mock("@/lib/mcp/regionalAnalyticsService", () => ({
+    getRegionalAnalytics: vi.fn(),
+}));
+
+type ToolHandler = (
+    input: Record<string, unknown>,
+) => Promise<{ content: [{ type: "text"; text: string }]; isError?: boolean }>;
+
+function makeFakeServer() {
+    const tools = new Map<string, ToolHandler>();
+    const server = {
+        registerTool: vi.fn((name: string, _def: unknown, handler: ToolHandler) => {
+            tools.set(name, handler);
+        }),
+    };
+    return { server, tools };
+}
+
+describe("registerRegionalAnalyticsTools", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("registers get_regional_analytics tool on the McpServer", () => {
+        const { server, tools } = makeFakeServer();
+        registerRegionalAnalyticsTools(
+            server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+            { userId: "user-1" },
+        );
+
+        expect(server.registerTool).toHaveBeenCalledWith(
+            "get_regional_analytics",
+            expect.objectContaining({
+                description: expect.stringContaining("get_regional_analytics"),
+            }),
+            expect.any(Function),
+        );
+        expect(tools.has("get_regional_analytics")).toBe(true);
+    });
+
+    it("executes get_regional_analytics and returns JSON stringified result", async () => {
+        const { server, tools } = makeFakeServer();
+        registerRegionalAnalyticsTools(
+            server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+            { userId: "user-1" },
+        );
+
+        const mockResult = {
+            totalCount: 5,
+            byPlugin: { aviation: 5 },
+            clusters: [
+                {
+                    cellId: "grid-0:0",
+                    center: { lat: 51.5, lon: -0.1 },
+                    bounds: { north: 52, south: 51, east: 0, west: -1 },
+                    count: 5,
+                    byPlugin: { aviation: 5 },
+                },
+            ],
+            bounds: { north: 52, south: 51, east: 0, west: -1 },
+        };
+
+        vi.mocked(getRegionalAnalytics).mockResolvedValue(mockResult as any);
+
+        const handler = tools.get("get_regional_analytics")!;
+        const response = await handler({
+            north: 52,
+            south: 51,
+            east: 0,
+            west: -1,
+            groupBy: "type",
+        });
+
+        expect(response.isError).toBeFalsy();
+        expect(response.content[0].type).toBe("text");
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.success).toBe(true);
+        expect(parsed.totalCount).toBe(5);
+        expect(parsed.clusters).toHaveLength(1);
+    });
+
+    it("returns error result with isError: true when service throws an error", async () => {
+        const { server, tools } = makeFakeServer();
+        registerRegionalAnalyticsTools(
+            server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+            { userId: "user-1" },
+        );
+
+        vi.mocked(getRegionalAnalytics).mockRejectedValue(new Error("Invalid coordinates"));
+
+        const handler = tools.get("get_regional_analytics")!;
+        const response = await handler({
+            north: -10,
+            south: 50,
+            east: 0,
+            west: 0,
+        });
+
+        expect(response.isError).toBe(true);
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.error).toBe("Invalid coordinates");
+    });
+});

--- a/src/app/api/mcp/regionalAnalyticsTools.ts
+++ b/src/app/api/mcp/regionalAnalyticsTools.ts
@@ -1,0 +1,74 @@
+/**
+ * @file regionalAnalyticsTools.ts
+ * @description MCP Tool registrar for regional spatial analytics and density clustering (Gap 2 / Tier 2).
+ */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { latSchema, lonSchema } from "@/lib/mcp/coordinateSchemas";
+import { getRegionalAnalytics } from "@/lib/mcp/regionalAnalyticsService";
+
+export function registerRegionalAnalyticsTools(
+    server: McpServer,
+    _ctx: { userId: string },
+): void {
+    server.registerTool(
+        "get_regional_analytics",
+        {
+            description:
+                "Compute aggregated geospatial statistics, category/type distributions, and density clusters within a bounding box. " +
+                "Returns totalCount, per-plugin entity counts, optional property breakdown (groupBy), and spatial density clusters without dumping raw entity lists. " +
+                "This is a READ-ONLY data tool -- it does not require an active browser session. " +
+                "Example: get_regional_analytics({ north: 55, south: 50, east: 5, west: -5, groupBy: 'type', clusterResolution: 4 })",
+            inputSchema: {
+                north: latSchema.describe("Northern latitude bound (-90 to 90)"),
+                south: latSchema.describe("Southern latitude bound (-90 to 90)"),
+                east: lonSchema.describe("Eastern longitude bound (-180 to 180)"),
+                west: lonSchema.describe("Western longitude bound (-180 to 180)"),
+                pluginId: z.string().optional().describe("Restrict analysis to a single plugin (e.g. 'aviation')"),
+                pluginIds: z.array(z.string()).optional().describe("Restrict analysis to specific plugin IDs"),
+                groupBy: z.string().optional().describe("Entity property or field to group counts by (e.g. 'type', 'status', 'country', 'operator', 'plugin')"),
+                clusterResolution: z.number().min(1).max(10).optional().describe("Grid clustering resolution (1 to 10 divisions per axis, default 4)"),
+                topN: z.number().min(1).max(50).optional().describe("Maximum top categories returned in groupBy breakdown before grouping remainder into 'other' (default 10)"),
+            },
+        },
+        async (input) => {
+            try {
+                const result = await getRegionalAnalytics({
+                    north: input.north,
+                    south: input.south,
+                    east: input.east,
+                    west: input.west,
+                    pluginId: input.pluginId,
+                    pluginIds: input.pluginIds,
+                    groupBy: input.groupBy,
+                    clusterResolution: input.clusterResolution,
+                    topN: input.topN,
+                });
+
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: JSON.stringify({
+                                success: true,
+                                ...result,
+                            }),
+                        },
+                    ],
+                };
+            } catch (err) {
+                const message = err instanceof Error ? err.message : "Failed to compute regional analytics";
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: JSON.stringify({ error: message }),
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        },
+    );
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -48,6 +48,7 @@ import { registerFavoritesTools } from "./favoritesTools";
 import { registerFilterTools } from "./filterTools";
 import { registerDiscoveryTools } from "./discoveryTools";
 import { registerProximityTools } from "./proximityTools";
+import { registerRegionalAnalyticsTools } from "./regionalAnalyticsTools";
 
 // ---------------------------------------------------------------------------
 // Route segment config (TRANS-03)
@@ -181,6 +182,8 @@ async function handleMcpRequest(request: Request): Promise<Response> {
     registerDiscoveryTools(server, { userId: authResult.userId });
     // PR 1: proximity tool (find_nearby_entities -- server-side haversine search)
     registerProximityTools(server, { userId: authResult.userId });
+    // Regional spatial analytics & clustering (Gap 2)
+    registerRegionalAnalyticsTools(server, { userId: authResult.userId });
     // Phase 26: orientation prompts (INST-03, INST-04)
     await registerOrientationPrompts(server, { userId: authResult.userId });
 

--- a/src/lib/mcp/regionalAnalyticsService.test.ts
+++ b/src/lib/mcp/regionalAnalyticsService.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getRegionalAnalytics } from "./regionalAnalyticsService";
+import { fetchPluginSnapshot, getAllPluginSnapshots } from "@/lib/data-query/service";
+import type { GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+
+vi.mock("@/lib/data-query/service", () => ({
+    fetchPluginSnapshot: vi.fn(),
+    getAllPluginSnapshots: vi.fn(),
+}));
+
+function makeEntity(
+    id: string,
+    pluginId: string,
+    lat: number,
+    lon: number,
+    properties: Record<string, unknown> = {},
+): GeoEntity {
+    return {
+        id,
+        pluginId,
+        latitude: lat,
+        longitude: lon,
+        timestamp: new Date(),
+        properties,
+    };
+}
+
+describe("getRegionalAnalytics", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("throws error for invalid bounding box inputs (e.g. NaN or north < south)", async () => {
+        await expect(
+            getRegionalAnalytics({
+                north: NaN,
+                south: 10,
+                east: 20,
+                west: 10,
+            }),
+        ).rejects.toThrow("Invalid bounding box");
+
+        await expect(
+            getRegionalAnalytics({
+                north: 10,
+                south: 20,
+                east: 20,
+                west: 10,
+            }),
+        ).rejects.toThrow("north latitude must be greater than or equal to south latitude");
+    });
+
+    it("returns plugin_not_streaming when target plugin is not streaming", async () => {
+        vi.mocked(fetchPluginSnapshot).mockResolvedValue(null);
+
+        const result = await getRegionalAnalytics({
+            north: 50,
+            south: 40,
+            east: 10,
+            west: 0,
+            pluginId: "non_existent",
+        });
+
+        expect(result.emptyReason).toBe("plugin_not_streaming");
+        expect(result.totalCount).toBe(0);
+        expect(result.clusters).toEqual([]);
+    });
+
+    it("returns no_data_matches when entities exist elsewhere but none in bounding box", async () => {
+        vi.mocked(fetchPluginSnapshot).mockResolvedValue({
+            pluginId: "aviation",
+            timestamp: new Date(),
+            entities: [makeEntity("flight-1", "aviation", 10, 10)],
+        });
+
+        const result = await getRegionalAnalytics({
+            north: 60,
+            south: 50,
+            east: 5,
+            west: -5,
+            pluginId: "aviation",
+        });
+
+        expect(result.emptyReason).toBe("no_data_matches");
+        expect(result.totalCount).toBe(0);
+        expect(result.clusters).toEqual([]);
+    });
+
+    it("correctly aggregates entity counts, byPlugin, and spatial clusters", async () => {
+        const entities: GeoEntity[] = [
+            makeEntity("f1", "aviation", 51.5, -0.1, { type: "commercial", country: "UK" }),
+            makeEntity("f2", "aviation", 51.6, -0.2, { type: "commercial", country: "UK" }),
+            makeEntity("f3", "aviation", 52.1, 0.5, { type: "cargo", country: "FR" }),
+            makeEntity("s1", "maritime", 51.4, 0.1, { type: "tanker", country: "PA" }),
+        ];
+
+        vi.mocked(getAllPluginSnapshots).mockResolvedValue([
+            { pluginId: "aviation", timestamp: new Date(), entities: entities.slice(0, 3) },
+            { pluginId: "maritime", timestamp: new Date(), entities: [entities[3]] },
+        ]);
+
+        const result = await getRegionalAnalytics({
+            north: 53,
+            south: 50,
+            east: 2,
+            west: -2,
+            groupBy: "type",
+            clusterResolution: 2,
+        });
+
+        expect(result.totalCount).toBe(4);
+        expect(result.byPlugin).toEqual({
+            aviation: 3,
+            maritime: 1,
+        });
+        expect(result.breakdown).toEqual({
+            commercial: 2,
+            cargo: 1,
+            tanker: 1,
+        });
+        expect(result.clusters.length).toBeGreaterThan(0);
+        const clusterSum = result.clusters.reduce((sum, c) => sum + c.count, 0);
+        expect(clusterSum).toBe(4);
+    });
+
+    it("handles antimeridian crossing bounding boxes (east < west)", async () => {
+        const entities: GeoEntity[] = [
+            makeEntity("e1", "maritime", 20, 179.5), // West of date line
+            makeEntity("e2", "maritime", 20, -179.5), // East of date line
+            makeEntity("e3", "maritime", 20, 0), // Outside
+        ];
+
+        vi.mocked(fetchPluginSnapshot).mockResolvedValue({
+            pluginId: "maritime",
+            timestamp: new Date(),
+            entities,
+        });
+
+        const result = await getRegionalAnalytics({
+            north: 30,
+            south: 10,
+            east: -170, // Across antimeridian
+            west: 170,
+            pluginId: "maritime",
+        });
+
+        expect(result.totalCount).toBe(2);
+        expect(result.byPlugin).toEqual({ maritime: 2 });
+    });
+
+    it("caps topN breakdown results and aggregates overflow into 'other'", async () => {
+        const entities: GeoEntity[] = [
+            makeEntity("e1", "demo", 10, 10, { cat: "A" }),
+            makeEntity("e2", "demo", 10, 10, { cat: "B" }),
+            makeEntity("e3", "demo", 10, 10, { cat: "C" }),
+            makeEntity("e4", "demo", 10, 10, { cat: "D" }),
+        ];
+
+        vi.mocked(fetchPluginSnapshot).mockResolvedValue({
+            pluginId: "demo",
+            timestamp: new Date(),
+            entities,
+        });
+
+        const result = await getRegionalAnalytics({
+            north: 20,
+            south: 0,
+            east: 20,
+            west: 0,
+            pluginId: "demo",
+            groupBy: "cat",
+            topN: 2,
+        });
+
+        expect(result.totalCount).toBe(4);
+        expect(result.breakdown).toBeDefined();
+        expect(result.breakdown?.other).toBe(2);
+        expect(Object.keys(result.breakdown!)).toHaveLength(3); // 2 top + 1 other
+    });
+});

--- a/src/lib/mcp/regionalAnalyticsService.ts
+++ b/src/lib/mcp/regionalAnalyticsService.ts
@@ -1,0 +1,272 @@
+/**
+ * @file regionalAnalyticsService.ts
+ * @description Computes spatial aggregations, category rollups, and density clusters
+ * across streaming entities within a specified bounding box (Gap 2 / Tier 2 analytics).
+ */
+
+import type { GeoEntity } from "@worldwideview/wwv-plugin-sdk";
+import { fetchPluginSnapshot, getAllPluginSnapshots } from "@/lib/data-query/service";
+import type { PluginDataSnapshot } from "@/lib/data-query/types";
+
+export interface RegionalAnalyticsOptions {
+    north: number;
+    south: number;
+    east: number;
+    west: number;
+    pluginId?: string;
+    pluginIds?: string[];
+    groupBy?: string;
+    clusterResolution?: number;
+    topN?: number;
+}
+
+export interface SpatialCluster {
+    cellId: string;
+    center: {
+        lat: number;
+        lon: number;
+    };
+    bounds: {
+        north: number;
+        south: number;
+        east: number;
+        west: number;
+    };
+    count: number;
+    byPlugin: Record<string, number>;
+}
+
+export interface RegionalAnalyticsResult {
+    totalCount: number;
+    byPlugin: Record<string, number>;
+    breakdown?: Record<string, number>;
+    clusters: SpatialCluster[];
+    bounds: {
+        north: number;
+        south: number;
+        east: number;
+        west: number;
+    };
+    emptyReason?: "plugin_not_streaming" | "no_data_matches";
+}
+
+/**
+ * Normalizes longitude to [-180, 180].
+ */
+function normalizeLon(lon: number): number {
+    let l = ((lon + 180) % 360 + 360) % 360 - 180;
+    if (l === -180 && lon > 0) l = 180;
+    return l;
+}
+
+/**
+ * Computes regional analytics across streaming entities.
+ */
+export async function getRegionalAnalytics(
+    options: RegionalAnalyticsOptions,
+): Promise<RegionalAnalyticsResult> {
+    const {
+        north,
+        south,
+        east,
+        west,
+        pluginId,
+        pluginIds,
+        groupBy,
+        clusterResolution = 4,
+        topN = 10,
+    } = options;
+
+    if (isNaN(north) || isNaN(south) || isNaN(east) || isNaN(west)) {
+        throw new Error("Invalid bounding box: north/south/east/west must all be valid numbers");
+    }
+
+    if (north < south) {
+        throw new Error("Invalid bounding box: north latitude must be greater than or equal to south latitude");
+    }
+
+    const isAntimeridian = east < west;
+
+    // Determine target plugins and retrieve snapshots
+    let snapshots: PluginDataSnapshot[] = [];
+    let requestedPluginNotFound = false;
+
+    if (pluginId) {
+        const snap = await fetchPluginSnapshot(pluginId);
+        if (!snap) {
+            return {
+                totalCount: 0,
+                byPlugin: {},
+                clusters: [],
+                bounds: { north, south, east, west },
+                emptyReason: "plugin_not_streaming",
+            };
+        }
+        snapshots = [snap];
+    } else if (pluginIds && pluginIds.length > 0) {
+        const fetched = await Promise.all(pluginIds.map(fetchPluginSnapshot));
+        snapshots = fetched.filter((s): s is PluginDataSnapshot => s !== null);
+        if (snapshots.length === 0) {
+            requestedPluginNotFound = true;
+        }
+    } else {
+        snapshots = await getAllPluginSnapshots();
+        if (snapshots.length === 0) {
+            requestedPluginNotFound = true;
+        }
+    }
+
+    if (requestedPluginNotFound) {
+        return {
+            totalCount: 0,
+            byPlugin: {},
+            clusters: [],
+            bounds: { north, south, east, west },
+            emptyReason: "plugin_not_streaming",
+        };
+    }
+
+    // Filter entities inside bounding box
+    const matchedEntities: GeoEntity[] = [];
+    const byPlugin: Record<string, number> = {};
+
+    for (const snapshot of snapshots) {
+        for (const entity of snapshot.entities) {
+            const { latitude: lat, longitude: lon } = entity;
+            if (typeof lat !== "number" || typeof lon !== "number") continue;
+            if (lat < south || lat > north) continue;
+
+            const inLon = isAntimeridian
+                ? lon >= west || lon <= east
+                : lon >= west && lon <= east;
+
+            if (inLon) {
+                matchedEntities.push(entity);
+                const pId = entity.pluginId || snapshot.pluginId;
+                byPlugin[pId] = (byPlugin[pId] ?? 0) + 1;
+            }
+        }
+    }
+
+    if (matchedEntities.length === 0) {
+        return {
+            totalCount: 0,
+            byPlugin: {},
+            clusters: [],
+            bounds: { north, south, east, west },
+            emptyReason: "no_data_matches",
+        };
+    }
+
+    // GroupBy Breakdown
+    let breakdown: Record<string, number> | undefined;
+    if (groupBy) {
+        const counts: Record<string, number> = {};
+        for (const entity of matchedEntities) {
+            let val: unknown;
+            if (groupBy === "plugin" || groupBy === "pluginId") {
+                val = entity.pluginId;
+            } else if (groupBy in entity) {
+                val = (entity as unknown as Record<string, unknown>)[groupBy];
+            } else if (entity.properties && typeof entity.properties === "object") {
+                val = entity.properties[groupBy];
+            }
+
+            const strVal = val !== undefined && val !== null ? String(val).trim() : "unknown";
+            const finalKey = strVal === "" ? "unknown" : strVal;
+            counts[finalKey] = (counts[finalKey] ?? 0) + 1;
+        }
+
+        // Limit to topN with "other"
+        const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+        if (sorted.length > topN) {
+            const top = sorted.slice(0, topN);
+            const otherCount = sorted.slice(topN).reduce((acc, [, c]) => acc + c, 0);
+            breakdown = Object.fromEntries(top);
+            if (otherCount > 0) {
+                breakdown.other = (breakdown.other ?? 0) + otherCount;
+            }
+        } else {
+            breakdown = Object.fromEntries(sorted);
+        }
+    }
+
+    // Compute Spatial Grid Clusters
+    const res = Math.max(1, Math.min(clusterResolution, 10));
+    const latSpan = north - south;
+    const lonSpan = isAntimeridian ? 360 - (west - east) : east - west;
+
+    const latStep = latSpan > 0 ? latSpan / res : 1;
+    const lonStep = lonSpan > 0 ? lonSpan / res : 1;
+
+    const gridCells = new Map<
+        string,
+        {
+            r: number;
+            c: number;
+            entities: GeoEntity[];
+            byPlugin: Record<string, number>;
+        }
+    >();
+
+    for (const entity of matchedEntities) {
+        const { latitude: lat, longitude: lon } = entity;
+        const r = Math.min(res - 1, Math.max(0, Math.floor((lat - south) / (latStep || 1))));
+
+        let lonOffset = lon - west;
+        if (isAntimeridian && lonOffset < 0) {
+            lonOffset += 360;
+        }
+        const c = Math.min(res - 1, Math.max(0, Math.floor(lonOffset / (lonStep || 1))));
+
+        const key = `${r}:${c}`;
+        let cell = gridCells.get(key);
+        if (!cell) {
+            cell = { r, c, entities: [], byPlugin: {} };
+            gridCells.set(key, cell);
+        }
+        cell.entities.push(entity);
+        const pId = entity.pluginId;
+        cell.byPlugin[pId] = (cell.byPlugin[pId] ?? 0) + 1;
+    }
+
+    const clusters: SpatialCluster[] = [];
+    for (const [key, cell] of gridCells.entries()) {
+        const cellSouth = south + cell.r * latStep;
+        const cellNorth = Math.min(north, cellSouth + latStep);
+
+        const cellWest = normalizeLon(west + cell.c * lonStep);
+        const cellEast = normalizeLon(west + (cell.c + 1) * lonStep);
+
+        const avgLat =
+            cell.entities.reduce((sum, e) => sum + e.latitude, 0) / cell.entities.length;
+        const avgLon =
+            cell.entities.reduce((sum, e) => sum + e.longitude, 0) / cell.entities.length;
+
+        clusters.push({
+            cellId: `grid-${key}`,
+            center: {
+                lat: Number(avgLat.toFixed(4)),
+                lon: Number(avgLon.toFixed(4)),
+            },
+            bounds: {
+                north: Number(cellNorth.toFixed(4)),
+                south: Number(cellSouth.toFixed(4)),
+                east: Number(cellEast.toFixed(4)),
+                west: Number(cellWest.toFixed(4)),
+            },
+            count: cell.entities.length,
+            byPlugin: cell.byPlugin,
+        });
+    }
+
+    clusters.sort((a, b) => b.count - a.count);
+
+    return {
+        totalCount: matchedEntities.length,
+        byPlugin,
+        ...(breakdown && { breakdown }),
+        clusters,
+        bounds: { north, south, east, west },
+    };
+}


### PR DESCRIPTION
## Summary
Addresses Gap 2 (C5: Token-budget guardrails & Spatial Aggregation) in the WorldWideView MCP system.

Previously, bounding-box region queries only returned raw, unordered samples of up to 100 entities without aggregate counts, property distributions, or density summaries. For large areas (e.g. whole countries or oceanic corridors), agents were forced to either consume large raw payloads or miss macro patterns.

### Changes
- Implemented \getRegionalAnalytics\ in \src/lib/mcp/regionalAnalyticsService.ts\ providing:
  - Total entity count within the region bounding box (with full antimeridian wrap support).
  - Per-plugin breakdown of entity counts.
  - Optional \groupBy\ property breakdowns (e.g. by \	ype\, \status\, \country\, \operator\) with a top-N limit and 'other' rollup.
  - Spatial density grid clustering into  \times N$ cells with localized centers and sub-bounding boxes.
  - Correct \mptyReason\ handling (\plugin_not_streaming\ vs \
o_data_matches\).
- Added \egisterRegionalAnalyticsTools\ in \src/app/api/mcp/regionalAnalyticsTools.ts\ and wired into \src/app/api/mcp/route.ts\.
- Added complete unit test coverage in \src/lib/mcp/regionalAnalyticsService.test.ts\ and \src/app/api/mcp/regionalAnalyticsTools.test.ts\ (19 MCP test files / 302 tests PASS, all 1369 repository unit tests PASS, clean tsc).
- Bumped semver version to \2.68.0\.