### PR TITLE
fix: websocket BFCache lifecycle + demo alerts gating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwideview",
-  "version": "2.68.1",
+  "version": "2.68.2",
   "private": true,
   "license": "EL-2.0",
   "type": "module",

--- a/src/components/alerts/AlertsPanel.demo.spec.tsx
+++ b/src/components/alerts/AlertsPanel.demo.spec.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { useStore } from "@/core/state/store";
+import { AlertsPanel } from "./AlertsPanel";
+
+const mockIsDemo = vi.hoisted(() => ({ value: false }));
+vi.mock("@/core/edition", () => ({
+    get isDemo() { return mockIsDemo.value; },
+}));
+
+describe("AlertsPanel — demo edition gating", () => {
+    beforeEach(() => {
+        mockIsDemo.value = false;
+        useStore.setState({
+            alertRules: [],
+            alertRulesLoading: false,
+            alertRulesError: null,
+            alertUnreadCount: 2,
+            alertToasts: [],
+        });
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("skips fetchAlerts and keeps the unread badge on the demo edition", async () => {
+        mockIsDemo.value = true;
+        const fetchMock = vi.mocked(fetch);
+        render(<AlertsPanel />);
+
+        // Let the mount effect flush.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        expect(fetchMock).not.toHaveBeenCalledWith("/api/alerts", expect.anything());
+        expect(useStore.getState().alertUnreadCount).toBe(2);
+        // The panel body itself still renders.
+        expect(screen.getByTestId("alerts-panel")).toBeDefined();
+    });
+
+    it("fetches alerts and clears the unread badge when not on demo", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ rules: [] }),
+        }));
+        render(<AlertsPanel />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/alerts", expect.anything()));
+        expect(useStore.getState().alertUnreadCount).toBe(0);
+    });
+});

--- a/src/components/alerts/AlertsPanel.tsx
+++ b/src/components/alerts/AlertsPanel.tsx
@@ -12,6 +12,7 @@
 import { useEffect, useState } from "react";
 import { Bell, Plus, Trash2 } from "lucide-react";
 import { useStore } from "@/core/state/store";
+import { isDemo } from "@/core/edition";
 import { getAlertDefinitionsFor } from "@/lib/alerts/alertablePlugins";
 import { formatCondition } from "@/lib/alerts/format";
 import { AlertRuleForm } from "./AlertRuleForm";
@@ -34,6 +35,9 @@ export function AlertsPanel() {
     const [creating, setCreating] = useState(false);
 
     useEffect(() => {
+        // Demo edition has no alerts backend (route 403s by design). Never
+        // fetch on demo so we don't spam the console with 403 noise.
+        if (isDemo) return;
         void fetchAlerts();
         clearAlertUnread();
     }, [fetchAlerts, clearAlertUnread]);

--- a/src/components/panels/DataConfig/index.spec.tsx
+++ b/src/components/panels/DataConfig/index.spec.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useStore } from "@/core/state/store";
+import { DataConfigPanel } from "./index";
+
+const mockIsDemo = vi.hoisted(() => ({ value: false }));
+vi.mock("@/core/edition", () => ({
+    get isDemo() { return mockIsDemo.value; },
+}));
+
+// The tab panels pull in heavy engine/plugin rendering; stub the ones that are
+// incidental to the alerts gating under test (AlertsPanel/AlertsTabButton stay
+// real so the gated mount is exercised end to end).
+vi.mock("@/components/panels/FilterPanel", () => ({
+    FilterSection: function FilterSectionStub() { return <div data-testid="filter-section" />; },
+}));
+vi.mock("./IntelTab", () => ({
+    IntelTab: function IntelTabStub() { return <div data-testid="intel-tab" />; },
+}));
+vi.mock("./CacheTab", () => ({
+    CacheTab: function CacheTabStub() { return <div data-testid="cache-tab" />; },
+}));
+vi.mock("./OverlayTab", () => ({
+    OverlayTab: function OverlayTabStub() { return <div data-testid="overlay-tab" />; },
+}));
+
+describe("DataConfigPanel — alerts gating on the demo edition", () => {
+    beforeEach(() => {
+        mockIsDemo.value = false;
+        useStore.setState({ configPanelOpen: true, activeConfigTab: "alerts" });
+        vi.stubGlobal("fetch", vi.fn());
+        // jsdom has no matchMedia; the panel's useIsMobile hook requires it.
+        Object.defineProperty(window, "matchMedia", {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            })),
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("hides the alerts tab button and panel on the demo edition", async () => {
+        mockIsDemo.value = true;
+        render(<DataConfigPanel />);
+
+        expect(screen.queryByTestId("alerts-tab")).toBeNull();
+        expect(screen.queryByTestId("alerts-panel")).toBeNull();
+        // The rest of the sidebar still renders.
+        expect(screen.getByText("Data Configuration")).toBeDefined();
+        expect(screen.getByText("Provide Feedback")).toBeDefined();
+        // AlertsPanel never mounts, so nothing fetches /api/alerts.
+        expect(fetch).not.toHaveBeenCalledWith("/api/alerts", expect.anything());
+    });
+
+    it("shows the alerts tab button and panel when not on demo", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ rules: [] }),
+        }));
+        const { findByTestId } = render(<DataConfigPanel />);
+
+        expect(screen.getByTestId("alerts-tab")).toBeDefined();
+        expect(await findByTestId("alerts-panel")).toBeDefined();
+    });
+});

