### PR TITLE
fix: resolve marketplace plugin entries via jsdelivr +esm instead of hardcoded dist/frontend.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.68.0",
+  "version": "2.68.1",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/app/api/marketplace/install/route.ts
+++ b/src/app/api/marketplace/install/route.ts
@@ -54,12 +54,16 @@ export async function POST(request: Request) {
                     finalManifest = { ...card };
 
                     // Reconstruct entry URL for plugins that are distributed via NPM.
+                    // Resolve the package's real module entry through jsdelivr's +esm
+                    // endpoint (reads package.json "module"/"exports"), matching the
+                    // marketplace install flow. Hardcoding dist/frontend.mjs 404s for
+                    // packages that ship their bundle under a different name.
                     // We also forcefully coerce format to "bundle" here because
                     // the marketplace cache might still return "static" for plugins we recently converted.
                     if (finalManifest.npmPackage) {
                         const targetVersion = version || finalManifest.version || "1.0.0";
                         finalManifest.format = "bundle";
-                        finalManifest.entry = `https://unpkg.com/${finalManifest.npmPackage}@${targetVersion}/dist/frontend.mjs`;
+                        finalManifest.entry = `https://cdn.jsdelivr.net/npm/${finalManifest.npmPackage}@${targetVersion}/+esm`;
                     }
                 }
             } catch (e) {

--- a/src/lib/marketplace/seedDefaultPlugins.test.ts
+++ b/src/lib/marketplace/seedDefaultPlugins.test.ts
@@ -58,7 +58,7 @@ function fakeManifest(id: string) {
         name: id,
         version: "1.0.0",
         format: "bundle",
-        entry: `https://unpkg.com/wwv-plugin-${id}@1.0.0/dist/frontend.mjs`,
+        entry: `https://cdn.jsdelivr.net/npm/wwv-plugin-${id}@1.0.0/+esm`,
         npmPackage: `wwv-plugin-${id}`,
         rendering: { type: "point", color: "#ff0000", size: 6 },
     };
@@ -208,5 +208,37 @@ describe("seedDefaultPlugins", () => {
             const manifest = JSON.parse(call[2]);
             expect(manifest.trust).toBe("verified");
         }
+    });
+
+    it("seeds a plugin without an entry field using the jsdelivr +esm resolution", async () => {
+        // Non-conforming bundle layout: the marketplace manifest has no `entry`
+        // field and the package ships its bundle under a different name
+        // (wwv-plugin-opencorporates ships dist/index.esm.js). The seeder must
+        // reconstruct the CDN entry via jsdelivr's +esm endpoint.
+        const nonConformingId = "opencorporates";
+        mockGetRegistryPluginList.mockResolvedValue([
+            { id: nonConformingId, autoSeed: true },
+        ]);
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                id: nonConformingId,
+                name: nonConformingId,
+                version: "1.0.0",
+                format: "bundle",
+                npmPackage: `wwv-plugin-${nonConformingId}`,
+                rendering: { type: "point", color: "#ff0000", size: 6 },
+            }),
+        });
+
+        await seedDefaultPlugins();
+
+        expect(mockUpsertPlugin).toHaveBeenCalledTimes(1);
+        const manifest = JSON.parse(mockUpsertPlugin.mock.calls[0][2]);
+        expect(manifest.entry).toBe(
+            `https://cdn.jsdelivr.net/npm/wwv-plugin-${nonConformingId}@1.0.0/+esm`,
+        );
+        expect(manifest.npmPackage).toBe(`wwv-plugin-${nonConformingId}`);
+        expect(manifest.format).toBe("bundle");
     });
 });

--- a/src/lib/marketplace/seedDefaultPlugins.ts
+++ b/src/lib/marketplace/seedDefaultPlugins.ts
@@ -84,11 +84,15 @@ export async function seedDefaultPlugins(): Promise<void> {
                 // Every plugin in the verified set is by definition verified.
                 manifest.trust = "verified";
 
-                // Reconstruct CDN entry for npm-distributed plugins
+                // Reconstruct CDN entry for npm-distributed plugins. Resolve the package's
+                // real module entry via jsdelivr's +esm endpoint (reads package.json
+                // "module"/"exports"), matching the marketplace install flow. Hardcoding
+                // dist/frontend.mjs 404s for packages that ship their bundle under a
+                // different name (e.g. dist/index.esm.js or dist/index.mjs).
                 if (manifest.npmPackage) {
                     const ver = manifest.version || "1.0.0";
                     manifest.format = "bundle";
-                    manifest.entry = `https://unpkg.com/${manifest.npmPackage}@${ver}/dist/frontend.mjs`;
+                    manifest.entry = `https://cdn.jsdelivr.net/npm/${manifest.npmPackage}@${ver}/+esm`;
                 }
 
                 const validation = validateManifest(manifest);


### PR DESCRIPTION
## Summary

Fixes #482. The fresh-install seeder (`src/lib/marketplace/seedDefaultPlugins.ts`) and the marketplace install route (`src/app/api/marketplace/install/route.ts`) reconstructed plugin entries by hardcoding `https://unpkg.com/<pkg>@<ver>/dist/frontend.mjs`. Packages that ship their browser bundle under a different file name (verified case: `wwv-plugin-opencorporates@1.0.0` ships only `dist/index.esm.js`) 404 on that URL, the dynamic import fails, and the plugin never mounts (`ManifestLoadError`).

Both paths now resolve the entry via jsdelivr's `+esm` endpoint (`https://cdn.jsdelivr.net/npm/<pkg>@<ver>/+esm`), which serves the `package.json` `module`/`exports` bundle regardless of the file name the build produced — the same resolution the marketplace install manifest (`pluginManifests.ts`) already uses. No other behavior changed (autoSeed filtering, trust stamp, format coercion identical).

## Verification

- Unit: 10/10 `seedDefaultPlugins` tests pass, including the new regression test "seeds a plugin without an entry field using the jsdelivr +esm resolution" (the real `wwv-plugin-opencorporates` manifest shape).
- `pnpm exec tsc --noEmit` exit 0; ESLint clean on all changed files.
- Live: the exact URL the fixed code produces for the broken package returns HTTP 200 and dynamic-imports in a real browser, exposing a valid plugin object (`id`, `initialize`, `destroy`). The old URL returns 404.
- Independent fresh-context verifier agent verdict: PASS on all criteria (entry resolution, scope discipline, tests, typecheck/lint, live URL).
- `pnpm build` local result confirmed separately.

Closes #482