--- a/src/components/panels/DataConfig/index.tsx
+++ b/src/components/panels/DataConfig/index.tsx
@@ -19,6 +19,7 @@ import { CacheTab } from "./CacheTab";
 import { OverlayTab } from "./OverlayTab";
 import { AlertsPanel } from "@/components/alerts/AlertsPanel";
 import { AlertsTabButton } from "@/components/alerts/AlertsTabButton";
+import { isDemo } from "@/core/edition";
 import { sectionHeaderStyle } from "./sharedStyles";
 
 import "./index.css";
@@ -101,7 +102,7 @@ export function DataConfigPanel() {
           >
             <Cog size="20" style={{ margin: 5, maxHeight: "20%" }} />
           </button>
-          <AlertsTabButton />
+          {!isDemo && <AlertsTabButton />}
         </div>
 
         <div style={{
@@ -122,7 +123,7 @@ export function DataConfigPanel() {
           </div>
                 )}
           {activeTab === "overlay" && <OverlayTab />}
-          {activeTab === "alerts" && (
+          {activeTab === "alerts" && !isDemo && (
           <div style={{ marginBottom: "var(--space-lg)" }}>
             <div style={sectionHeaderStyle}>Alerts</div>
             <AlertsPanel />

--- a/src/core/data/WsClient.bfcache.spec.ts
+++ b/src/core/data/WsClient.bfcache.spec.ts
@@ -1,0 +1,319 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./DataBus", () => ({
+    dataBus: { emit: vi.fn() },
+}));
+vi.mock("../plugins/PluginManager", () => ({
+    pluginManager: { getPlugin: vi.fn(() => null) },
+}));
+vi.mock("../state/store", () => ({
+    useStore: { getState: vi.fn(() => ({ entitiesByPlugin: {} })) },
+}));
+vi.mock("../edition", () => ({
+    ticketAuthEnabledForPlugin: vi.fn(() => false),
+}));
+
+import { wsClient } from "./WsClient";
+
+const ENGINE_URL = "wss://engine-bfcache.test";
+
+// Fake WebSocket that stays CONNECTING until explicitly opened by tests.
+class FakeWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static instances: FakeWebSocket[] = [];
+
+    readyState = FakeWebSocket.CONNECTING;
+    onopen: ((e: Event) => void) | null = null;
+    onmessage: ((e: MessageEvent) => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: ((e: Event) => void) | null = null;
+    readonly sentMessages: string[] = [];
+
+    constructor(public url: string) {
+        FakeWebSocket.instances.push(this);
+    }
+
+    send(data: string) {
+        this.sentMessages.push(data);
+    }
+
+    close() {
+        this.readyState = FakeWebSocket.CLOSED;
+        this.onclose?.();
+    }
+
+    triggerOpen() {
+        this.readyState = FakeWebSocket.OPEN;
+        this.onopen?.(new Event("open"));
+    }
+
+    // Fire a close event without going through close() — simulates a deferred
+    // close event landing from a socket the restore path already replaced.
+    triggerCloseEvent() {
+        this.onclose?.();
+    }
+
+    triggerError() {
+        this.onerror?.(new Event("error"));
+    }
+}
+
+type EngineInternals = {
+    ws: FakeWebSocket | null;
+    reconnectTimer: ReturnType<typeof setTimeout> | null;
+    stableConnectionTimer: ReturnType<typeof setTimeout> | null;
+    authTimeoutTimer: ReturnType<typeof setTimeout> | null;
+    awaitingWelcome: boolean;
+    reconnectAttempts: number;
+    subscriptions: Set<string>;
+};
+
+function engineInternals(): EngineInternals {
+    const engines = (wsClient as unknown as { engines: Map<string, EngineInternals> }).engines;
+    const engine = engines.get(ENGINE_URL);
+    if (!engine) throw new Error(`engine for ${ENGINE_URL} was not created`);
+    return engine;
+}
+
+function setPageFrozen(value: boolean): void {
+    (wsClient as unknown as { pageFrozen: boolean }).pageFrozen = value;
+}
+
+function isPageFrozen(): boolean {
+    return (wsClient as unknown as { pageFrozen: boolean }).pageFrozen;
+}
+
+const pageHide = (persisted: boolean) =>
+    window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted }));
+const pageShow = (persisted: boolean) =>
+    window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted }));
+const setVisibility = (state: "visible" | "hidden") => {
+    Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+};
+
+let savedWebSocket: typeof WebSocket;
+
+describe("WsClient — BFCache / page-lifecycle", () => {
+    beforeEach(() => {
+        FakeWebSocket.instances.length = 0;
+        savedWebSocket = global.WebSocket;
+        global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+        vi.clearAllMocks();
+        (wsClient as unknown as { engines: Map<string, EngineInternals> }).engines.clear();
+        setPageFrozen(false);
+        Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
+    });
+
+    afterEach(() => {
+        global.WebSocket = savedWebSocket;
+    });
+
+    it("registers the page-lifecycle listeners only once across instances (module guard)", async () => {
+        // Load a fresh module instance so the constructor runs under the spy
+        // (the statically imported singleton already registered at import time).
+        vi.resetModules();
+        const windowSpy = vi.spyOn(window, "addEventListener");
+        const documentSpy = vi.spyOn(document, "addEventListener");
+        const { wsClient: freshClient } = await import("./WsClient");
+        const WsClientCtor = freshClient.constructor as unknown as new () => typeof freshClient;
+
+        // The first instance registers each lifecycle listener exactly once.
+        expect(windowSpy).toHaveBeenCalledWith("pagehide", expect.any(Function));
+        expect(windowSpy).toHaveBeenCalledWith("pageshow", expect.any(Function));
+        expect(documentSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+        // A second instance registers nothing more: the module guard holds.
+        new WsClientCtor();
+        expect(windowSpy).toHaveBeenCalledTimes(2);
+        expect(documentSpy).toHaveBeenCalledTimes(1);
+
+        windowSpy.mockRestore();
+        documentSpy.mockRestore();
+    });
+
+    it("freezes on persisted pagehide: closes an OPEN socket and clears the stable timer", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        const closeSpy = vi.spyOn(ws, "close");
+
+        pageHide(true);
+
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(engineInternals().ws).toBeNull();
+        expect(engineInternals().stableConnectionTimer).toBeNull();
+        expect(engineInternals().reconnectTimer).toBeNull();
+        expect(isPageFrozen()).toBe(true);
+    });
+
+    it("closes a CONNECTING socket on persisted pagehide", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        const closeSpy = vi.spyOn(ws, "close");
+
+        pageHide(true);
+
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(engineInternals().ws).toBeNull();
+        expect(isPageFrozen()).toBe(true);
+    });
+
+    it("clears a pending reconnect timer on persisted pagehide", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        // A real close with subscriptions schedules a reconnect timer.
+        ws.triggerCloseEvent();
+        expect(engineInternals().reconnectTimer).not.toBeNull();
+
+        pageHide(true);
+
+        expect(engineInternals().reconnectTimer).toBeNull();
+        expect(isPageFrozen()).toBe(true);
+    });
+
+    it("does nothing for a non-persisted pagehide", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        const closeSpy = vi.spyOn(ws, "close");
+
+        pageHide(false);
+
+        expect(closeSpy).not.toHaveBeenCalled();
+        expect(engineInternals().ws).toBe(ws);
+        expect(isPageFrozen()).toBe(false);
+    });
+
+    it("does not schedule a reconnect for a close event that fires while frozen", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        pageHide(true);
+        // A deferred close event from the frozen socket lands after the freeze.
+        ws.triggerCloseEvent();
+
+        expect(engineInternals().reconnectTimer).toBeNull();
+        expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    it("lets a deferred close from a superseded socket keep the restored socket and skip reconnect", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws1 = FakeWebSocket.instances.at(-1)!;
+        ws1.triggerOpen();
+
+        // Freeze: ws1 is closed cleanly and marked frozen.
+        pageHide(true);
+        expect(engineInternals().ws).toBeNull();
+
+        // Restore: a fresh socket is swapped in immediately (still CONNECTING).
+        pageShow(true);
+        const ws2 = FakeWebSocket.instances.at(-1)!;
+        expect(FakeWebSocket.instances).toHaveLength(2);
+        expect(engineInternals().ws).toBe(ws2);
+
+        // Deferred close from ws1 lands while the new socket is CONNECTING.
+        ws1.triggerCloseEvent();
+        expect(engineInternals().ws).toBe(ws2);
+        expect(FakeWebSocket.instances).toHaveLength(2);
+        expect(engineInternals().reconnectTimer).toBeNull();
+
+        // New socket opens; ws1's deferred close lands again — still no clobber.
+        ws2.triggerOpen();
+        ws1.triggerCloseEvent();
+        expect(engineInternals().ws).toBe(ws2);
+        expect(FakeWebSocket.instances).toHaveLength(2);
+        expect(engineInternals().reconnectTimer).toBeNull();
+    });
+
+    it("nulls the current socket on close and schedules a backoff reconnect when subscriptions exist", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        ws.triggerCloseEvent();
+
+        expect(engineInternals().ws).toBeNull();
+        expect(engineInternals().reconnectTimer).not.toBeNull();
+        expect(engineInternals().reconnectAttempts).toBe(1);
+    });
+
+    it("reconnects immediately and resets the backoff on persisted pageshow", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        ws.triggerCloseEvent(); // schedules a reconnect timer, ws -> null
+        engineInternals().reconnectAttempts = 4;
+        expect(engineInternals().reconnectTimer).not.toBeNull();
+
+        pageShow(true);
+
+        expect(engineInternals().reconnectAttempts).toBe(0);
+        expect(engineInternals().reconnectTimer).toBeNull();
+        expect(FakeWebSocket.instances).toHaveLength(2);
+        expect(engineInternals().ws).toBe(FakeWebSocket.instances.at(-1)!);
+    });
+
+    it("no-ops on persisted pageshow when the socket is already open", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+
+        pageShow(false); // non-persisted pageshow must not reconnect
+        expect(FakeWebSocket.instances).toHaveLength(1);
+
+        pageShow(true);
+        expect(FakeWebSocket.instances).toHaveLength(1);
+        expect(engineInternals().ws).toBe(ws);
+    });
+
+    it("skips engines without subscriptions on persisted pageshow", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        ws.triggerCloseEvent(); // schedules a reconnect timer, ws -> null
+        wsClient.unsubscribe("plugin-a", ENGINE_URL); // subscriptions now empty
+
+        pageShow(true);
+
+        // No immediate reconnect for an engine with zero subscriptions.
+        expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    it("reconnects immediately on visibilitychange -> visible, but not while hidden", () => {
+        wsClient.subscribe("plugin-a", ENGINE_URL);
+        const ws = FakeWebSocket.instances.at(-1)!;
+        ws.triggerOpen();
+        ws.triggerCloseEvent(); // schedules a reconnect timer, ws -> null
+        engineInternals().reconnectAttempts = 3;
+
+        setVisibility("hidden");
+        expect(FakeWebSocket.instances).toHaveLength(1);
+        expect(isPageFrozen()).toBe(false);
+
+        setVisibility("visible");
+        expect(FakeWebSocket.instances).toHaveLength(2);
+        expect(engineInternals().reconnectAttempts).toBe(0);
+        expect(engineInternals().reconnectTimer).toBeNull();
+    });
+
+    it("logs the truthful message on WebSocket error (reconnect handled on close)", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            wsClient.subscribe("plugin-a", ENGINE_URL);
+            const ws = FakeWebSocket.instances.at(-1)!;
+            ws.triggerError();
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining("reconnect is handled on close"),
+            );
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+});

--- a/src/core/data/WsClient.ts
+++ b/src/core/data/WsClient.ts
@@ -51,8 +51,71 @@ function extractEnvelopeFetchedAt(payload: WsStreamPayload["payload"]): string |
   return typeof fetchedAt === "string" ? fetchedAt : undefined;
 }
 
+/** Guards against duplicate page-lifecycle listener registration (module singleton). */
+let windowLifecycleAttached = false;
+
 class WebSocketClient {
   private engines = new Map<string, EngineConnection>();
+
+  /** True while the page is frozen in the BFCache (pagehide persisted to pageshow/visible). */
+  private pageFrozen = false;
+
+  constructor() {
+    if (typeof window === "undefined") return;
+    if (windowLifecycleAttached) return;
+    windowLifecycleAttached = true;
+    window.addEventListener("pagehide", this.handlePageHide);
+    window.addEventListener("pageshow", this.handlePageShow);
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+  }
+
+  /**
+   * BFCache freeze (`pagehide` with `persisted === true`): the browser
+   * suspends the page and forcibly tears down half-open WebSockets. Close
+   * them cleanly and drop the pending reconnect timer so nothing fires while
+   * frozen; the restore path reconnects immediately with a reset backoff.
+   */
+  private handlePageHide = (event: PageTransitionEvent) => {
+    if (!event.persisted) return;
+    this.pageFrozen = true;
+    for (const engine of this.engines.values()) {
+      if (engine.reconnectTimer) { clearTimeout(engine.reconnectTimer); engine.reconnectTimer = null; }
+      if (engine.stableConnectionTimer) { clearTimeout(engine.stableConnectionTimer); engine.stableConnectionTimer = null; }
+      if (engine.authTimeoutTimer) { clearTimeout(engine.authTimeoutTimer); engine.authTimeoutTimer = null; }
+      engine.awaitingWelcome = false;
+      if (engine.ws && (engine.ws.readyState === WebSocket.CONNECTING || engine.ws.readyState === WebSocket.OPEN)) {
+        engine.ws.close();
+      }
+    }
+  };
+
+  /** BFCache restore (`pageshow` with `persisted === true`): reconnect now. */
+  private handlePageShow = (event: PageTransitionEvent) => {
+    if (!event.persisted) return;
+    this.pageFrozen = false;
+    this.reconnectImmediately();
+  };
+
+  /** Tab became visible again: reconnect now instead of waiting out the timer. */
+  private handleVisibilityChange = () => {
+    if (document.visibilityState !== "visible") return;
+    this.pageFrozen = false;
+    this.reconnectImmediately();
+  };
+
+  /**
+   * Reconnect every engine with active subscriptions immediately, with a
+   * reset backoff. `connectEngine` no-ops when a socket is already
+   * CONNECTING/OPEN, so this is safe on every restore/visibility event.
+   */
+  private reconnectImmediately = () => {
+    for (const [engineUrl, engine] of this.engines.entries()) {
+      if (engine.subscriptions.size === 0) continue;
+      engine.reconnectAttempts = 0;
+      if (engine.reconnectTimer) { clearTimeout(engine.reconnectTimer); engine.reconnectTimer = null; }
+      this.connectEngine(engineUrl);
+    }
+  };
 
   private getOrCreateEngine(engineUrl: string): EngineConnection {
     let engine = this.engines.get(engineUrl);
@@ -80,7 +143,8 @@ class WebSocketClient {
     }
 
     const wsStart = performance.now();
-    engine.ws = new WebSocket(engineUrl);
+    const ws = new WebSocket(engineUrl);
+    engine.ws = ws;
 
     engine.ws.onopen = () => {
       console.debug(`[WSClient] 🟢 Connected to ${engineUrl}. WS Handshake took ${(performance.now() - wsStart).toFixed(2)}ms`);
@@ -164,11 +228,14 @@ class WebSocketClient {
     };
 
     engine.ws.onerror = () => {
-      console.warn(`[WSClient] Connection to ${engineUrl} failed. Retrying in background...`);
+      console.warn(`[WSClient] WebSocket error on ${engineUrl} - reconnect is handled on close`);
     };
 
     engine.ws.onclose = () => {
-      engine.ws = null;
+      // BFCache restore can reconnect and swap in a fresh socket before a
+      // deferred close event from the frozen socket lands. Only clear the
+      // reference when this close belongs to the current socket.
+      if (engine.ws === ws) engine.ws = null;
       engine.awaitingWelcome = false;
       if (engine.authTimeoutTimer) { clearTimeout(engine.authTimeoutTimer); engine.authTimeoutTimer = null; }
       if (engine.stableConnectionTimer) {
@@ -176,6 +243,12 @@ class WebSocketClient {
         engine.stableConnectionTimer = null;
       }
       if (engine.reconnectTimer) clearTimeout(engine.reconnectTimer);
+      // While the page is frozen in the BFCache, don't schedule a reconnect.
+      // The pageshow/visibilitychange restore path reconnects immediately.
+      if (this.pageFrozen) return;
+      // A deferred close from a superseded socket must not schedule a reconnect
+      // when the restore path already swapped in a fresh connection.
+      if (engine.ws && (engine.ws.readyState === WebSocket.CONNECTING || engine.ws.readyState === WebSocket.OPEN)) return;
       // Only reconnect if there are still active subscriptions
       if (engine.subscriptions.size > 0) {
         // Exponential backoff with jitter to prevent thundering herd on engine restart.

--- a/src/lib/alerts/engine.ts
+++ b/src/lib/alerts/engine.ts
@@ -13,6 +13,7 @@
 import { useEffect } from "react";
 import type { AlertRuleSnapshot, DataBusEvents, GeoEntity } from "@worldwideview/wwv-plugin-sdk";
 import { dataBus } from "@/core/data/DataBus";
+import { isDemo } from "@/core/edition";
 import { evaluateRule } from "./evaluate";
 
 export const DEDUPE_WINDOW_MS = 60_000;
@@ -156,6 +157,9 @@ export function attachAlertEngine(
 export function useAlertEngine(): void {
     useEffect(() => {
         if (typeof window === "undefined") return;
+        // Demo edition has no alerts backend (route 403s by design). Never
+        // attach the engine so it doesn't poll /api/alerts every 60s.
+        if (isDemo) return;
         return attachAlertEngine(dataBus);
     }, []);
 }

--- a/src/lib/alerts/useAlertEngine.spec.tsx
+++ b/src/lib/alerts/useAlertEngine.spec.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { useAlertEngine } from "./engine";
+
+const mockIsDemo = vi.hoisted(() => ({ value: false }));
+vi.mock("@/core/edition", () => ({
+    get isDemo() { return mockIsDemo.value; },
+}));
+vi.mock("@/core/data/DataBus", () => ({
+    dataBus: {
+        on: vi.fn(() => () => {}),
+        off: vi.fn(),
+        emit: vi.fn(),
+    },
+}));
+
+function AlertEngineProbe() {
+    useAlertEngine();
+    return null;
+}
+
+describe("useAlertEngine — demo edition gating", () => {
+    beforeEach(() => {
+        mockIsDemo.value = false;
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ rules: [] }),
+        }));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        cleanup();
+    });
+
+    it("does not attach the engine or poll /api/alerts on the demo edition", async () => {
+        mockIsDemo.value = true;
+        const fetchMock = vi.mocked(fetch);
+
+        render(<AlertEngineProbe />);
+        // Give the mount effect a chance to run.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        expect(fetchMock).not.toHaveBeenCalledWith("/api/alerts", expect.anything());
+    });
+
+    it("attaches the engine and refreshes rules from /api/alerts when not on demo", async () => {
+        render(<AlertEngineProbe />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/alerts", expect.anything()));
+    });
+});


### PR DESCRIPTION
## Summary

Two small, investigated fixes for the main app.

### Fix 1 - WebSocket page-lifecycle handling (`src/core/data/WsClient.ts`)

Chrome forcibly closes WebSockets when a page enters the Back-Forward Cache (BFCache freeze). Previously the client had zero page-lifecycle handling: on restore the reconnect only happened after the 5-9s+ backoff timer expired, and it escalated on repeated restores.

Changes:
- `pagehide` with `persisted === true` (BFCache freeze): proactively close open sockets cleanly and clear/skip pending timers (reconnect, stable-connection, auth-timeout) so nothing fires while frozen.
- `pageshow` with `persisted === true` and `visibilitychange` to visible: reset the backoff attempt counter and reconnect immediately when subscriptions exist, instead of waiting out the old timer. A `pageFrozen` flag also prevents `onclose` from scheduling a redundant cached-backoff reconnect during freeze/restore races.
- `onclose` now only clears `engine.ws` when the close belongs to the current socket, so a deferred close from a frozen socket cannot clobber a freshly reconnected one.
- Fixed the misleading `onerror` log ("Retrying in background..." retried nothing): now states "reconnect is handled on close".
- Listener registration is guarded by a module flag (the client is a module singleton `wsClient`), so no duplicate registration under StrictMode/HMR.

Subscription/reconnect protocol semantics are unchanged outside lifecycle handling.

### Fix 2 - Hide alerts UI on demo edition

The demo edition intentionally short-circuits `/api/alerts` with 403 ("Not available in demo edition") - that route was left untouched. But the client rendered/fetched the alerts UI unconditionally, so demo builds hit the 403 on mount and every 60s (engine poll), producing console noise.

Changes:
- `DataConfig/index.tsx`: AlertsTabButton and AlertsPanel mounts are gated with `!isDemo`, matching the existing demo-gating pattern (e.g. Header hiding signout on demo).
- `AlertsPanel.tsx`: mount-time `fetchAlerts()` is skipped on demo.
- `lib/alerts/engine.ts`: `useAlertEngine()` no longer attaches on demo, killing the 60s `/api/alerts` poll.

Alerts remain fully functional on local/cloud editions.

## Verification

- `npx tsc --noEmit` (CI-equivalent, pre-build): PASS, exit 0
- `pnpm build`: PASS, exit 0
- Targeted tests (WsClient x2 + seederHealth + alertsSlice + engine + alerts components): 115/115 PASS
- Full `pnpm test`: 1508/1509 PASS; the single failure (`better-auth.test.ts` "exports an auth instance", a 10s timeout under full-suite parallel load) passes solo and is unrelated to this diff, as is a separate pre-existing stale SDK-dist suite failure in `packages/wwv-lib-incidents`
- `npx eslint` on changed files: 0 errors (8 pre-existing warnings, none introduced)
- `node scripts/check-demo-gates.mjs`: 66 passed, 0 failed

## Evidence

- Verified against origin/main before implementing (no pagehide/pageshow/visibilitychange listeners existed; onerror log was misleading; onclose already had sound exponential backoff).
- Alerts route 403 on demo is intentional (route short-circuits), so demo builds must not render/fetch alerts at all.